### PR TITLE
fix: route widget chat to unified server for logging

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10436,7 +10436,7 @@ function selectHomeSearchResult(result, query) {
           }
         }
 
-        fetch('https://assistant.safecast.org/chat', {
+        fetch('/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Changes widget fetch URL from `https://assistant.safecast.org/chat` (standalone web-chat on port 3334, no DuckDB logging) to relative `/chat` (unified server on port 3333, has logging)
- This ensures widget questions are captured in `analytics.duckdb`
- Using relative URL avoids CloudFront caching/CORS complications

## Test plan
- [ ] Deploy and submit a question via the map widget
- [ ] Verify the question appears in `chat_questions` table via `query_duckdb_logs` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)