### PR TITLE
feat: log chat questions to DuckDB analytics

### DIFF
--- a/cmd/unified-server/chat_logging.go
+++ b/cmd/unified-server/chat_logging.go
@@ -1,0 +1,120 @@
+// Chat question logging to DuckDB analytics
+// Captures user questions from the web-chat and map widget with request metadata
+
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// logChatQuestion logs a user's chat question to DuckDB asynchronously.
+func logChatQuestion(r *http.Request, question, source, model, sessionID string, historyLen int) {
+	if !duckDBAvailable() {
+		return
+	}
+
+	if len(question) > 5000 {
+		question = question[:5000]
+	}
+
+	ip := getClientIP(r)
+	ua := r.Header.Get("User-Agent")
+	isMobile, osName, browser := parseUserAgent(ua)
+	country := r.Header.Get("CloudFront-Viewer-Country")
+	acceptLang := r.Header.Get("Accept-Language")
+	if len(acceptLang) > 200 {
+		acceptLang = acceptLang[:200]
+	}
+	referer := r.Header.Get("Referer")
+	isCloudFront := r.Header.Get("CloudFront-Viewer-Country") != "" ||
+		r.Header.Get("CloudFront-Forwarded-Proto") != "" ||
+		r.Header.Get("X-Amz-Cf-Id") != ""
+
+	go func() {
+		_, err := duckDB.Exec(`
+			INSERT INTO chat_questions (
+				question, source, ip_address, user_agent, is_mobile,
+				os, browser, country, accept_language, referer,
+				session_id, history_length, model, cloudfront
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			question, source, ip, ua, isMobile,
+			osName, browser, country, acceptLang, referer,
+			sessionID, historyLen, model, isCloudFront,
+		)
+		if err != nil {
+			log.Printf("chat_questions insert error: %v", err)
+		}
+	}()
+}
+
+// getClientIP extracts the client IP from the request, respecting proxy headers.
+func getClientIP(r *http.Request) string {
+	// X-Forwarded-For may contain multiple IPs: client, proxy1, proxy2
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.SplitN(xff, ",", 2)
+		ip := strings.TrimSpace(parts[0])
+		if ip != "" {
+			return ip
+		}
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// parseUserAgent extracts mobile/desktop, OS, and browser from User-Agent string.
+func parseUserAgent(ua string) (isMobile bool, osName, browser string) {
+	lower := strings.ToLower(ua)
+
+	// Mobile detection
+	isMobile = strings.Contains(lower, "mobile") ||
+		strings.Contains(lower, "android") && !strings.Contains(lower, "tablet") ||
+		strings.Contains(lower, "iphone") ||
+		strings.Contains(lower, "ipod")
+
+	// OS detection
+	switch {
+	case strings.Contains(lower, "iphone") || strings.Contains(lower, "ipad") || strings.Contains(lower, "ipod"):
+		osName = "iOS"
+	case strings.Contains(lower, "android"):
+		osName = "Android"
+	case strings.Contains(lower, "windows"):
+		osName = "Windows"
+	case strings.Contains(lower, "macintosh") || strings.Contains(lower, "mac os"):
+		osName = "macOS"
+	case strings.Contains(lower, "linux"):
+		osName = "Linux"
+	case strings.Contains(lower, "cros"):
+		osName = "ChromeOS"
+	default:
+		osName = "Unknown"
+	}
+
+	// Browser detection (order matters — check specific before generic)
+	switch {
+	case strings.Contains(lower, "edg/") || strings.Contains(lower, "edge/"):
+		browser = "Edge"
+	case strings.Contains(lower, "opr/") || strings.Contains(lower, "opera"):
+		browser = "Opera"
+	case strings.Contains(lower, "firefox/"):
+		browser = "Firefox"
+	case strings.Contains(lower, "chrome/") && !strings.Contains(lower, "chromium"):
+		browser = "Chrome"
+	case strings.Contains(lower, "safari/") && !strings.Contains(lower, "chrome"):
+		browser = "Safari"
+	case strings.Contains(lower, "chromium"):
+		browser = "Chromium"
+	default:
+		browser = "Unknown"
+	}
+
+	return
+}

--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -113,6 +113,26 @@ func createDuckDBSchema() error {
 			commit_hash VARCHAR,
 			error VARCHAR
 		);
+
+		CREATE SEQUENCE IF NOT EXISTS seq_chat_questions START 1;
+		CREATE TABLE IF NOT EXISTS chat_questions (
+			id BIGINT DEFAULT nextval('seq_chat_questions'),
+			timestamp TIMESTAMPTZ DEFAULT now(),
+			question VARCHAR,
+			source VARCHAR,
+			ip_address VARCHAR,
+			user_agent VARCHAR,
+			is_mobile BOOLEAN,
+			os VARCHAR,
+			browser VARCHAR,
+			country VARCHAR,
+			accept_language VARCHAR,
+			referer VARCHAR,
+			session_id VARCHAR,
+			history_length INTEGER,
+			model VARCHAR,
+			cloudfront BOOLEAN
+		);
 	`
 
 	if _, err := duckDB.Exec(createSchemaQuery); err != nil {
@@ -125,6 +145,8 @@ func createDuckDBSchema() error {
 		"CREATE INDEX IF NOT EXISTS idx_query_log_timestamp ON mcp_query_log(timestamp);",
 		"CREATE INDEX IF NOT EXISTS idx_ai_log_tool ON mcp_ai_query_log(tool_name);",
 		"CREATE INDEX IF NOT EXISTS idx_ai_log_timestamp ON mcp_ai_query_log(timestamp);",
+		"CREATE INDEX IF NOT EXISTS idx_chat_q_timestamp ON chat_questions(timestamp);",
+		"CREATE INDEX IF NOT EXISTS idx_chat_q_source ON chat_questions(source);",
 	}
 
 	for _, idx := range indexes {

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -188,6 +188,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		var chatReq struct {
 			Message string              `json:"message"`
 			History []anthropicMessage `json:"history,omitempty"`
+			Source  string              `json:"source,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&chatReq); err != nil || chatReq.Message == "" {
 			w.WriteHeader(http.StatusBadRequest)
@@ -197,6 +198,13 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 			}
 			return
 		}
+
+		// Default source if not provided by frontend
+		source := chatReq.Source
+		if source == "" {
+			source = "web-chat"
+		}
+		logChatQuestion(r, chatReq.Message, source, model, "", len(chatReq.History))
 
 		mc, err := mcpclient.NewStreamableHttpClient(mcpURL)
 		if err != nil {

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10423,7 +10423,8 @@ function selectHomeSearchResult(result, query) {
           body: JSON.stringify({
             message: text,
             history: chatHistory,
-            map_context: getMapContext()
+            map_context: getMapContext(),
+            source: 'widget'
           }),
         }).then(response => {
           const reader = response.body.getReader();

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -573,7 +573,8 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         message: text,
-        history: conversationHistory
+        history: conversationHistory,
+        source: 'web-chat'
       }),
     }).then(response => {
       const reader  = response.body.getReader();

--- a/cmd/unified-server/tool_duckdb_logs.go
+++ b/cmd/unified-server/tool_duckdb_logs.go
@@ -11,7 +11,7 @@ import (
 var queryDuckDBLogsToolDef = mcp.NewTool(
 	"query_duckdb_logs",
 	mcp.WithDescription(
-		"Query MCP AI logs stored in DuckDB. Supports simple SQL SELECT queries.",
+		"Query MCP AI logs stored in DuckDB. Supports simple SQL SELECT queries. Available tables: mcp_ai_query_log (tool execution logs), mcp_query_log (tool usage stats), chat_questions (user questions from web-chat and map widget with metadata: timestamp, question, source, ip_address, user_agent, is_mobile, os, browser, country, accept_language, referer, session_id, history_length, model, cloudfront).",
 	),
 	mcp.WithString(
 		"query",


### PR DESCRIPTION
## Summary
- Adds `chat_questions` table to `analytics.duckdb` capturing every question from the web-chat and map widget
- Logs rich metadata: IP, User-Agent (parsed for mobile/OS/browser), CloudFront country, Accept-Language, referer, history length, model
- Async logging via goroutine — never blocks chat responses
- Frontend sends `source` field to distinguish widget vs web-chat origin

## Files Changed
- **New:** `cmd/unified-server/chat_logging.go` — logging logic, UA parser, IP extraction
- `cmd/unified-server/duckdb_analytics.go` — new table schema + indexes
- `cmd/unified-server/mcp_register.go` — hook logging into `/chat` handler
- `cmd/unified-server/public_html/map.html` — widget sends `source: 'widget'`
- `cmd/unified-server/static/index.html` — assistant sends `source: 'web-chat'`
- `cmd/unified-server/tool_duckdb_logs.go` — updated tool description

## Test plan
- [x] Verified locally: sent test chat via curl, confirmed row in `chat_questions` table
- [ ] Deploy to production and verify widget + assistant questions are logged
- [ ] Verify CloudFront country header populates in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)