### PR TITLE
feat: log AI answers in chat_questions table

### DIFF
--- a/cmd/unified-server/chat_logging.go
+++ b/cmd/unified-server/chat_logging.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 )
 
-// logChatQuestion logs a user's chat question to DuckDB asynchronously.
-func logChatQuestion(r *http.Request, question, source, model, sessionID string, historyLen int, clientTimestamp string) {
+// logChatQuestion logs a user's chat question to DuckDB and returns the row ID.
+// The returned ID can be passed to logChatAnswer to attach the AI response.
+func logChatQuestion(r *http.Request, question, source, model, sessionID string, historyLen int, clientTimestamp string) int64 {
 	if !duckDBAvailable() {
-		return
+		return 0
 	}
 
 	if len(question) > 5000 {
@@ -39,19 +40,37 @@ func logChatQuestion(r *http.Request, question, source, model, sessionID string,
 		clientTS = clientTimestamp
 	}
 
+	var id int64
+	err := duckDB.QueryRow(`
+		INSERT INTO chat_questions (
+			question, source, ip_address, user_agent, is_mobile,
+			os, browser, country, accept_language, referer,
+			session_id, history_length, model, cloudfront, client_timestamp
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id`,
+		question, source, ip, ua, isMobile,
+		osName, browser, country, acceptLang, referer,
+		sessionID, historyLen, model, isCloudFront, clientTS,
+	).Scan(&id)
+	if err != nil {
+		log.Printf("chat_questions insert error: %v", err)
+		return 0
+	}
+	return id
+}
+
+// logChatAnswer updates a chat_questions row with the AI's response (async).
+func logChatAnswer(rowID int64, answer string) {
+	if !duckDBAvailable() || rowID == 0 {
+		return
+	}
+	if len(answer) > 50000 {
+		answer = answer[:50000]
+	}
 	go func() {
-		_, err := duckDB.Exec(`
-			INSERT INTO chat_questions (
-				question, source, ip_address, user_agent, is_mobile,
-				os, browser, country, accept_language, referer,
-				session_id, history_length, model, cloudfront, client_timestamp
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			question, source, ip, ua, isMobile,
-			osName, browser, country, acceptLang, referer,
-			sessionID, historyLen, model, isCloudFront, clientTS,
-		)
+		_, err := duckDB.Exec(`UPDATE chat_questions SET answer = ? WHERE id = ?`, answer, rowID)
 		if err != nil {
-			log.Printf("chat_questions insert error: %v", err)
+			log.Printf("chat_questions answer update error: %v", err)
 		}
 	}()
 }

--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -132,7 +132,8 @@ func createDuckDBSchema() error {
 			history_length INTEGER,
 			model VARCHAR,
 			cloudfront BOOLEAN,
-			client_timestamp TIMESTAMPTZ
+			client_timestamp TIMESTAMPTZ,
+			answer VARCHAR
 		);
 	`
 
@@ -140,8 +141,9 @@ func createDuckDBSchema() error {
 		return fmt.Errorf("create schema: %w", err)
 	}
 
-	// Migrate: add client_timestamp column if table already exists without it
+	// Migrate: add columns if table already exists without them
 	duckDB.Exec("ALTER TABLE chat_questions ADD COLUMN IF NOT EXISTS client_timestamp TIMESTAMPTZ;")
+	duckDB.Exec("ALTER TABLE chat_questions ADD COLUMN IF NOT EXISTS answer VARCHAR;")
 
 	// Create indexes for common queries
 	indexes := []string{

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
@@ -205,7 +206,8 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		if source == "" {
 			source = "web-chat"
 		}
-		logChatQuestion(r, chatReq.Message, source, model, "", len(chatReq.History), chatReq.ClientTimestamp)
+		chatRowID := logChatQuestion(r, chatReq.Message, source, model, "", len(chatReq.History), chatReq.ClientTimestamp)
+		var answerText strings.Builder
 
 		mc, err := mcpclient.NewStreamableHttpClient(mcpURL)
 		if err != nil {
@@ -265,6 +267,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 			for _, block := range resp.Content {
 				switch block.Type {
 				case "text":
+					answerText.WriteString(block.Text)
 					writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
 				case "tool_use":
 					toolUses = append(toolUses, block)
@@ -308,6 +311,8 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 				Content: toolResults,
 			})
 		}
+
+		logChatAnswer(chatRowID, strings.TrimSpace(answerText.String()))
 
 		writeChunkBuffered(w, chunk{Type: "done"}, &buffer, isCloudFront)
 		if isCloudFront {

--- a/cmd/unified-server/tool_duckdb_logs.go
+++ b/cmd/unified-server/tool_duckdb_logs.go
@@ -11,7 +11,7 @@ import (
 var queryDuckDBLogsToolDef = mcp.NewTool(
 	"query_duckdb_logs",
 	mcp.WithDescription(
-		"Query MCP AI logs stored in DuckDB. Supports simple SQL SELECT queries. Available tables: mcp_ai_query_log (tool execution logs), mcp_query_log (tool usage stats), chat_questions (user questions from web-chat and map widget with metadata: timestamp, question, source, ip_address, user_agent, is_mobile, os, browser, country, accept_language, referer, session_id, history_length, model, cloudfront).",
+		"Query MCP AI logs stored in DuckDB. Supports simple SQL SELECT queries. Available tables: mcp_ai_query_log (tool execution logs), mcp_query_log (tool usage stats), chat_questions (user questions and AI answers from web-chat and map widget with metadata: timestamp, question, answer, source, ip_address, user_agent, is_mobile, os, browser, country, accept_language, referer, session_id, history_length, model, cloudfront).",
 	),
 	mcp.WithString(
 		"query",


### PR DESCRIPTION
## Summary
- Adds `answer` column to `chat_questions` DuckDB table
- Captures the full AI response text alongside the user's question
- Question INSERT is now synchronous (returns row ID via `RETURNING`), answer UPDATE is async
- Answer text truncated at 50K chars

## Test plan
- [ ] Deploy and ask a question via the widget
- [ ] Query `chat_questions` and verify both `question` and `answer` columns are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)