### PR TITLE
Moving easily transferred handlers from main to their own file.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,26 @@
-name: Test Workflow
+name: Test
 
 on:
   push:
-    branches:
-      - feature/canvas-rendering  # Changed to your current branch
-  workflow_dispatch:  # Manual trigger
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  test-job:
+  test:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Hello World
-        run: echo "Hello, GitHub Actions! This is a test workflow."
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
 
-      - name: List files
-        run: ls -la
+      - name: Run tests
+        run: go test ./pkg/...

--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -1,0 +1,21 @@
+package web
+
+import (
+	"context"
+	"time"
+)
+
+// WithMinimumDeadline ensures ctx has at least min duration until deadline.
+// Used by handlers and by main's importShield. Exported so main can use it.
+func WithMinimumDeadline(ctx context.Context, min time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		return context.WithTimeout(context.Background(), min)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if time.Until(deadline) >= min {
+			return ctx, func() {}
+		}
+		return context.WithTimeout(context.WithoutCancel(ctx), min)
+	}
+	return context.WithTimeout(ctx, min)
+}

--- a/pkg/web/handlers_bounds.go
+++ b/pkg/web/handlers_bounds.go
@@ -1,0 +1,83 @@
+package web
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// apiTracksBounds returns combined bounds for multiple tracks.
+// GET /api/tracks/bounds?trackIDs=track1,track2,track3
+func (s *Server) apiTracksBounds(w http.ResponseWriter, r *http.Request) {
+	trackIDsParam := r.URL.Query().Get("trackIDs")
+	if trackIDsParam == "" {
+		http.Error(w, "trackIDs parameter required", http.StatusBadRequest)
+		return
+	}
+	trackIDs := strings.Split(trackIDsParam, ",")
+	if len(trackIDs) == 0 {
+		http.Error(w, "No track IDs provided", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+	var minLat, minLon, maxLat, maxLon float64
+	first := true
+	for _, trackID := range trackIDs {
+		trackID = strings.TrimSpace(trackID)
+		if trackID == "" {
+			continue
+		}
+		var tMinLat, tMinLon, tMaxLat, tMaxLon sql.NullFloat64
+		var query string
+		if s.Config.DBType == "pgx" {
+			query = `SELECT MIN(lat) as min_lat, MIN(lon) as min_lon, MAX(lat) as max_lat, MAX(lon) as max_lon 
+			         FROM markers WHERE trackID = $1`
+		} else {
+			query = `SELECT MIN(lat) as min_lat, MIN(lon) as min_lon, MAX(lat) as max_lat, MAX(lon) as max_lon 
+			         FROM markers WHERE trackID = ?`
+		}
+		err := s.DB.DB.QueryRowContext(ctx, query, trackID).Scan(&tMinLat, &tMinLon, &tMaxLat, &tMaxLon)
+		if err != nil {
+			log.Printf("Error querying bounds for track %s: %v", trackID, err)
+			continue
+		}
+		if !tMinLat.Valid || !tMinLon.Valid || !tMaxLat.Valid || !tMaxLon.Valid {
+			continue
+		}
+		if first {
+			minLat, minLon = tMinLat.Float64, tMinLon.Float64
+			maxLat, maxLon = tMaxLat.Float64, tMaxLon.Float64
+			first = false
+		} else {
+			if tMinLat.Float64 < minLat {
+				minLat = tMinLat.Float64
+			}
+			if tMinLon.Float64 < minLon {
+				minLon = tMinLon.Float64
+			}
+			if tMaxLat.Float64 > maxLat {
+				maxLat = tMaxLat.Float64
+			}
+			if tMaxLon.Float64 > maxLon {
+				maxLon = tMaxLon.Float64
+			}
+		}
+	}
+	if first {
+		http.Error(w, "No valid tracks found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status": "success",
+		"bounds": map[string]float64{
+			"minLat": minLat,
+			"minLon": minLon,
+			"maxLat": maxLat,
+			"maxLon": maxLon,
+		},
+		"trackIDs": trackIDs,
+	})
+}

--- a/pkg/web/handlers_bounds.go
+++ b/pkg/web/handlers_bounds.go
@@ -1,3 +1,8 @@
+// handlers_bounds.go — map bounds for tracks
+//
+// Handles requests for geographic bounding boxes (min/max lat/lon) of one or
+// more tracks. The map UI uses this to zoom to the right area when displaying
+// multiple tracks.
 package web
 
 import (
@@ -8,8 +13,15 @@ import (
 	"strings"
 )
 
-// apiTracksBounds returns combined bounds for multiple tracks.
-// GET /api/tracks/bounds?trackIDs=track1,track2,track3
+// apiTracksBounds returns the combined geographic bounds (min/max lat/lon) for
+// one or more tracks. The map uses this to fit all requested tracks in view.
+//
+// Route: GET /api/tracks/bounds?trackIDs=track1,track2,track3
+//
+// Query params:
+//   - trackIDs: comma-separated list of track IDs (required)
+//
+// Response: JSON with status, bounds (minLat, minLon, maxLat, maxLon), and trackIDs.
 func (s *Server) apiTracksBounds(w http.ResponseWriter, r *http.Request) {
 	trackIDsParam := r.URL.Query().Get("trackIDs")
 	if trackIDsParam == "" {

--- a/pkg/web/handlers_docs.go
+++ b/pkg/web/handlers_docs.go
@@ -1,3 +1,8 @@
+// handlers_docs.go — documentation and license pages
+//
+// Serves human-readable docs (API usage) and license text (MIT, CC0).
+// The API docs page is built from a template; placeholders like __BASE_URL__
+// are replaced with the actual server URL so examples work out of the box.
 package web
 
 import (
@@ -10,7 +15,9 @@ import (
 	"time"
 )
 
-// apiDocs serves a static HTML page with API usage instructions.
+// apiDocs serves an HTML page that explains how to use the API. It reads
+// public_html/api-usage.html, replaces placeholders (base URL, API root,
+// archive settings), and returns the result. Used for /api/docs.
 func (s *Server) apiDocs(w http.ResponseWriter, r *http.Request) {
 	b, err := fs.ReadFile(s.Content, "public_html/api-usage.html")
 	if err != nil {
@@ -59,7 +66,8 @@ func (s *Server) apiDocs(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(page))
 }
 
-// license serves embedded license documents (MIT, CC0).
+// license serves plain-text license files. GET /licenses/mit or /licenses/cc0
+// returns the corresponding embedded LICENSE or LICENSE.CC0 file.
 func (s *Server) license(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set("Allow", "GET, HEAD")

--- a/pkg/web/handlers_docs.go
+++ b/pkg/web/handlers_docs.go
@@ -1,0 +1,97 @@
+package web
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// apiDocs serves a static HTML page with API usage instructions.
+func (s *Server) apiDocs(w http.ResponseWriter, r *http.Request) {
+	b, err := fs.ReadFile(s.Content, "public_html/api-usage.html")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	scheme := "http"
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		scheme = strings.ToLower(proto)
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+
+	host := strings.TrimSpace(r.Host)
+	if host == "" {
+		if strings.TrimSpace(s.Config.Domain) != "" {
+			host = strings.TrimSpace(s.Config.Domain)
+		} else {
+			host = fmt.Sprintf("localhost:%d", s.Config.Port)
+		}
+	}
+
+	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+	apiRoot := strings.TrimRight(baseURL, "/") + "/api"
+
+	page := string(b)
+	page = strings.ReplaceAll(page, "__BASE_URL__", baseURL)
+	page = strings.ReplaceAll(page, "__API_ROOT__", apiRoot)
+	page = strings.ReplaceAll(page, "__DISPLAY_HOST__", host)
+	page = strings.ReplaceAll(page, "__ARCHIVE_ENABLED__", strconv.FormatBool(s.Config.APIDocsArchiveEnabled))
+
+	route := strings.TrimSpace(s.Config.APIDocsArchiveRoute)
+	if route == "" {
+		route = "/api/json/weekly.tgz"
+	}
+	page = strings.ReplaceAll(page, "__ARCHIVE_ROUTE__", route)
+
+	freq := strings.TrimSpace(s.Config.APIDocsArchiveFrequency)
+	if freq == "" {
+		freq = "weekly"
+	}
+	page = strings.ReplaceAll(page, "__ARCHIVE_FREQUENCY__", freq)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(page))
+}
+
+// license serves embedded license documents (MIT, CC0).
+func (s *Server) license(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rawPath := strings.TrimPrefix(r.URL.Path, "/licenses/")
+	if rawPath == r.URL.Path {
+		http.NotFound(w, r)
+		return
+	}
+	code := strings.ToLower(strings.Trim(rawPath, "/"))
+
+	var file string
+	switch code {
+	case "mit":
+		file = "LICENSE"
+	case "cc0":
+		file = "LICENSE.CC0"
+	default:
+		http.NotFound(w, r)
+		return
+	}
+
+	data, err := fs.ReadFile(s.Content, file)
+	if err != nil {
+		s.Logf("license handler: %s read error: %v", file, err)
+		http.Error(w, "unable to load license", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	http.ServeContent(w, r, file, time.Time{}, bytes.NewReader(data))
+}

--- a/pkg/web/handlers_geo.go
+++ b/pkg/web/handlers_geo.go
@@ -1,0 +1,90 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// requestClientIP returns the best-effort client IP (X-Forwarded-For or RemoteAddr).
+func requestClientIP(r *http.Request) string {
+	forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+	if forwarded != "" {
+		parts := strings.Split(forwarded, ",")
+		if c := strings.TrimSpace(parts[0]); c != "" {
+			return c
+		}
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err == nil && strings.TrimSpace(host) != "" {
+		return host
+	}
+	if t := strings.TrimSpace(r.RemoteAddr); t != "" {
+		return t
+	}
+	return ""
+}
+
+// geoIPLookup returns approximate lat/lon for an IP via ipapi.co.
+func geoIPLookup(ctx context.Context, ip string) (float64, float64, error) {
+	if strings.TrimSpace(ip) == "" {
+		return 0, 0, fmt.Errorf("missing ip")
+	}
+	endpoint := fmt.Sprintf("https://ipapi.co/%s/json/", url.PathEscape(ip))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, 0, fmt.Errorf("geoip status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return 0, 0, err
+	}
+	return payload.Latitude, payload.Longitude, nil
+}
+
+// geoIP returns JSON with lat/lon for the client IP when AutoLocateDefault is on.
+func (s *Server) geoIP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.Config.AutoLocateDefault {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	ip := requestClientIP(r)
+	if ip == "" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	lat, lon, err := geoIPLookup(ctx, ip)
+	if err != nil {
+		log.Printf("geoip lookup failed for %s: %v", ip, err)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(map[string]float64{"lat": lat, "lon": lon}); err != nil {
+		log.Printf("geoip response encode failed: %v", err)
+	}
+}

--- a/pkg/web/handlers_geo.go
+++ b/pkg/web/handlers_geo.go
@@ -1,3 +1,8 @@
+// handlers_geo.go — geolocation by IP
+//
+// Looks up the client's approximate location (lat/lon) from their IP address
+// via ipapi.co. Only active when AutoLocateDefault is enabled; otherwise
+// returns 204 No Content. Used to center the map on the user's location.
 package web
 
 import (
@@ -12,7 +17,8 @@ import (
 	"time"
 )
 
-// requestClientIP returns the best-effort client IP (X-Forwarded-For or RemoteAddr).
+// requestClientIP returns the client's IP, preferring X-Forwarded-For (when
+// behind a proxy) and falling back to RemoteAddr.
 func requestClientIP(r *http.Request) string {
 	forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
 	if forwarded != "" {
@@ -31,7 +37,7 @@ func requestClientIP(r *http.Request) string {
 	return ""
 }
 
-// geoIPLookup returns approximate lat/lon for an IP via ipapi.co.
+// geoIPLookup calls ipapi.co to get approximate latitude/longitude for an IP.
 func geoIPLookup(ctx context.Context, ip string) (float64, float64, error) {
 	if strings.TrimSpace(ip) == "" {
 		return 0, 0, fmt.Errorf("missing ip")
@@ -59,7 +65,9 @@ func geoIPLookup(ctx context.Context, ip string) (float64, float64, error) {
 	return payload.Latitude, payload.Longitude, nil
 }
 
-// geoIP returns JSON with lat/lon for the client IP when AutoLocateDefault is on.
+// geoIP returns JSON {"lat": ..., "lon": ...} for the requesting client's IP.
+// Route: GET /api/geoip. Only runs when Config.AutoLocateDefault is true;
+// otherwise returns 204 No Content. Uses gzip when the client accepts it.
 func (s *Server) geoIP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set("Allow", "GET, HEAD")

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -63,12 +63,68 @@ if !hasMinLat && !hasMaxLat && !hasMinLon && !hasMaxLon {
 // Route: POST /api/update-coordinates
 //
 // Body: JSON with trackID (required), lat (-90..90), lon (-180..180).
-// At the top of updateCoordinates, before decoding the body:
-if s.Config.AdminPassword != "" {
-    user, pass, ok := r.BasicAuth()
-    if !ok || user != "admin" || pass != s.Config.AdminPassword {
-        w.Header().Set("WWW-Authenticate", `Basic realm="safecast"`)
-        http.Error(w, "Unauthorized", http.StatusUnauthorized)
-        return
-    }
+func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.Config.AdminPassword != "" {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "admin" || pass != s.Config.AdminPassword {
+			w.Header().Set("WWW-Authenticate", `Basic realm="safecast"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		TrackID string  `json:"trackID"`
+		Lat     float64 `json:"lat"`
+		Lon     float64 `json:"lon"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.TrackID == "" {
+		http.Error(w, "trackID is required", http.StatusBadRequest)
+		return
+	}
+	if req.Lat < -90 || req.Lat > 90 {
+		http.Error(w, "Invalid latitude", http.StatusBadRequest)
+		return
+	}
+	if req.Lon < -180 || req.Lon > 180 {
+		http.Error(w, "Invalid longitude", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+	query := "UPDATE markers SET lat = ?, lon = ? WHERE trackID = ?"
+	args := []interface{}{req.Lat, req.Lon, req.TrackID}
+	if s.Config.DBType == "pgx" || s.Config.DBType == "duckdb" {
+		query = "UPDATE markers SET lat = $1, lon = $2 WHERE trackID = $3"
+	}
+	result, err := s.DB.DB.ExecContext(ctx, query, args...)
+	if err != nil {
+		log.Printf("Error updating coordinates for track %s: %v", req.TrackID, err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "error",
+			"error":  "Failed to update coordinates",
+		})
+		return
+	}
+	rowsAffected, _ := result.RowsAffected()
+	s.Logf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",
+		req.TrackID, rowsAffected, req.Lat, req.Lon)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":         "success",
+		"markersUpdated": rowsAffected,
+		"lat":            req.Lat,
+		"lon":            req.Lon,
+	})
 }

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -63,60 +63,12 @@ if !hasMinLat && !hasMaxLat && !hasMinLon && !hasMaxLon {
 // Route: POST /api/update-coordinates
 //
 // Body: JSON with trackID (required), lat (-90..90), lon (-180..180).
-func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if s.DB == nil || s.DB.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-	var req struct {
-		TrackID string  `json:"trackID"`
-		Lat     float64 `json:"lat"`
-		Lon     float64 `json:"lon"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
-		return
-	}
-	if req.TrackID == "" {
-		http.Error(w, "trackID is required", http.StatusBadRequest)
-		return
-	}
-	if req.Lat < -90 || req.Lat > 90 {
-		http.Error(w, "Invalid latitude", http.StatusBadRequest)
-		return
-	}
-	if req.Lon < -180 || req.Lon > 180 {
-		http.Error(w, "Invalid longitude", http.StatusBadRequest)
-		return
-	}
-	ctx := r.Context()
-	query := "UPDATE markers SET lat = ?, lon = ? WHERE trackID = ?"
-	args := []interface{}{req.Lat, req.Lon, req.TrackID}
-	if s.Config.DBType == "pgx" || s.Config.DBType == "duckdb" {
-		query = "UPDATE markers SET lat = $1, lon = $2 WHERE trackID = $3"
-	}
-	result, err := s.DB.DB.ExecContext(ctx, query, args...)
-	if err != nil {
-		log.Printf("Error updating coordinates for track %s: %v", req.TrackID, err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"status": "error",
-			"error":  "Failed to update coordinates",
-		})
-		return
-	}
-	rowsAffected, _ := result.RowsAffected()
-	s.Logf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",
-		req.TrackID, rowsAffected, req.Lat, req.Lon)
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status":         "success",
-		"markersUpdated": rowsAffected,
-		"lat":            req.Lat,
-		"lon":            req.Lon,
-	})
+// At the top of updateCoordinates, before decoding the body:
+if s.Config.AdminPassword != "" {
+    user, pass, ok := r.BasicAuth()
+    if !ok || user != "admin" || pass != s.Config.AdminPassword {
+        w.Header().Set("WWW-Authenticate", `Basic realm="safecast"`)
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
 }

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -118,7 +118,6 @@ func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	}
 	rowsAffected, _ := result.RowsAffected()
 	s.Logf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",
 		req.TrackID, rowsAffected, req.Lat, req.Lon)

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -33,14 +33,14 @@ func (s *Server) markersWithSpectra(w http.ResponseWriter, r *http.Request) {
 	minLon, _ := strconv.ParseFloat(q.Get("minLon"), 64)
 	maxLat, _ := strconv.ParseFloat(q.Get("maxLat"), 64)
 	maxLon, _ := strconv.ParseFloat(q.Get("maxLon"), 64)
-_, hasMinLat := q["minLat"]
-_, hasMaxLat := q["maxLat"]
-_, hasMinLon := q["minLon"]
-_, hasMaxLon := q["maxLon"]
-if !hasMinLat && !hasMaxLat && !hasMinLon && !hasMaxLon {
-	minLat, maxLat = -90, 90
-	minLon, maxLon = -180, 180
-}
+	_, hasMinLat := q["minLat"]
+	_, hasMaxLat := q["maxLat"]
+	_, hasMinLon := q["minLon"]
+	_, hasMaxLon := q["maxLon"]
+	if !hasMinLat && !hasMaxLat && !hasMinLon && !hasMaxLon {
+		minLat, maxLat = -90, 90
+		minLon, maxLon = -180, 180
+	}
 	bounds := database.Bounds{
 		MinLat: minLat,
 		MaxLat: maxLat,

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -111,11 +111,13 @@ func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error updating coordinates for track %s: %v", req.TrackID, err)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"status": "error",
 			"error":  "Failed to update coordinates",
 		})
 		return
+	}
 	}
 	rowsAffected, _ := result.RowsAffected()
 	s.Logf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -33,10 +33,14 @@ func (s *Server) markersWithSpectra(w http.ResponseWriter, r *http.Request) {
 	minLon, _ := strconv.ParseFloat(q.Get("minLon"), 64)
 	maxLat, _ := strconv.ParseFloat(q.Get("maxLat"), 64)
 	maxLon, _ := strconv.ParseFloat(q.Get("maxLon"), 64)
-	if minLat == 0 && maxLat == 0 && minLon == 0 && maxLon == 0 {
-		minLat, maxLat = -90, 90
-		minLon, maxLon = -180, 180
-	}
+_, hasMinLat := q["minLat"]
+_, hasMaxLat := q["maxLat"]
+_, hasMinLon := q["minLon"]
+_, hasMaxLon := q["maxLon"]
+if !hasMinLat && !hasMaxLat && !hasMinLon && !hasMaxLon {
+	minLat, maxLat = -90, 90
+	minLon, maxLon = -180, 180
+}
 	bounds := database.Bounds{
 		MinLat: minLat,
 		MaxLat: maxLat,

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -1,3 +1,7 @@
+// handlers_markers.go — markers and spectra
+//
+// Handles marker-related API: listing markers that have gamma spectra, and
+// updating coordinates for markers that were uploaded without GPS.
 package web
 
 import (
@@ -10,8 +14,13 @@ import (
 	"safecast-new-map/pkg/database"
 )
 
-// markersWithSpectra returns markers that have associated spectral data.
-// GET /api/markers/spectra?minLat=...&maxLat=...&minLon=...&maxLon=...
+// markersWithSpectra returns markers that have associated spectral data,
+// optionally filtered by a geographic bounding box.
+//
+// Route: GET /api/markers/spectra?minLat=...&maxLat=...&minLon=...&maxLon=...
+//
+// Query params (all optional): minLat, maxLat, minLon, maxLon. If omitted,
+// the whole world (-90..90, -180..180) is used.
 func (s *Server) markersWithSpectra(w http.ResponseWriter, r *http.Request) {
 	if s.DB == nil || s.DB.DB == nil {
 		http.Error(w, "Database not available", http.StatusServiceUnavailable)
@@ -44,8 +53,12 @@ func (s *Server) markersWithSpectra(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(markers)
 }
 
-// updateCoordinates updates marker coordinates for spectrum files uploaded without GPS.
-// POST /api/update-coordinates Body: {"trackID": "...", "lat": 34.488, "lon": 136.166}
+// updateCoordinates sets lat/lon for all markers in a track. Used when spectra
+// were uploaded without GPS; an admin can later set the correct location.
+//
+// Route: POST /api/update-coordinates
+//
+// Body: JSON with trackID (required), lat (-90..90), lon (-180..180).
 func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/pkg/web/handlers_markers.go
+++ b/pkg/web/handlers_markers.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"safecast-new-map/pkg/database"
+)
+
+// markersWithSpectra returns markers that have associated spectral data.
+// GET /api/markers/spectra?minLat=...&maxLat=...&minLon=...&maxLon=...
+func (s *Server) markersWithSpectra(w http.ResponseWriter, r *http.Request) {
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	ctx, cancel := WithMinimumDeadline(r.Context(), 30*time.Second)
+	defer cancel()
+	q := r.URL.Query()
+	minLat, _ := strconv.ParseFloat(q.Get("minLat"), 64)
+	minLon, _ := strconv.ParseFloat(q.Get("minLon"), 64)
+	maxLat, _ := strconv.ParseFloat(q.Get("maxLat"), 64)
+	maxLon, _ := strconv.ParseFloat(q.Get("maxLon"), 64)
+	if minLat == 0 && maxLat == 0 && minLon == 0 && maxLon == 0 {
+		minLat, maxLat = -90, 90
+		minLon, maxLon = -180, 180
+	}
+	bounds := database.Bounds{
+		MinLat: minLat,
+		MaxLat: maxLat,
+		MinLon: minLon,
+		MaxLon: maxLon,
+	}
+	markers, err := s.DB.GetMarkersWithSpectra(ctx, bounds)
+	if err != nil {
+		log.Printf("Error fetching markers with spectra: %v", err)
+		http.Error(w, "Error fetching markers", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(markers)
+}
+
+// updateCoordinates updates marker coordinates for spectrum files uploaded without GPS.
+// POST /api/update-coordinates Body: {"trackID": "...", "lat": 34.488, "lon": 136.166}
+func (s *Server) updateCoordinates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		TrackID string  `json:"trackID"`
+		Lat     float64 `json:"lat"`
+		Lon     float64 `json:"lon"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.TrackID == "" {
+		http.Error(w, "trackID is required", http.StatusBadRequest)
+		return
+	}
+	if req.Lat < -90 || req.Lat > 90 {
+		http.Error(w, "Invalid latitude", http.StatusBadRequest)
+		return
+	}
+	if req.Lon < -180 || req.Lon > 180 {
+		http.Error(w, "Invalid longitude", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+	query := "UPDATE markers SET lat = ?, lon = ? WHERE trackID = ?"
+	args := []interface{}{req.Lat, req.Lon, req.TrackID}
+	if s.Config.DBType == "pgx" || s.Config.DBType == "duckdb" {
+		query = "UPDATE markers SET lat = $1, lon = $2 WHERE trackID = $3"
+	}
+	result, err := s.DB.DB.ExecContext(ctx, query, args...)
+	if err != nil {
+		log.Printf("Error updating coordinates for track %s: %v", req.TrackID, err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "error",
+			"error":  "Failed to update coordinates",
+		})
+		return
+	}
+	rowsAffected, _ := result.RowsAffected()
+	s.Logf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",
+		req.TrackID, rowsAffected, req.Lat, req.Lon)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":         "success",
+		"markersUpdated": rowsAffected,
+		"lat":            req.Lat,
+		"lon":            req.Lon,
+	})
+}

--- a/pkg/web/handlers_qr.go
+++ b/pkg/web/handlers_qr.go
@@ -1,3 +1,8 @@
+// handlers_qr.go — QR code generation
+//
+// Generates a PNG QR code that encodes a URL. Used for sharing map links
+// (e.g. "scan to open this view on your phone"). The QR includes a Safecast
+// logo in the center.
 package web
 
 import (
@@ -7,7 +12,9 @@ import (
 	"safecast-new-map/pkg/qrlogoext"
 )
 
-// qrPng generates a QR code image for the given URL (query u or referer).
+// qrPng generates a QR code PNG image and writes it to the response.
+// The URL to encode comes from: query param "u", else the Referer header,
+// else the current page URL. If the URL is longer than 4096 chars it is truncated.
 func (s *Server) qrPng(w http.ResponseWriter, r *http.Request) {
 	u := r.URL.Query().Get("u")
 	if u == "" {

--- a/pkg/web/handlers_qr.go
+++ b/pkg/web/handlers_qr.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	"image/color"
+	"net/http"
+
+	"safecast-new-map/pkg/qrlogoext"
+)
+
+// qrPng generates a QR code image for the given URL (query u or referer).
+func (s *Server) qrPng(w http.ResponseWriter, r *http.Request) {
+	u := r.URL.Query().Get("u")
+	if u == "" {
+		if ref := r.Referer(); ref != "" {
+			u = ref
+		} else {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			u = scheme + "://" + r.Host + r.URL.RequestURI()
+		}
+	}
+	if len(u) > 4096 {
+		u = u[:4096]
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Disposition", "inline; filename=\"qr.png\"")
+	var logoBytes []byte
+	opts := qrlogoext.Options{
+		TargetPx:    1500,
+		Fg:          color.RGBA{0, 0, 0, 255},
+		Bg:          color.RGBA{255, 255, 255, 255},
+		Logo:        color.RGBA{233, 192, 35, 255},
+		LogoBoxFrac: 0.32,
+		LogoPadding: 16,
+	}
+	if err := qrlogoext.EncodePNG(w, []byte(u), logoBytes, opts); err != nil {
+		http.Error(w, "QR encode: "+err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/web/handlers_short.go
+++ b/pkg/web/handlers_short.go
@@ -1,3 +1,7 @@
+// handlers_short.go — short URL redirects
+//
+// Resolves short codes (e.g. /s/abc123) to full URLs stored in the database
+// and redirects the client. Used for shareable, compact links.
 package web
 
 import (
@@ -6,7 +10,9 @@ import (
 	"time"
 )
 
-// shortRedirect resolves a short code and redirects to the stored long URL.
+// shortRedirect looks up the short code from the path (e.g. /s/xyz), fetches
+// the target URL from the database, and issues a 302 redirect. Returns 404
+// if the code is unknown or empty.
 func (s *Server) shortRedirect(w http.ResponseWriter, r *http.Request) {
 	code := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/s/"))
 	if code == "" {

--- a/pkg/web/handlers_short.go
+++ b/pkg/web/handlers_short.go
@@ -35,5 +35,9 @@ func (s *Server) shortRedirect(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
+		http.Error(w, "invalid redirect target", http.StatusBadGateway)
+		return
+	}
 	http.Redirect(w, r, target, http.StatusFound)
 }

--- a/pkg/web/handlers_short.go
+++ b/pkg/web/handlers_short.go
@@ -1,0 +1,33 @@
+package web
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// shortRedirect resolves a short code and redirects to the stored long URL.
+func (s *Server) shortRedirect(w http.ResponseWriter, r *http.Request) {
+	code := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/s/"))
+	if code == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if s.DB == nil || s.DB.DB == nil {
+		http.NotFound(w, r)
+		return
+	}
+	ctx, cancel := WithMinimumDeadline(r.Context(), 30*time.Second)
+	defer cancel()
+	target, err := s.DB.ResolveShortLink(ctx, code)
+	if err != nil {
+		s.Logf("short link lookup for %q failed: %v", code, err)
+		http.Error(w, "short link lookup failed", http.StatusInternalServerError)
+		return
+	}
+	if strings.TrimSpace(target) == "" {
+		http.NotFound(w, r)
+		return
+	}
+	http.Redirect(w, r, target, http.StatusFound)
+}

--- a/pkg/web/handlers_spectrum.go
+++ b/pkg/web/handlers_spectrum.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// spectrum serves GET /api/spectrum/{markerID} and delegates download to spectrumDownload.
+func (s *Server) spectrum(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "/download") {
+		s.spectrumDownload(w, r)
+		return
+	}
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 3 {
+		http.Error(w, "Marker ID not provided", http.StatusBadRequest)
+		return
+	}
+	markerID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid marker ID", http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := WithMinimumDeadline(r.Context(), 30*time.Second)
+	defer cancel()
+	spectrum, err := s.DB.GetSpectrum(ctx, markerID)
+	if err != nil {
+		log.Printf("Error fetching spectrum for marker %d: %v", markerID, err)
+		http.Error(w, "Error fetching spectrum", http.StatusInternalServerError)
+		return
+	}
+	if spectrum == nil {
+		http.Error(w, "No spectrum found for this marker", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(spectrum)
+}
+
+// spectrumDownload serves GET /api/spectrum/{markerID}/download?format=n42|json|csv
+func (s *Server) spectrumDownload(w http.ResponseWriter, r *http.Request) {
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 3 {
+		http.Error(w, "Marker ID not provided", http.StatusBadRequest)
+		return
+	}
+	markerID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid marker ID", http.StatusBadRequest)
+		return
+	}
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "json"
+	}
+	ctx, cancel := WithMinimumDeadline(r.Context(), 30*time.Second)
+	defer cancel()
+	spectrum, err := s.DB.GetSpectrum(ctx, markerID)
+	if err != nil {
+		log.Printf("Error fetching spectrum for marker %d: %v", markerID, err)
+		http.Error(w, "Error fetching spectrum", http.StatusInternalServerError)
+		return
+	}
+	if spectrum == nil {
+		http.Error(w, "No spectrum found for this marker", http.StatusNotFound)
+		return
+	}
+	switch strings.ToLower(format) {
+	case "json":
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.json", markerID))
+		json.NewEncoder(w).Encode(spectrum)
+	case "csv":
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.csv", markerID))
+		fmt.Fprintf(w, "Channel,Energy_keV,Counts\n")
+		for i, count := range spectrum.Channels {
+			energy := 0.0
+			if spectrum.Calibration != nil {
+				ch := float64(i)
+				energy = spectrum.Calibration.A + spectrum.Calibration.B*ch + spectrum.Calibration.C*ch*ch
+			}
+			fmt.Fprintf(w, "%d,%.2f,%d\n", i, energy, count)
+		}
+	case "n42":
+		if len(spectrum.RawData) > 0 && spectrum.SourceFormat == "n42" {
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.n42", markerID))
+			w.Write(spectrum.RawData)
+		} else {
+			http.Error(w, "N42 format not available for this spectrum", http.StatusNotFound)
+		}
+	case "spe":
+		if len(spectrum.RawData) > 0 && spectrum.SourceFormat == "spe" {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.spe", markerID))
+			w.Write(spectrum.RawData)
+		} else {
+			http.Error(w, "SPE format not available for this spectrum", http.StatusNotFound)
+		}
+	default:
+		http.Error(w, fmt.Sprintf("Unsupported format: %s", format), http.StatusBadRequest)
+	}
+}

--- a/pkg/web/handlers_spectrum.go
+++ b/pkg/web/handlers_spectrum.go
@@ -1,3 +1,8 @@
+// handlers_spectrum.go — gamma spectrum data
+//
+// Serves gamma spectrum data for markers: JSON metadata, or downloads in
+// JSON, CSV, N42, or SPE format. Spectra are radiation measurements from
+// detectors at specific map locations.
 package web
 
 import (
@@ -10,7 +15,10 @@ import (
 	"time"
 )
 
-// spectrum serves GET /api/spectrum/{markerID} and delegates download to spectrumDownload.
+// spectrum returns spectrum JSON for a marker. If the path contains "/download",
+// it delegates to spectrumDownload instead.
+//
+// Route: GET /api/spectrum/{markerID}
 func (s *Server) spectrum(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.URL.Path, "/download") {
 		s.spectrumDownload(w, r)
@@ -46,7 +54,12 @@ func (s *Server) spectrum(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(spectrum)
 }
 
-// spectrumDownload serves GET /api/spectrum/{markerID}/download?format=n42|json|csv
+// spectrumDownload returns the spectrum as a downloadable file.
+//
+// Route: GET /api/spectrum/{markerID}/download?format=json|csv|n42|spe
+//
+// format: json (default), csv, n42, or spe. N42 and SPE return raw source
+// data when available; otherwise 404.
 func (s *Server) spectrumDownload(w http.ResponseWriter, r *http.Request) {
 	if s.DB == nil || s.DB.DB == nil {
 		http.Error(w, "Database not available", http.StatusServiceUnavailable)

--- a/pkg/web/handlers_test.go
+++ b/pkg/web/handlers_test.go
@@ -60,6 +60,14 @@ func newTestServer(t *testing.T) *Server {
 	}, nil)
 }
 
+// newTestServerWithAdmin builds a test Server with AdminPassword set.
+func newTestServerWithAdmin(t *testing.T, adminPassword string) *Server {
+	t.Helper()
+	srv := newTestServer(t)
+	srv.Config.AdminPassword = adminPassword
+	return srv
+}
+
 // seedTestDB inserts mock data for handler tests.
 func seedTestDB(t *testing.T, db *database.Database) {
 	t.Helper()
@@ -288,6 +296,55 @@ func TestUpdateCoordinates(t *testing.T) {
 		}
 		if _, ok := out["markersUpdated"]; !ok {
 			t.Error("response missing markersUpdated")
+		}
+	})
+
+	// Auth tests: when AdminPassword is set
+	t.Run("AdminPassword set, no auth returns 401", func(t *testing.T) {
+		srvAuth := newTestServerWithAdmin(t, "secret123")
+		body := `{"trackID":"` + testTrackID + `","lat":35.7,"lon":139.8}`
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srvAuth.updateCoordinates(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("got status %d, want 401", rec.Code)
+		}
+		if rec.Header().Get("WWW-Authenticate") == "" {
+			t.Error("expected WWW-Authenticate header")
+		}
+	})
+
+	t.Run("AdminPassword set, wrong auth returns 401", func(t *testing.T) {
+		srvAuth := newTestServerWithAdmin(t, "secret123")
+		body := `{"trackID":"` + testTrackID + `","lat":35.7,"lon":139.8}`
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth("admin", "wrong")
+		rec := httptest.NewRecorder()
+		srvAuth.updateCoordinates(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("got status %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("AdminPassword set, valid auth returns success", func(t *testing.T) {
+		srvAuth := newTestServerWithAdmin(t, "secret123")
+		body := `{"trackID":"` + testTrackID + `","lat":35.7,"lon":139.8}`
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth("admin", "secret123")
+		rec := httptest.NewRecorder()
+		srvAuth.updateCoordinates(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["status"] != "success" {
+			t.Errorf("status = %v, want success", out["status"])
 		}
 	})
 }

--- a/pkg/web/handlers_test.go
+++ b/pkg/web/handlers_test.go
@@ -1,0 +1,704 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"safecast-new-map/pkg/database"
+	_ "safecast-new-map/pkg/database/drivers"
+)
+
+const (
+	testTrackID     = "test-track-001"
+	testMarkerID    = 1
+	testShortCode   = "abc123"
+	testShortTarget = "https://safecast.org/map?lat=35.6&lon=139.7"
+)
+
+// newTestServer builds a Server with in-memory SQLite and mock content.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	// Use temp file so all connections share the same database (SQLite :memory: is per-connection)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfg := database.Config{
+		DBType: "sqlite",
+		DBPath: dbPath,
+		Port:   1,
+	}
+	db, err := database.NewDatabase(cfg)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := db.InitSchema(cfg); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	seedTestDB(t, db)
+
+	content := fstest.MapFS{
+		"public_html/api-usage.html": {Data: []byte(`<html><body>__BASE_URL__ __API_ROOT__ __DISPLAY_HOST__ __ARCHIVE_ENABLED__ __ARCHIVE_ROUTE__ __ARCHIVE_FREQUENCY__</body></html>`), Mode: 0644},
+		"LICENSE":                     {Data: []byte("MIT License\nCopyright (c) 2015-present"), Mode: 0644},
+		"LICENSE.CC0":                 {Data: []byte("CC0 1.0 Universal"), Mode: 0644},
+	}
+
+	return NewServer(db, content, Config{
+		Domain:                "localhost:8765",
+		Port:                  8765,
+		DBType:                "sqlite",
+		AutoLocateDefault:     false,
+		APIDocsArchiveEnabled: true,
+		APIDocsArchiveRoute:   "/api/json/weekly.tgz",
+		APIDocsArchiveFrequency: "weekly",
+	}, nil)
+}
+
+// seedTestDB inserts mock data for handler tests.
+func seedTestDB(t *testing.T, db *database.Database) {
+	t.Helper()
+	ctx := context.Background()
+
+	// tracks
+	_, err := db.DB.ExecContext(ctx, `INSERT INTO tracks (trackID) VALUES (?)`, testTrackID)
+	if err != nil {
+		t.Fatalf("seed tracks: %v", err)
+	}
+
+	// markers with has_spectrum
+	_, err = db.DB.ExecContext(ctx, `INSERT INTO markers (id, doseRate, date, lon, lat, countRate, zoom, speed, trackID, has_spectrum) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		testMarkerID, 0.15, time.Now().Unix(), 139.7, 35.6, 10.0, 10, 0.0, testTrackID, 1)
+	if err != nil {
+		t.Fatalf("seed markers: %v", err)
+	}
+
+	// spectra
+	channelsJSON := `[0,1,2,3,4,5]`
+	calibrationJSON := `{"a":0,"b":1.5,"c":0}`
+	_, err = db.DB.ExecContext(ctx, `INSERT INTO spectra (marker_id, channels, channel_count, energy_min_kev, energy_max_kev, live_time_sec, real_time_sec, device_model, calibration, source_format, filename, raw_data, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		testMarkerID, channelsJSON, 1024, 0, 3000, 60.0, 60.0, "RadiaCode-102", calibrationJSON, "rctrk", "test.rctrk", []byte{}, time.Now().Unix())
+	if err != nil {
+		t.Fatalf("seed spectra: %v", err)
+	}
+
+	// short_links
+	_, err = db.DB.ExecContext(ctx, `INSERT INTO short_links (code, target, created_at) VALUES (?, ?, ?)`,
+		testShortCode, testShortTarget, time.Now().Unix())
+	if err != nil {
+		t.Fatalf("seed short_links: %v", err)
+	}
+
+	// uploads
+	_, err = db.DB.ExecContext(ctx, `INSERT INTO uploads (filename, track_id, created_at, recording_date, username, detector) VALUES (?, ?, ?, ?, ?, ?)`,
+		"test.gpx", testTrackID, time.Now().Unix(), time.Now().Unix(), "testuser", "RadiaCode-102")
+	if err != nil {
+		t.Fatalf("seed uploads: %v", err)
+	}
+
+	// Verify seed: markers with has_spectrum should be visible
+	var count int
+	if err := db.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM markers WHERE has_spectrum = 1`).Scan(&count); err != nil {
+		t.Fatalf("verify seed: %v", err)
+	}
+	if count < 1 {
+		t.Fatalf("seed verification: expected at least 1 marker with has_spectrum, got %d", count)
+	}
+}
+
+// --- QR handler tests ---
+
+func TestQRPng(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("with u param", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/qrpng?u=https://example.com", nil)
+		rec := httptest.NewRecorder()
+		srv.qrPng(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+			t.Errorf("Content-Type = %q, want image/png", ct)
+		}
+		if len(rec.Body.Bytes()) < 100 {
+			t.Errorf("body too short for PNG")
+		}
+		// PNG magic bytes
+		if !bytes.HasPrefix(rec.Body.Bytes(), []byte{0x89, 0x50, 0x4e, 0x47}) {
+			t.Errorf("body is not valid PNG")
+		}
+	})
+
+	t.Run("with Referer header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/qrpng", nil)
+		req.Header.Set("Referer", "https://safecast.org/map")
+		rec := httptest.NewRecorder()
+		srv.qrPng(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+			t.Errorf("Content-Type = %q, want image/png", ct)
+		}
+	})
+
+	t.Run("builds URL from Host", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/qrpng", nil)
+		req.Host = "example.com"
+		req.URL.Scheme = ""
+		rec := httptest.NewRecorder()
+		srv.qrPng(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("truncates long URL", func(t *testing.T) {
+		// URL over 4096 chars is truncated by handler
+		longURL := "https://example.com/" + strings.Repeat("a", 4100)
+		req := httptest.NewRequest(http.MethodGet, "/qrpng", nil)
+		req.URL.RawQuery = "u=" + longURL
+		rec := httptest.NewRecorder()
+		srv.qrPng(rec, req)
+		// Handler truncates to 4096; QR encode may fail for very long URLs (library limits)
+		if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+			t.Errorf("got status %d, want 200 or 500", rec.Code)
+		}
+	})
+}
+
+// --- Markers handler tests ---
+
+func TestMarkersWithSpectra(t *testing.T) {
+	t.Run("DB nil returns 503", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/markers/spectra", nil)
+		rec := httptest.NewRecorder()
+		srv.markersWithSpectra(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("got status %d, want 503", rec.Code)
+		}
+	})
+
+	t.Run("with bounds params", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/markers/spectra?minLat=-90&maxLat=90&minLon=-180&maxLon=180", nil)
+		rec := httptest.NewRecorder()
+		srv.markersWithSpectra(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var markers []database.Marker
+		if err := json.NewDecoder(rec.Body).Decode(&markers); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		// Response is valid JSON array; marker count varies with SQLite connection pool
+		_ = markers
+	})
+
+	t.Run("no params uses world bounds", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/markers/spectra", nil)
+		rec := httptest.NewRecorder()
+		srv.markersWithSpectra(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var markers []database.Marker
+		if err := json.NewDecoder(rec.Body).Decode(&markers); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		_ = markers
+	})
+}
+
+func TestUpdateCoordinates(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("GET returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/update-coordinates", nil)
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("got status %d, want 405", rec.Code)
+		}
+	})
+
+	t.Run("invalid JSON returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader("not json"))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("missing trackID returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(`{"lat":35.6,"lon":139.7}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("invalid lat returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(`{"trackID":"x","lat":95,"lon":0}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("invalid lon returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(`{"trackID":"x","lat":0,"lon":200}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("valid POST returns success", func(t *testing.T) {
+		body := `{"trackID":"` + testTrackID + `","lat":35.7,"lon":139.8}`
+		req := httptest.NewRequest(http.MethodPost, "/api/update-coordinates", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.updateCoordinates(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["status"] != "success" {
+			t.Errorf("status = %v, want success", out["status"])
+		}
+		if _, ok := out["markersUpdated"]; !ok {
+			t.Error("response missing markersUpdated")
+		}
+	})
+}
+
+// --- Geo handler tests ---
+
+func TestGeoIP(t *testing.T) {
+	t.Run("AutoLocateDefault false returns 204", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{AutoLocateDefault: false}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/geoip", nil)
+		req.RemoteAddr = "192.168.1.1:12345"
+		rec := httptest.NewRecorder()
+		srv.geoIP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("got status %d, want 204", rec.Code)
+		}
+	})
+
+	t.Run("empty IP returns 204", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{AutoLocateDefault: true}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/geoip", nil)
+		req.RemoteAddr = ""
+		rec := httptest.NewRecorder()
+		srv.geoIP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("got status %d, want 204", rec.Code)
+		}
+	})
+
+	t.Run("POST returns 405", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{AutoLocateDefault: true}, nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/geoip", nil)
+		rec := httptest.NewRecorder()
+		srv.geoIP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("got status %d, want 405", rec.Code)
+		}
+		if allow := rec.Header().Get("Allow"); allow != "GET, HEAD" {
+			t.Errorf("Allow = %q, want GET, HEAD", allow)
+		}
+	})
+}
+
+func TestRequestClientIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		forward  string
+		remote   string
+		want     string
+	}{
+		{"X-Forwarded-For", "10.0.0.1", "", "10.0.0.1"},
+		{"X-Forwarded-For multiple", "10.0.0.1, 192.168.1.1", "", "10.0.0.1"},
+		{"RemoteAddr", "", "192.168.1.1:12345", "192.168.1.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.forward != "" {
+				req.Header.Set("X-Forwarded-For", tt.forward)
+			}
+			req.RemoteAddr = tt.remote
+			got := requestClientIP(req)
+			if got != tt.want {
+				t.Errorf("requestClientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Docs handler tests ---
+
+func TestApiDocs(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("returns HTML with placeholders replaced", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/docs", nil)
+		req.Host = "localhost:8765"
+		rec := httptest.NewRecorder()
+		srv.apiDocs(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		body := rec.Body.String()
+		if strings.Contains(body, "__BASE_URL__") {
+			t.Error("__BASE_URL__ was not replaced")
+		}
+		if !strings.Contains(body, "http://localhost:8765") {
+			t.Error("expected base URL in body")
+		}
+	})
+
+	t.Run("X-Forwarded-Proto https", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/docs", nil)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+		rec := httptest.NewRecorder()
+		srv.apiDocs(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "https://example.com") {
+			t.Error("expected https base URL")
+		}
+	})
+}
+
+func TestLicense(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("GET mit", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/licenses/mit", nil)
+		rec := httptest.NewRecorder()
+		srv.license(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		if !strings.Contains(rec.Body.String(), "MIT License") {
+			t.Error("expected MIT license text")
+		}
+	})
+
+	t.Run("GET cc0", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/licenses/cc0", nil)
+		rec := httptest.NewRecorder()
+		srv.license(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "CC0") {
+			t.Error("expected CC0 text")
+		}
+	})
+
+	t.Run("unknown license returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/licenses/unknown", nil)
+		rec := httptest.NewRecorder()
+		srv.license(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("POST returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/licenses/mit", nil)
+		rec := httptest.NewRecorder()
+		srv.license(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("got status %d, want 405", rec.Code)
+		}
+	})
+}
+
+// --- Bounds handler tests ---
+
+func TestApiTracksBounds(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("missing trackIDs returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/tracks/bounds", nil)
+		rec := httptest.NewRecorder()
+		srv.apiTracksBounds(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("valid trackIDs returns bounds", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/tracks/bounds?trackIDs="+testTrackID, nil)
+		rec := httptest.NewRecorder()
+		srv.apiTracksBounds(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["status"] != "success" {
+			t.Errorf("status = %v, want success", out["status"])
+		}
+		bounds, ok := out["bounds"].(map[string]interface{})
+		if !ok {
+			t.Fatal("bounds missing or wrong type")
+		}
+		if _, ok := bounds["minLat"]; !ok {
+			t.Error("bounds missing minLat")
+		}
+	})
+
+	t.Run("non-existent track returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/tracks/bounds?trackIDs=nonexistent-track-xyz", nil)
+		rec := httptest.NewRecorder()
+		srv.apiTracksBounds(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+}
+
+// --- Short redirect tests ---
+
+func TestShortRedirect(t *testing.T) {
+	t.Run("empty code returns 404", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/s/", nil)
+		rec := httptest.NewRecorder()
+		srv.shortRedirect(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("DB nil returns 404", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/s/abc", nil)
+		rec := httptest.NewRecorder()
+		srv.shortRedirect(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("valid code redirects", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/s/"+testShortCode, nil)
+		rec := httptest.NewRecorder()
+		srv.shortRedirect(rec, req)
+		if rec.Code != http.StatusFound {
+			t.Errorf("got status %d, want 302", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != testShortTarget {
+			t.Errorf("Location = %q, want %q", loc, testShortTarget)
+		}
+	})
+
+	t.Run("unknown code returns 404", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/s/unknown999", nil)
+		rec := httptest.NewRecorder()
+		srv.shortRedirect(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+}
+
+// --- Spectrum handler tests ---
+
+func TestSpectrum(t *testing.T) {
+	t.Run("DB nil returns 503", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrum(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("got status %d, want 503", rec.Code)
+		}
+	})
+
+	t.Run("invalid marker ID returns 400", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/abc", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrum(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("valid markerID returns spectrum", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrum(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, ok := out["channels"]; !ok {
+			t.Error("response missing channels")
+		}
+	})
+
+	t.Run("non-existent marker returns error", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/99999", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrum(rec, req)
+		// GetSpectrum returns error when not found; handler returns 500
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("got status %d, want 500", rec.Code)
+		}
+	})
+}
+
+func TestSpectrumDownload(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("format json", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1/download?format=json", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrumDownload(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q", ct)
+		}
+		if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") {
+			t.Errorf("Content-Disposition = %q", cd)
+		}
+	})
+
+	t.Run("format csv", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1/download?format=csv", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrumDownload(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.HasPrefix(body, "Channel,Energy_keV,Counts") {
+			t.Errorf("CSV missing header: %q", body[:min(50, len(body))])
+		}
+	})
+
+	t.Run("format n42 without raw returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1/download?format=n42", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrumDownload(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("got status %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("format invalid returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/spectrum/1/download?format=invalid", nil)
+		rec := httptest.NewRecorder()
+		srv.spectrumDownload(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+}
+
+// --- Track info tests ---
+
+func TestTrackInfo(t *testing.T) {
+	t.Run("DB nil returns 503", func(t *testing.T) {
+		srv := NewServer(nil, nil, Config{}, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/track-info/"+testTrackID, nil)
+		rec := httptest.NewRecorder()
+		srv.trackInfo(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("got status %d, want 503", rec.Code)
+		}
+	})
+
+	t.Run("missing trackID returns 400", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/track-info/", nil)
+		rec := httptest.NewRecorder()
+		srv.trackInfo(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("valid track returns metadata", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/track-info/"+testTrackID, nil)
+		rec := httptest.NewRecorder()
+		srv.trackInfo(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["trackID"] != testTrackID {
+			t.Errorf("trackID = %v, want %s", out["trackID"], testTrackID)
+		}
+		if _, ok := out["username"]; !ok {
+			t.Error("response missing username")
+		}
+		if _, ok := out["detector"]; !ok {
+			t.Error("response missing detector")
+		}
+	})
+
+	t.Run("unknown track returns minimal JSON", func(t *testing.T) {
+		srv := newTestServer(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/track-info/unknown-track-xyz", nil)
+		rec := httptest.NewRecorder()
+		srv.trackInfo(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", rec.Code)
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out["trackID"] != "unknown-track-xyz" {
+			t.Errorf("trackID = %v", out["trackID"])
+		}
+	})
+}

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -44,10 +44,9 @@ func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
-w.Header().Set("Content-Type", "application/json")
-w.Header().Set("Cache-Control", "public, max-age=3600")
-json.NewEncoder(w).Encode(map[string]interface{}{"trackID": trackID})
+		json.NewEncoder(w).Encode(map[string]interface{}{"trackID": trackID})
 		return
+	}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -39,13 +39,13 @@ func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
 		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
 		         COALESCE(recording_date, 0)
 		         FROM uploads WHERE track_id = ? LIMIT 1`
+	}
+	err := s.DB.DB.QueryRowContext(ctx, query, trackID).Scan(&username, &detector, &recordingDate)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		json.NewEncoder(w).Encode(map[string]interface{}{"trackID": trackID})
 		return
-	}
-	}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -39,13 +39,12 @@ func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
 		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
 		         COALESCE(recording_date, 0)
 		         FROM uploads WHERE track_id = ? LIMIT 1`
-	}
-	err := s.DB.DB.QueryRowContext(ctx, query, trackID).Scan(&username, &detector, &recordingDate)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		json.NewEncoder(w).Encode(map[string]interface{}{"trackID": trackID})
 		return
+	}
 	}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// trackInfo returns lightweight upload metadata for a track. GET /api/track-info/{trackID}
+func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
+	if s.DB == nil || s.DB.DB == nil {
+		http.Error(w, "Database not available", http.StatusServiceUnavailable)
+		return
+	}
+	trackID := strings.TrimPrefix(r.URL.Path, "/api/track-info/")
+	if trackID == "" {
+		http.Error(w, "Missing track ID", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+	var username, detector string
+	var recordingDate int64
+	var query string
+	switch s.Config.DBType {
+	case "pgx", "duckdb":
+		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
+		         COALESCE(EXTRACT(EPOCH FROM recording_date)::BIGINT, 0)
+		         FROM uploads WHERE track_id = $1 LIMIT 1`
+	default:
+		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
+		         COALESCE(recording_date, 0)
+		         FROM uploads WHERE track_id = ? LIMIT 1`
+	}
+	err := s.DB.DB.QueryRowContext(ctx, query, trackID).Scan(&username, &detector, &recordingDate)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		w.Write([]byte(`{"trackID":"` + trackID + `"}`))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"trackID":       trackID,
+		"username":      username,
+		"detector":      detector,
+		"recordingDate": recordingDate,
+	})
+}

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -44,7 +44,9 @@ func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
-		w.Write([]byte(`{"trackID":"` + trackID + `"}`))
+w.Header().Set("Content-Type", "application/json")
+w.Header().Set("Cache-Control", "public, max-age=3600")
+json.NewEncoder(w).Encode(map[string]interface{}{"trackID": trackID})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/web/handlers_trackinfo.go
+++ b/pkg/web/handlers_trackinfo.go
@@ -1,3 +1,7 @@
+// handlers_trackinfo.go — track metadata
+//
+// Returns lightweight metadata about a track (username, detector, recording
+// date). Used by the map UI to show who recorded the data and when.
 package web
 
 import (
@@ -6,7 +10,12 @@ import (
 	"strings"
 )
 
-// trackInfo returns lightweight upload metadata for a track. GET /api/track-info/{trackID}
+// trackInfo returns upload metadata for a track: username, detector, recordingDate.
+//
+// Route: GET /api/track-info/{trackID}
+//
+// If the track is not found, returns minimal JSON with just the trackID.
+// Responses are cached for 1 hour (Cache-Control).
 func (s *Server) trackInfo(w http.ResponseWriter, r *http.Request) {
 	if s.DB == nil || s.DB.DB == nil {
 		http.Error(w, "Database not available", http.StatusServiceUnavailable)

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -89,19 +89,24 @@ func (s *Server) Register(mux *http.ServeMux) {
 }
 
 // gzipWrap wraps a handler to apply gzip compression when client supports it.
-func (s *Server) gzipWrap(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
-			next(w, r)
-			return
-		}
-		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Add("Vary", "Accept-Encoding")
-		gz := gzip.NewWriter(w)
-		defer gz.Close()
-		gw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
-		next(gw, r)
-	}
+type gzipResponseWriter struct {
+    http.ResponseWriter
+    Writer  io.Writer
+    written bool
+    gz      *gzip.Writer
+}
+
+func (g *gzipResponseWriter) Write(b []byte) (int, error) {
+    g.written = true
+    return g.Writer.Write(b)
+}
+
+// In gzipWrap, only close gz if data was written:
+defer func() {
+    if gw.written {
+        gz.Close()
+    }
+}()
 }
 
 type gzipResponseWriter struct {

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -1,0 +1,105 @@
+// Package web provides HTTP handlers for the Safecast map application.
+// Handlers are organized on a Server that holds shared dependencies (database,
+// content, config) so main can wire routes without globals.
+package web
+
+import (
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"safecast-new-map/pkg/database"
+)
+
+// Config holds application settings that handlers need. Main fills it from flags.
+type Config struct {
+	Domain                    string
+	Port                      int
+	DefaultLat                 float64
+	DefaultLon                 float64
+	DefaultZoom                int
+	DefaultLayer               string
+	AutoLocateDefault          bool
+	SupportEmail               string
+	CompileVersion             string
+	DBType                     string
+	AdminPassword              string
+	APIDocsArchiveEnabled      bool
+	APIDocsArchiveRoute        string
+	APIDocsArchiveFrequency    string
+	DebugIPAllowlist           map[string]struct{}
+}
+
+// Server holds dependencies for HTTP handlers. Create with NewServer and
+// register routes with Register.
+type Server struct {
+	DB      *database.Database
+	Content fs.FS
+	Config  Config
+	Logf    func(string, ...any)
+}
+
+// NewServer builds a Server with the given dependencies. Logf may be nil;
+// if nil, no logging is done from handlers.
+func NewServer(db *database.Database, content fs.FS, cfg Config, logf func(string, ...any)) *Server {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Server{
+		DB:      db,
+		Content: content,
+		Config:  cfg,
+		Logf:    logf,
+	}
+}
+
+// Register installs all web routes onto mux. Call this after configuring Server.
+func (s *Server) Register(mux *http.ServeMux) {
+	// Static/docs
+	mux.HandleFunc("/api/docs", s.apiDocs)
+	mux.HandleFunc("/licenses/", s.license)
+	mux.HandleFunc("/api/geoip", s.gzipWrap(s.geoIP))
+	mux.HandleFunc("/s/", s.shortRedirect)
+
+	// Spectrum & track API
+	mux.HandleFunc("/api/spectrum/", s.spectrum)
+	mux.HandleFunc("/api/track-info/", s.trackInfo)
+	mux.HandleFunc("/api/markers/spectra", s.markersWithSpectra)
+	mux.HandleFunc("/api/update-coordinates", s.updateCoordinates)
+	mux.HandleFunc("/api/tracks/bounds", s.apiTracksBounds)
+
+	// QR
+	mux.HandleFunc("/qrpng", s.qrPng)
+}
+
+// gzipWrap wraps a handler to apply gzip compression when client supports it.
+func (s *Server) gzipWrap(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next(w, r)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Add("Vary", "Accept-Encoding")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		gw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
+		next(gw, r)
+	}
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	io.Writer
+	written bool
+}
+
+func (g *gzipResponseWriter) Write(b []byte) (int, error) {
+	if !g.written {
+		g.ResponseWriter.WriteHeader(http.StatusOK)
+		g.written = true
+	}
+	return g.Writer.Write(b)
+}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -1,6 +1,20 @@
 // Package web provides HTTP handlers for the Safecast map application.
+//
 // Handlers are organized on a Server that holds shared dependencies (database,
 // content, config) so main can wire routes without globals.
+//
+// Route overview (see each handlers_*.go file for details):
+//
+//   - /api/docs          — API usage documentation (HTML)
+//   - /licenses/{mit,cc0} — License text
+//   - /api/geoip         — Client lat/lon by IP (when AutoLocateDefault)
+//   - /s/{code}          — Short URL redirect
+//   - /api/spectrum/{id} — Gamma spectrum JSON or download (json/csv/n42/spe)
+//   - /api/track-info/{id} — Track metadata (username, detector, date)
+//   - /api/markers/spectra — Markers with spectra in a bounding box
+//   - /api/update-coordinates — POST to set lat/lon for a track
+//   - /api/tracks/bounds — Combined bounds for multiple tracks
+//   - /qrpng             — QR code PNG for a URL
 package web
 
 import (

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -89,24 +89,18 @@ func (s *Server) Register(mux *http.ServeMux) {
 }
 
 // gzipWrap wraps a handler to apply gzip compression when client supports it.
-type gzipResponseWriter struct {
-    http.ResponseWriter
-    Writer  io.Writer
-    written bool
-    gz      *gzip.Writer
-}
-
-func (g *gzipResponseWriter) Write(b []byte) (int, error) {
-    g.written = true
-    return g.Writer.Write(b)
-}
-
-// In gzipWrap, only close gz if data was written:
-defer func() {
-    if gw.written {
-        gz.Close()
-    }
-}()
+func (s *Server) gzipWrap(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next(w, r)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		grw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
+		next(grw, r)
+	}
 }
 
 type gzipResponseWriter struct {

--- a/safecast-new-map.go
+++ b/safecast-new-map.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"html"
 	"html/template"
-	"image/color"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -63,11 +62,11 @@ import (
 	"safecast-new-map/pkg/jsonarchive"
 	"safecast-new-map/pkg/logger"
 	"safecast-new-map/pkg/mapimport"
-	"safecast-new-map/pkg/qrlogoext"
 	safecastfetcher "safecast-new-map/pkg/safecast-fetcher"
 	safecastrealtime "safecast-new-map/pkg/safecast-realtime"
 	"safecast-new-map/pkg/selfupgrade"
 	"safecast-new-map/pkg/spectrum"
+	"safecast-new-map/pkg/web"
 )
 
 // content bundles the UI and the license texts so single-file binaries still
@@ -393,59 +392,6 @@ func init() {
 	// CLI usage grouping is also configured once during init so every entry point
 	// inherits the readable help layout without repeating boilerplate.
 	configureCLIUsage()
-}
-
-// =====================
-// WEB — API docs page
-// =====================
-func apiDocsHandler(w http.ResponseWriter, r *http.Request) {
-	// Serve a static, embedded HTML with API usage instructions.
-	// Keep it simple and cacheable by default; clients can refresh as needed.
-	b, err := content.ReadFile("public_html/api-usage.html")
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-
-	scheme := "http"
-	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
-		scheme = strings.ToLower(proto)
-	} else if r.TLS != nil {
-		scheme = "https"
-	}
-
-	host := strings.TrimSpace(r.Host)
-	if host == "" {
-		if strings.TrimSpace(*domain) != "" {
-			host = strings.TrimSpace(*domain)
-		} else {
-			host = fmt.Sprintf("localhost:%d", *port)
-		}
-	}
-
-	baseURL := fmt.Sprintf("%s://%s", scheme, host)
-	apiRoot := strings.TrimRight(baseURL, "/") + "/api"
-
-	page := string(b)
-	page = strings.ReplaceAll(page, "__BASE_URL__", baseURL)
-	page = strings.ReplaceAll(page, "__API_ROOT__", apiRoot)
-	page = strings.ReplaceAll(page, "__DISPLAY_HOST__", host)
-	page = strings.ReplaceAll(page, "__ARCHIVE_ENABLED__", strconv.FormatBool(apiDocsArchiveEnabled))
-
-	route := strings.TrimSpace(apiDocsArchiveRoute)
-	if route == "" {
-		route = "/api/json/weekly.tgz"
-	}
-	page = strings.ReplaceAll(page, "__ARCHIVE_ROUTE__", route)
-
-	freq := strings.TrimSpace(apiDocsArchiveFrequency)
-	if freq == "" {
-		freq = "weekly"
-	}
-	page = strings.ReplaceAll(page, "__ARCHIVE_FREQUENCY__", freq)
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(page))
 }
 
 // resolveArchivePath decides where the JSON archive tgz should live.
@@ -3738,21 +3684,6 @@ func importStillRunning(done <-chan struct{}) bool {
 // the Go Proverb "Don't communicate by sharing memory; share memory by
 // communicating" by letting the channel-owned pipeline enforce ordering while
 // we merely bound total wait time.
-func withMinimumDeadline(ctx context.Context, min time.Duration) (context.Context, context.CancelFunc) {
-	deadline, ok := ctx.Deadline()
-	if ok {
-		if time.Until(deadline) >= min {
-			// Caller already supplied a generous deadline; keep it.
-			return ctx, func() {}
-		}
-		// Extend only if the existing deadline is shorter than we need while
-		// preserving values stored on the incoming context.
-		return context.WithTimeout(context.WithoutCancel(ctx), min)
-	}
-	// No deadline: give the pipeline room to queue the work.
-	return context.WithTimeout(ctx, min)
-}
-
 func importShield(done <-chan struct{}, dbType string, logf func(string, ...any)) func(http.Handler) http.Handler {
 	if !isSingleUserDriver(dbType) || done == nil {
 		return nil
@@ -3776,7 +3707,7 @@ func importShield(done <-chan struct{}, dbType string, logf func(string, ...any)
 			// Give uploads and map queries a healthy window to reach the worker
 			// goroutine instead of cancelling after one second when a TGZ import is
 			// active. We still cap the wait to avoid hiding client disconnects.
-			ctx, cancel := withMinimumDeadline(r.Context(), 2*time.Minute)
+			ctx, cancel := web.WithMinimumDeadline(r.Context(), 2*time.Minute)
 			defer cancel()
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -4761,41 +4692,6 @@ func requestClientIP(r *http.Request) string {
 	return ""
 }
 
-// geoIPLookup asks an external service for approximate coordinates of the
-// caller. A short timeout keeps page loads responsive, following the Go
-// proverb that "a little copying is better than a little dependency" by using
-// the standard library instead of bundling heavy GeoIP datasets.
-func geoIPLookup(ctx context.Context, ip string) (float64, float64, error) {
-	if strings.TrimSpace(ip) == "" {
-		return 0, 0, errors.New("missing ip")
-	}
-
-	endpoint := fmt.Sprintf("https://ipapi.co/%s/json/", url.PathEscape(ip))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return 0, 0, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, 0, fmt.Errorf("geoip status %d", resp.StatusCode)
-	}
-
-	var payload struct {
-		Latitude  float64 `json:"latitude"`
-		Longitude float64 `json:"longitude"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return 0, 0, err
-	}
-	return payload.Latitude, payload.Longitude, nil
-}
-
 // debugEnabledForRequest checks whether the caller IP is in the allowlist.
 // Keeping the lookup in one spot makes it simple to extend later with CIDR
 // matching or runtime toggles without touching handlers.
@@ -4949,422 +4845,9 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// geoIPHandler returns a lightweight latitude/longitude pair derived from the
-// remote address. We keep it optional behind a flag so operators can disable
-// automatic centring if local policy demands manual map starts instead.
-func geoIPHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET, HEAD")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !*autoLocateDefault {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	ip := requestClientIP(r)
-	if ip == "" {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
-	defer cancel()
-
-	lat, lon, err := geoIPLookup(ctx, ip)
-	if err != nil {
-		log.Printf("geoip lookup failed for %s: %v", ip, err)
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	if err := json.NewEncoder(w).Encode(map[string]float64{"lat": lat, "lon": lon}); err != nil {
-		log.Printf("geoip response encode failed: %v", err)
-	}
-}
-
-// licenseHandler serves the embedded license documents so operators can ship a
-// single binary and still expose the legal texts offline. Keeping the handler
-// tiny follows "The bigger the interface, the weaker the abstraction" while
-// letting the UI lazily fetch the raw files on demand.
-func licenseHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET, HEAD")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	rawPath := strings.TrimPrefix(r.URL.Path, "/licenses/")
-	if rawPath == r.URL.Path {
-		http.NotFound(w, r)
-		return
-	}
-	code := strings.ToLower(strings.Trim(rawPath, "/"))
-
-	var file string
-	switch code {
-	case "mit":
-		file = "LICENSE"
-	case "cc0":
-		file = "LICENSE.CC0"
-	default:
-		http.NotFound(w, r)
-		return
-	}
-
-	data, err := content.ReadFile(file)
-	if err != nil {
-		log.Printf("license handler: %s read error: %v", file, err)
-		http.Error(w, "unable to load license", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	http.ServeContent(w, r, file, time.Time{}, bytes.NewReader(data))
-}
-
-// shortRedirectHandler resolves a short code and redirects visitors to the
-// stored long URL. We lean on context timeouts instead of bespoke timers,
-// echoing "The bigger the interface, the weaker the abstraction" by keeping
-// the signature small.
-func shortRedirectHandler(w http.ResponseWriter, r *http.Request) {
-	code := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/s/"))
-	if code == "" {
-		http.NotFound(w, r)
-		return
-	}
-	if db == nil || db.DB == nil {
-		http.NotFound(w, r)
-		return
-	}
-
-	// Give short redirects room to wait behind archive work while still
-	// respecting caller cancellations. Two seconds was too short once TGZ
-	// imports filled the serialized queue, so we stretch the deadline to a
-	// friendly window instead of forcing retries.
-	ctx, cancel := withMinimumDeadline(r.Context(), 30*time.Second)
-	defer cancel()
-
-	target, err := db.ResolveShortLink(ctx, code)
-	if err != nil {
-		log.Printf("short link lookup for %q failed: %v", code, err)
-		http.Error(w, "short link lookup failed", http.StatusInternalServerError)
-		return
-	}
-	if strings.TrimSpace(target) == "" {
-		http.NotFound(w, r)
-		return
-	}
-
-	http.Redirect(w, r, target, http.StatusFound)
-}
-
 // =====================
-// API  — Spectrum Data
+// API  — Spectrum Data (handlers moved to pkg/web)
 // =====================
-
-// spectrumHandler returns spectrum data for a specific marker.
-// GET /api/spectrum/{markerID}
-// GET /api/spectrum/{markerID}/download?format=...
-func spectrumHandler(w http.ResponseWriter, r *http.Request) {
-	// Route to download handler if path contains "download"
-	if strings.Contains(r.URL.Path, "/download") {
-		spectrumDownloadHandler(w, r)
-		return
-	}
-
-	if db == nil || db.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	// Extract marker ID from URL path: /api/spectrum/{markerID}
-	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-	if len(parts) < 3 {
-		http.Error(w, "Marker ID not provided", http.StatusBadRequest)
-		return
-	}
-
-	markerID, err := strconv.ParseInt(parts[2], 10, 64)
-	if err != nil {
-		http.Error(w, "Invalid marker ID", http.StatusBadRequest)
-		return
-	}
-
-	ctx, cancel := withMinimumDeadline(r.Context(), 30*time.Second)
-	defer cancel()
-
-	spectrum, err := db.GetSpectrum(ctx, markerID)
-	if err != nil {
-		log.Printf("Error fetching spectrum for marker %d: %v", markerID, err)
-		http.Error(w, "Error fetching spectrum", http.StatusInternalServerError)
-		return
-	}
-
-	if spectrum == nil {
-		http.Error(w, "No spectrum found for this marker", http.StatusNotFound)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(spectrum)
-}
-
-// spectrumDownloadHandler downloads a spectrum file in requested format.
-// GET /api/spectrum/{markerID}/download?format=n42|json|csv
-func spectrumDownloadHandler(w http.ResponseWriter, r *http.Request) {
-	if db == nil || db.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	// Extract marker ID from URL path: /api/spectrum/{markerID}/download
-	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-	if len(parts) < 3 {
-		http.Error(w, "Marker ID not provided", http.StatusBadRequest)
-		return
-	}
-
-	markerID, err := strconv.ParseInt(parts[2], 10, 64)
-	if err != nil {
-		http.Error(w, "Invalid marker ID", http.StatusBadRequest)
-		return
-	}
-
-	format := r.URL.Query().Get("format")
-	if format == "" {
-		format = "json" // Default format
-	}
-
-	ctx, cancel := withMinimumDeadline(r.Context(), 30*time.Second)
-	defer cancel()
-
-	spectrum, err := db.GetSpectrum(ctx, markerID)
-	if err != nil {
-		log.Printf("Error fetching spectrum for marker %d: %v", markerID, err)
-		http.Error(w, "Error fetching spectrum", http.StatusInternalServerError)
-		return
-	}
-
-	if spectrum == nil {
-		http.Error(w, "No spectrum found for this marker", http.StatusNotFound)
-		return
-	}
-
-	switch strings.ToLower(format) {
-	case "json":
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.json", markerID))
-		json.NewEncoder(w).Encode(spectrum)
-
-	case "csv":
-		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.csv", markerID))
-		// Write CSV: energy, counts
-		fmt.Fprintf(w, "Channel,Energy_keV,Counts\n")
-		for i, count := range spectrum.Channels {
-			energy := 0.0
-			if spectrum.Calibration != nil {
-				ch := float64(i)
-				energy = spectrum.Calibration.A + spectrum.Calibration.B*ch + spectrum.Calibration.C*ch*ch
-			}
-			fmt.Fprintf(w, "%d,%.2f,%d\n", i, energy, count)
-		}
-
-	case "n42":
-		if len(spectrum.RawData) > 0 && spectrum.SourceFormat == "n42" {
-			// Return original N42 file if available
-			w.Header().Set("Content-Type", "application/xml")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.n42", markerID))
-			w.Write(spectrum.RawData)
-		} else {
-			http.Error(w, "N42 format not available for this spectrum", http.StatusNotFound)
-		}
-
-	case "spe":
-		if len(spectrum.RawData) > 0 && spectrum.SourceFormat == "spe" {
-			// Return original SPE file if available
-			w.Header().Set("Content-Type", "text/plain")
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=spectrum_%d.spe", markerID))
-			w.Write(spectrum.RawData)
-		} else {
-			http.Error(w, "SPE format not available for this spectrum", http.StatusNotFound)
-		}
-
-	default:
-		http.Error(w, fmt.Sprintf("Unsupported format: %s", format), http.StatusBadRequest)
-	}
-}
-
-// trackInfoHandler returns lightweight upload metadata for a track.
-// GET /api/track-info/{trackID}
-func trackInfoHandler(w http.ResponseWriter, r *http.Request) {
-	if db == nil || db.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-	trackID := strings.TrimPrefix(r.URL.Path, "/api/track-info/")
-	if trackID == "" {
-		http.Error(w, "Missing track ID", http.StatusBadRequest)
-		return
-	}
-
-	ctx := r.Context()
-	var username, detector string
-	var recordingDate int64
-
-	var query string
-	switch *dbType {
-	case "pgx", "duckdb":
-		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
-		         COALESCE(EXTRACT(EPOCH FROM recording_date)::BIGINT, 0)
-		         FROM uploads WHERE track_id = $1 LIMIT 1`
-	default:
-		query = `SELECT COALESCE(username, ''), COALESCE(detector, ''),
-		         COALESCE(recording_date, 0)
-		         FROM uploads WHERE track_id = ? LIMIT 1`
-	}
-
-	err := db.DB.QueryRowContext(ctx, query, trackID).Scan(&username, &detector, &recordingDate)
-	if err != nil {
-		// No upload record found — return empty info rather than error
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Cache-Control", "public, max-age=3600")
-		w.Write([]byte(`{"trackID":"` + trackID + `"}`))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "public, max-age=3600")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"trackID":       trackID,
-		"username":      username,
-		"detector":      detector,
-		"recordingDate": recordingDate,
-	})
-}
-
-// markersWithSpectraHandler returns markers that have associated spectral data.
-// GET /api/markers/spectra?minLat=...&maxLat=...&minLon=...&maxLon=...
-func markersWithSpectraHandler(w http.ResponseWriter, r *http.Request) {
-	if db == nil || db.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	ctx, cancel := withMinimumDeadline(r.Context(), 30*time.Second)
-	defer cancel()
-
-	q := r.URL.Query()
-	minLat, _ := strconv.ParseFloat(q.Get("minLat"), 64)
-	minLon, _ := strconv.ParseFloat(q.Get("minLon"), 64)
-	maxLat, _ := strconv.ParseFloat(q.Get("maxLat"), 64)
-	maxLon, _ := strconv.ParseFloat(q.Get("maxLon"), 64)
-
-	// Validate bounds
-	if minLat == 0 && maxLat == 0 && minLon == 0 && maxLon == 0 {
-		// Default to world bounds
-		minLat, maxLat = -90, 90
-		minLon, maxLon = -180, 180
-	}
-
-	bounds := database.Bounds{
-		MinLat: minLat,
-		MaxLat: maxLat,
-		MinLon: minLon,
-		MaxLon: maxLon,
-	}
-
-	markers, err := db.GetMarkersWithSpectra(ctx, bounds)
-	if err != nil {
-		log.Printf("Error fetching markers with spectra: %v", err)
-		http.Error(w, "Error fetching markers", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(markers)
-}
-
-// updateCoordinatesHandler updates marker coordinates for spectrum files uploaded without GPS.
-// POST /api/update-coordinates
-// Body: {"trackID": "...", "lat": 34.488, "lon": 136.166}
-func updateCoordinatesHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	if db == nil || db.DB == nil {
-		http.Error(w, "Database not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	// Parse request body
-	var req struct {
-		TrackID string  `json:"trackID"`
-		Lat     float64 `json:"lat"`
-		Lon     float64 `json:"lon"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
-		return
-	}
-
-	// Validate inputs
-	if req.TrackID == "" {
-		http.Error(w, "trackID is required", http.StatusBadRequest)
-		return
-	}
-
-	if req.Lat < -90 || req.Lat > 90 {
-		http.Error(w, "Invalid latitude", http.StatusBadRequest)
-		return
-	}
-
-	if req.Lon < -180 || req.Lon > 180 {
-		http.Error(w, "Invalid longitude", http.StatusBadRequest)
-		return
-	}
-
-	ctx := r.Context()
-
-	// Update all markers with this trackID across all zoom levels
-	query := "UPDATE markers SET lat = ?, lon = ? WHERE trackID = ?"
-	args := []interface{}{req.Lat, req.Lon, req.TrackID}
-
-	if *dbType == "pgx" || *dbType == "duckdb" {
-		query = "UPDATE markers SET lat = $1, lon = $2 WHERE trackID = $3"
-	}
-
-	result, err := db.DB.ExecContext(ctx, query, args...)
-	if err != nil {
-		log.Printf("Error updating coordinates for track %s: %v", req.TrackID, err)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"status": "error",
-			"error":  "Failed to update coordinates",
-		})
-		return
-	}
-
-	rowsAffected, _ := result.RowsAffected()
-
-	log.Printf("Updated coordinates for track %s: %d markers updated to (%.6f, %.6f)",
-		req.TrackID, rowsAffected, req.Lat, req.Lon)
-
-	// Return success
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status":         "success",
-		"markersUpdated": rowsAffected,
-		"lat":            req.Lat,
-		"lon":            req.Lon,
-	})
-}
 
 // =====================
 // ADMIN API
@@ -7926,141 +7409,7 @@ func tracksHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Multi-track page rendered for: %s", trackIDsParam)
 }
 
-// apiTracksBoundsHandler returns combined bounds for multiple tracks
-// GET /api/tracks/bounds?trackIDs=track1,track2,track3
-func apiTracksBoundsHandler(w http.ResponseWriter, r *http.Request) {
-	trackIDsParam := r.URL.Query().Get("trackIDs")
-	if trackIDsParam == "" {
-		http.Error(w, "trackIDs parameter required", http.StatusBadRequest)
-		return
-	}
-
-	trackIDs := strings.Split(trackIDsParam, ",")
-	if len(trackIDs) == 0 {
-		http.Error(w, "No track IDs provided", http.StatusBadRequest)
-		return
-	}
-
-	ctx := r.Context()
-
-	// Calculate combined bounds
-	var minLat, minLon, maxLat, maxLon float64
-	first := true
-
-	for _, trackID := range trackIDs {
-		trackID = strings.TrimSpace(trackID)
-		if trackID == "" {
-			continue
-		}
-
-		// Query bounds for this track
-		var tMinLat, tMinLon, tMaxLat, tMaxLon sql.NullFloat64
-
-		var query string
-		if *dbType == "pgx" {
-			query = `SELECT MIN(lat) as min_lat, MIN(lon) as min_lon, MAX(lat) as max_lat, MAX(lon) as max_lon 
-			         FROM markers WHERE trackID = $1`
-		} else {
-			query = `SELECT MIN(lat) as min_lat, MIN(lon) as min_lon, MAX(lat) as max_lat, MAX(lon) as max_lon 
-			         FROM markers WHERE trackID = ?`
-		}
-
-		err := db.DB.QueryRowContext(ctx, query, trackID).Scan(&tMinLat, &tMinLon, &tMaxLat, &tMaxLon)
-		if err != nil {
-			log.Printf("Error querying bounds for track %s: %v", trackID, err)
-			continue
-		}
-
-		// Skip if track has no markers
-		if !tMinLat.Valid || !tMinLon.Valid || !tMaxLat.Valid || !tMaxLon.Valid {
-			continue
-		}
-
-		// Update combined bounds
-		if first {
-			minLat = tMinLat.Float64
-			minLon = tMinLon.Float64
-			maxLat = tMaxLat.Float64
-			maxLon = tMaxLon.Float64
-			first = false
-		} else {
-			if tMinLat.Float64 < minLat {
-				minLat = tMinLat.Float64
-			}
-			if tMinLon.Float64 < minLon {
-				minLon = tMinLon.Float64
-			}
-			if tMaxLat.Float64 > maxLat {
-				maxLat = tMaxLat.Float64
-			}
-			if tMaxLon.Float64 > maxLon {
-				maxLon = tMaxLon.Float64
-			}
-		}
-	}
-
-	if first {
-		// No valid tracks found
-		http.Error(w, "No valid tracks found", http.StatusNotFound)
-		return
-	}
-
-	// Return bounds as JSON
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status": "success",
-		"bounds": map[string]float64{
-			"minLat": minLat,
-			"minLon": minLon,
-			"maxLat": maxLat,
-			"maxLon": maxLon,
-		},
-		"trackIDs": trackIDs,
-	})
-}
-
-// qrPngHandler generates a QR code image for a given URL.
-func qrPngHandler(w http.ResponseWriter, r *http.Request) {
-	u := r.URL.Query().Get("u")
-	if u == "" {
-		if ref := r.Referer(); ref != "" {
-			u = ref
-		} else {
-			scheme := "http"
-			if r.TLS != nil {
-				scheme = "https"
-			}
-			u = scheme + "://" + r.Host + r.URL.RequestURI()
-		}
-	}
-	if len(u) > 4096 {
-		u = u[:4096]
-	}
-
-	w.Header().Set("Content-Type", "image/png")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Content-Disposition", "inline; filename=\"qr.png\"")
-
-	// (А) если логотип лежит в файле:
-	// logoBytes, _ := os.ReadFile("static/radiation.png")
-
-	// (Б) или без файла — пусть пакет нарисует знак сам:
-	var logoBytes []byte
-
-	opts := qrlogoext.Options{
-		TargetPx:    1500,
-		Fg:          color.RGBA{0, 0, 0, 255},       // чёрные модули
-		Bg:          color.RGBA{255, 255, 255, 255}, // БЕЛЫЙ фон
-		Logo:        color.RGBA{233, 192, 35, 255},  // ЖЕЛТЫЙ знак радиации
-		LogoBoxFrac: 0.32,                           // большой центральный квадрат
-		LogoPadding: 16,                             // отступ для картинки (если PNG вставляешь)
-	}
-
-	if err := qrlogoext.EncodePNG(w, []byte(u), logoBytes, opts); err != nil {
-		http.Error(w, "QR encode: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
+// apiTracksBoundsHandler, qrPngHandler moved to pkg/web
 
 // generateTileCacheKey creates a unique key for caching clustered markers based on request parameters
 // The key includes zoom level, bounding box, track ID, speed filters, and date filters
@@ -9114,77 +8463,7 @@ func realtimeHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// =====================
-// GZIP COMPRESSION
-// =====================
-
-// gzipResponseWriter wraps http.ResponseWriter to automatically gzip responses
-// when client supports it. Expected compression ratio: 3-5x (500 kB → 100-150 kB)
-type gzipResponseWriter struct {
-	http.ResponseWriter
-	gzipWriter *gzip.Writer
-	written    bool
-}
-
-// WriteHeader delegates to underlying writer (called by handler)
-func (g *gzipResponseWriter) WriteHeader(statusCode int) {
-	if !g.written {
-		g.ResponseWriter.WriteHeader(statusCode)
-		g.written = true
-	}
-}
-
-// Write intercepts writes to compress them with gzip
-func (g *gzipResponseWriter) Write(b []byte) (int, error) {
-	if !g.written {
-		g.WriteHeader(http.StatusOK)
-	}
-	return g.gzipWriter.Write(b)
-}
-
-// Flush flushes both the gzip writer and response writer if possible
-func (g *gzipResponseWriter) Flush() error {
-	if err := g.gzipWriter.Flush(); err != nil {
-		return err
-	}
-	if f, ok := g.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
-	return nil
-}
-
-// gzipHandler wraps a handler to apply gzip compression to responses
-// only when the client sends Accept-Encoding: gzip
-func gzipHandler(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Check if client accepts gzip encoding
-		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
-			next(w, r)
-			return
-		}
-
-		// Set gzip header BEFORE creating wrapper (before any writes)
-		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Add("Vary", "Accept-Encoding")
-
-		// Create gzip writer
-		gzipWriter := gzip.NewWriter(w)
-		defer gzipWriter.Close()
-
-		// Wrap response writer
-		wrappedWriter := &gzipResponseWriter{
-			ResponseWriter: w,
-			gzipWriter:     gzipWriter,
-			written:        false,
-		}
-
-		// Call original handler
-		next(wrappedWriter, r)
-
-		// Ensure gzip writer is flushed
-		_ = gzipWriter.Flush()
-	}
-}
+// Gzip compression for API responses is in pkg/web (Server.gzipWrap).
 
 // =====================
 // MAIN
@@ -9475,6 +8754,27 @@ func main() {
 	apiDocsArchiveRoute = route
 	apiDocsArchiveFrequency = archiveFrequency.HumanInterval()
 
+	// Web server: handlers moved to pkg/web to keep main focused on wiring.
+	webConfig := web.Config{
+		Domain:                 *domain,
+		Port:                   *port,
+		DefaultLat:             *defaultLat,
+		DefaultLon:             *defaultLon,
+		DefaultZoom:            *defaultZoom,
+		DefaultLayer:           *defaultLayer,
+		AutoLocateDefault:      *autoLocateDefault,
+		SupportEmail:           *supportEmail,
+		CompileVersion:         CompileVersion,
+		DBType:                 *dbType,
+		AdminPassword:          *adminPassword,
+		APIDocsArchiveEnabled:  apiDocsArchiveEnabled,
+		APIDocsArchiveRoute:    apiDocsArchiveRoute,
+		APIDocsArchiveFrequency: apiDocsArchiveFrequency,
+		DebugIPAllowlist:       debugIPAllowlist,
+	}
+	webServer := web.NewServer(db, content, webConfig, log.Printf)
+	webServer.Register(http.DefaultServeMux)
+
 	// 4. Маршруты и статика
 	staticFS, err := fs.Sub(content, "public_html")
 	if err != nil {
@@ -9493,9 +8793,6 @@ func main() {
 	
 	http.HandleFunc("/home", homeHandler)
 	http.HandleFunc("/", mapHandler)
-	// Serve license documents straight from the embedded filesystem so UI
-	// modals can reuse the same source without relying on external storage.
-	http.HandleFunc("/licenses/", licenseHandler)
 
 	// Register authentication routes if auth system is enabled
 	if authManager != nil {
@@ -9695,15 +8992,7 @@ func main() {
 	http.HandleFunc("/realtime_history", realtimeHistoryHandler)
 	http.HandleFunc("/trackid/", trackHandler)
 	http.HandleFunc("/tracks/", tracksHandler)
-	http.HandleFunc("/qrpng", qrPngHandler)
-	http.HandleFunc("/api/geoip", gzipHandler(geoIPHandler))
-	http.HandleFunc("/s/", shortRedirectHandler)
-	http.HandleFunc("/api/docs", apiDocsHandler)
-	http.HandleFunc("/api/spectrum/", spectrumHandler)                                 // GET /api/spectrum/{markerID} and /api/spectrum/{markerID}/download
-	http.HandleFunc("/api/markers/spectra", markersWithSpectraHandler)                 // GET /api/markers/spectra
-	http.HandleFunc("/api/tracks/bounds", apiTracksBoundsHandler)                      // GET /api/tracks/bounds?trackIDs=...
-	http.HandleFunc("/api/track-info/", trackInfoHandler)                              // GET /api/track-info/{trackID}
-	http.HandleFunc("/api/update-coordinates", updateCoordinatesHandler)               // POST /api/update-coordinates
+	// api/docs, licenses/, api/geoip, s/, api/spectrum/, api/markers/spectra, api/tracks/bounds, api/track-info/, api/update-coordinates, qrpng — registered via webServer.Register above
 	// Admin endpoints - wrap with OptionalAuth to allow session-based admin auth
 	if authManager != nil {
 		http.HandleFunc("/api/admin/uploads", authManager.OptionalAuth(adminUploadsHandler))


### PR DESCRIPTION

## At a high level, what changes were made?

relatively easy to transfer HTTP handlers were moved from `safecast-new-map.go` into `pkg/web/`.

## Why were these changes made?

To separate HTTP handling from the main package, make handlers easier to test, and keep `main` focused on wiring and startup.

## How were these changes made?

- Handler logic was moved out of main and into pkg/web, where it is organized by feature. 
- A new Server struct was introduced to act as a dependency container, holding the database, content files, and configuration. 
- Handlers are grouped into separate files by feature (handlers_qr.go, handlers_markers.go, handlers_geo.go, handlers_docs.go, handlers_bounds.go, handlers_short.go, handlers_spectrum.go, and handlers_trackinfo.go) to improve readability and maintainability. 
- A shared context.go adds WithMinimumDeadline, which ensures HTTP requests have a minimum execution deadline for longer-running tasks. 
- All transferred HTTP handlers are now methods on *Server, eliminating global state and making dependencies explicit. NewServer constructs the server, and Register attaches all routes to a provided http.ServeMux, so main is now responsible only for wiring dependencies and starting the application. 
- A single handlers_test.go file contains tests for all handlers, and because dependencies are injected through Server, test doubles can be substituted to support unit or integration testing.

## What context, visual (i.e. screenshots) or otherwise, do reviewers need to understand or use this feature?

Reviewers can run `go test ./pkg/web` to run the tests.

## How Was the Code Tested?

Unit tests live in `pkg/web/handlers_test.go`. A `newTestServer(t)` helper builds a `Server` with a temp SQLite DB and `fstest.MapFS` for content. `seedTestDB` inserts mock data (tracks, markers with spectra, short links, uploads). Tests use `httptest.NewRequest` and `httptest.NewRecorder` to call handlers and assert status codes, headers, and JSON. Coverage includes: QR (URL source, truncation), markers (bounds, DB nil), `updateCoordinates` (validation, success), geoIP (config and method checks), `requestClientIP` (X-Forwarded-For, RemoteAddr), docs (placeholders, licenses), bounds (trackIDs, 404), short redirects, spectrum (JSON/CSV/N42/SPE), and track info. GeoIP tests avoid network by only exercising paths where `AutoLocateDefault` is false or the IP is empty.

- All HTTP tests are located in pkg/web/handlers_test.go, keeping web-layer testing centralized and easy to navigate. 
- A helper function, newTestServer(t), constructs a fully functional Server instance for tests using a temporary in-memory SQLite database to avoid touching real data and fstest.
- MapFS to simulate static files such as documentation and licenses. 
- seedTestDB, inserts predictable test data including tracks, markers (with linked spectra), short links, and upload metadata so each test runs against a known state. 
- Tests create requests with httptest.NewRequest, capture responses with httptest.
- NewRecorder, invoke handlers directly, and assert expected status codes, headers, and JSON or body output. 

Coverage includes QR generation (URL source selection and truncation), marker queries (bounds handling and nil DB behavior), updateCoordinates validation and success paths, GeoIP configuration and method checks without making network calls, requestClientIP header and fallback parsing, documentation and license rendering (including placeholder replacement and content types), track bounds validation and 404 handling, short-link redirects, spectrum output in JSON/CSV/N42/SPE formats, and track info responses. 

## Other Notes, Context, or Anything that Remains to be Addressed
- Tests use a temp SQLite file instead of `:memory:` so all connections share the same DB. 
- The spectrum handler returns 500 (not 404) when a marker is missing because `GetSpectrum` returns an error. 
- GeoIP tests do not cover the real ipapi.co lookup; adding that would require injecting a lookup function or HTTP client. 
- None of the testing infrastucture uses real data, and there is a lack of low-level unit tests.