### PR TITLE
fix: update deploy workflow for DuckLake env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,11 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          DUCKLAKE_PG_URL: ${{ secrets.DUCKLAKE_PG_URL }}
+          DUCKLAKE_DATA_PATH: ${{ secrets.DUCKLAKE_DATA_PATH }}
         run: |
           ssh -i ~/.ssh/deploy_key root@65.108.24.131 \
-            "printf 'DATABASE_URL=${DATABASE_URL}\nDUCKDB_PATH=/root/safecast-mcp-server/analytics.duckdb\nMCP_HINTS_DIR=/root/safecast-mcp-server/hints\nANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\nCLAUDE_MODEL=claude-sonnet-4-5\nMCP_BASE_URL=https://simplemap.safecast.org/mcp\n' > /root/safecast-mcp-server/.env"
+            "printf 'DATABASE_URL=${DATABASE_URL}\nDUCKLAKE_PG_URL=${DUCKLAKE_PG_URL}\nDUCKLAKE_DATA_PATH=${DUCKLAKE_DATA_PATH}\nMCP_HINTS_DIR=/root/safecast-mcp-server/hints\nANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\nCLAUDE_MODEL=claude-sonnet-4-5\nMCP_BASE_URL=https://simplemap.safecast.org/mcp\n' > /root/safecast-mcp-server/.env"
 
       - name: Restart service with new config
         run: |


### PR DESCRIPTION
## Summary
- Replace `DUCKDB_PATH` with `DUCKLAKE_PG_URL` and `DUCKLAKE_DATA_PATH` in deploy workflow `.env` generation
- Added corresponding GitHub secrets: `DUCKLAKE_PG_URL`, `DUCKLAKE_DATA_PATH`

## Test plan
- [ ] Next deploy writes correct `.env` with DuckLake vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)