### PR TITLE
PR template added

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,11 @@
+## At a high level, what changes were made?
+
+## Why were these changes made?
+
+## How were these changes made?
+
+## What context, visual (i.e. screenshots) or otherwise, do reviewers need to understand or use this feature?
+
+## How Was the Code Tested?
+
+## Other Notes, Context, or Anything that Remains to be Addressed


### PR DESCRIPTION
## At a high level, what changes were made?

A PR template was introduced.

## Why were these changes made?

Allows consistency in the presentation of changes, and encourages good coding practices like testing, documenting contextual information for future devs, providing rationales for the existence of code, ect. This is designed to allow consistent long-term collaboration as people move in and out of the project, and will hopefully prevent undocumented, unreadable code from entering the codebase.

## How were these changes made?
Markdown file added to `.github/workflows`, this should allow the PR template to appear as a dropdown option in future PRs. This template is based on previous templates I have used in univeristy projects and contract work.  

## What context, visual (i.e. screenshots) or otherwise, do reviewers need to understand or use this feature?
This PR is in the new PR format!

## How Was the Code Tested?
I believe I need to check if the PR template is available in a dropdown in future PRs after merging. I am unsure though, usually I have only used templates rather than set them up. 

## Other Notes, Context, or Anything that Remains to be Addressed
Please let me know if there are suggestions on how to change the PR template! Currently, the development team is small, and I do not want to force other developers to my template format if it is a burden to them. At the same time, it is important that I, and future developers, know how the codebase has evolved.