### PR TITLE
fix: update docs for DuckLake migration + remove hardcoded password

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The unified server includes an MCP (Model Context Protocol) server with a Claude
 # Basic build (PostgreSQL only)
 go build -o safecast-new-map ./cmd/unified-server
 
-# With DuckDB analytics (requires CGO)
+# With DuckDB analytics via DuckLake (requires CGO)
 CGO_ENABLED=1 go build -tags duckdb -o safecast-new-map ./cmd/unified-server
 ```
 
@@ -223,9 +223,10 @@ CGO_ENABLED=1 go build -tags duckdb -o safecast-new-map ./cmd/unified-server
 # Map server with MCP (PostgreSQL required)
 DATABASE_URL="postgres://user:pass@localhost/db" ./safecast-new-map
 
-# With DuckDB analytics
+# With DuckLake analytics (in-memory DuckDB + PostgreSQL catalog + Parquet data)
 DATABASE_URL="postgres://..." \
-DUCKDB_PATH="./analytics.duckdb" \
+DUCKLAKE_PG_URL="dbname=ducklake_catalog host=localhost user=ducklake_rw" \
+DUCKLAKE_DATA_PATH="/var/lib/safecast/ducklake/" \
 ./safecast-new-map
 
 # With AI web chat (requires Anthropic API key)
@@ -562,7 +563,7 @@ For deploying to production servers with CloudFront/CDN setup, see:
 
 ## Performance Notes
 
-**DuckDB Performance:** For large imports, see [doc/DUCKDB_PERFORMANCE.md](doc/DUCKDB_PERFORMANCE.md) for checkpoint and Parquet optimization.
+**Analytics:** The platform uses DuckLake for analytics (in-memory DuckDB with a PostgreSQL catalog and Parquet data files), allowing multiple services to share analytics tables concurrently. Set `DUCKLAKE_PG_URL` and `DUCKLAKE_DATA_PATH` environment variables to configure.
 
 **PostgreSQL Tuning:** Use connection pooling and appropriate `work_mem` settings for large batch imports.
 

--- a/cmd/mcp-server/duckdb_client.go
+++ b/cmd/mcp-server/duckdb_client.go
@@ -44,7 +44,7 @@ func initDuckDB() error {
 	// Attach DuckLake catalog via PostgreSQL
 	ducklakePGURL := os.Getenv("DUCKLAKE_PG_URL")
 	if ducklakePGURL == "" {
-		ducklakePGURL = "dbname=ducklake_catalog host=localhost user=postgres password=LvjxpY1xNTijMT"
+		ducklakePGURL = "dbname=ducklake_catalog host=localhost user=ducklake_rw"
 	}
 	dataPath := os.Getenv("DUCKLAKE_DATA_PATH")
 	if dataPath == "" {

--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -48,7 +48,7 @@ func initDuckDBAnalytics() error {
 	// Attach DuckLake catalog via PostgreSQL
 	ducklakePGURL := os.Getenv("DUCKLAKE_PG_URL")
 	if ducklakePGURL == "" {
-		ducklakePGURL = "dbname=ducklake_catalog host=localhost user=postgres password=LvjxpY1xNTijMT"
+		ducklakePGURL = "dbname=ducklake_catalog host=localhost user=ducklake_rw"
 	}
 	dataPath := os.Getenv("DUCKLAKE_DATA_PATH")
 	if dataPath == "" {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -125,6 +125,8 @@ aws cloudfront create-invalidation --distribution-id E12FYIQ8RRXOJ1 --paths "/*"
 | `AWS_ACCESS_KEY_ID` | CloudFront cache invalidation |
 | `AWS_SECRET_ACCESS_KEY` | CloudFront cache invalidation |
 | `DATABASE_URL` | Postgres connection string for MCP server |
+| `DUCKLAKE_PG_URL` | DuckLake PostgreSQL catalog connection (e.g., `dbname=ducklake_catalog host=localhost user=ducklake_rw`) |
+| `DUCKLAKE_DATA_PATH` | Path for DuckLake Parquet data files (e.g., `/var/lib/safecast/ducklake/`) |
 | `ANTHROPIC_API_KEY` | Claude API key for web-chat service |
 
 ### Workflow Steps
@@ -173,6 +175,16 @@ AWS WAF protects against:
 - ~~Large request bodies~~ (Changed to "Count" mode for file uploads)
 
 **Important:** `SizeRestrictions_BODY` rule is in "Count" mode to allow large file uploads. See [docs/cloudfront-fix-waf-403.md](cloudfront-fix-waf-403.md) for details.
+
+## Analytics (DuckLake)
+
+Both the unified server and MCP server use DuckLake for analytics (tool usage logs, chat questions). Architecture: in-memory DuckDB attaches a shared DuckLake catalog backed by PostgreSQL + Parquet files, allowing concurrent access from multiple services.
+
+**Required env vars** (set in `.env` files or systemd service):
+- `DUCKLAKE_PG_URL` — PostgreSQL connection for DuckLake catalog (e.g., `dbname=ducklake_catalog host=localhost user=ducklake_rw`)
+- `DUCKLAKE_DATA_PATH` — Directory for Parquet data files (e.g., `/var/lib/safecast/ducklake/`)
+
+**Shared tables:** `chat_questions`, `mcp_query_log`, `mcp_ai_query_log`
 
 ## Server Configuration
 

--- a/docs/Mermaid Chart - Create complex, visual diagrams with text.-2026-02-28-043816.mmd
+++ b/docs/Mermaid Chart - Create complex, visual diagrams with text.-2026-02-28-043816.mmd
@@ -16,7 +16,7 @@ flowchart TB
  subgraph MCP["MCP Server — cmd/mcp-server (port 3333)"]
         MCPTools["16 MCP Tools\n(radiation, sensors, tracks, spectra)"]
         REST_MCP["REST API + Swagger\n/api/radiation /api/sensors /docs/"]
-        DuckDB["DuckDB\n(tool usage analytics)"]
+        DuckLake["DuckLake\n(analytics: PG catalog + Parquet)"]
   end
  subgraph MapServer["Map Server — safecast-new-map.go (port 8765)"]
         MapUI["Interactive Map UI\n(map tiles, markers, spectrum viewer)"]
@@ -47,7 +47,7 @@ flowchart TB
  subgraph CICD["⚙️ GitHub Actions (CI/CD)"]
         GH_All["safecast-new-map (monorepo)\n→ builds all 3 binaries + deploys"]
   end
-    MCPTools --> DuckDB
+    MCPTools --> DuckLake
     MCPTools -- primary: localhost queries --> DB
     MapServer --> DB
     Fetcher -- "auto-sync approved imports" --> DB


### PR DESCRIPTION
## Summary
- Update README.md, Mermaid architecture diagram, and DEPLOYMENT.md to reflect the DuckLake migration (replacing old `DUCKDB_PATH`/`analytics.duckdb` references with `DUCKLAKE_PG_URL` and `DUCKLAKE_DATA_PATH`)
- Remove hardcoded postgres password from DuckLake fallback defaults in both `cmd/unified-server/duckdb_analytics.go` and `cmd/mcp-server/duckdb_client.go` (fixes GitGuardian alert from PR #19)
- Add DuckLake analytics section to DEPLOYMENT.md

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Confirm server starts with `DUCKLAKE_PG_URL` env var set (password now required via env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)