### PR TITLE
feat: MCP Analytics admin page with tabbed navigation

### DIFF
--- a/cmd/unified-server/admin_mcp.go
+++ b/cmd/unified-server/admin_mcp.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// adminMCPDataHandler returns JSON data for MCP analytics tables.
+// GET /api/admin/mcp/data?table=chat_questions&limit=50&offset=0&sort=timestamp&order=desc&search=...
+func adminMCPDataHandler(w http.ResponseWriter, r *http.Request) {
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	tableName := r.URL.Query().Get("table")
+	columns, ok := mcpTableColumns[tableName]
+	if !ok {
+		http.Error(w, "Invalid table name", http.StatusBadRequest)
+		return
+	}
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 || limit > 1000 {
+		limit = 50
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	sortCol := r.URL.Query().Get("sort")
+	if !isValidColumn(sortCol, columns) {
+		sortCol = "timestamp"
+	}
+	order := strings.ToUpper(r.URL.Query().Get("order"))
+	if order != "ASC" {
+		order = "DESC"
+	}
+
+	search := r.URL.Query().Get("search")
+
+	// Build WHERE clause for search
+	var whereClauses []string
+	if search != "" {
+		for _, col := range columns {
+			whereClauses = append(whereClauses, fmt.Sprintf("CAST(%s AS VARCHAR) ILIKE '%%%s%%'", col, escapeLike(search)))
+		}
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " OR ")
+	}
+
+	// Count total
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", tableName, whereSQL)
+	var total int
+	if err := duckDB.QueryRow(countQuery).Scan(&total); err != nil {
+		log.Printf("admin mcp count error (table=%s): %v", tableName, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": fmt.Sprintf("DuckDB query failed: %v", err),
+			"data":  []interface{}{},
+			"total": 0,
+		})
+		return
+	}
+
+	// Fetch data — use LEFT() to work around DuckLake Go driver bug where large
+	// inlined VARCHAR values are truncated to a single byte on read.
+	// LEFT(col, 100000) forces DuckDB to materialize a new string that the driver reads correctly.
+	longTextCols := map[string]bool{"question": true, "answer": true, "generated_query": true, "user_agent": true}
+	castCols := make([]string, len(columns))
+	for i, col := range columns {
+		if longTextCols[col] {
+			castCols[i] = fmt.Sprintf("LEFT(%s, 100000) AS %s", col, col)
+		} else {
+			castCols[i] = col
+		}
+	}
+	colList := strings.Join(castCols, ", ")
+	dataQuery := fmt.Sprintf("SELECT %s FROM %s %s ORDER BY %s %s LIMIT %d OFFSET %d",
+		colList, tableName, whereSQL, sortCol, order, limit, offset)
+
+	rows, err := duckDB.Query(dataQuery)
+	if err != nil {
+		log.Printf("admin mcp query error: %v", err)
+		http.Error(w, "Query failed", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	var results []map[string]interface{}
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		ptrs := make([]interface{}, len(columns))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			log.Printf("admin mcp scan error: %v", err)
+			continue
+		}
+		row := make(map[string]interface{})
+		for i, col := range columns {
+			// DuckDB Go driver may return []byte for VARCHAR columns from DuckLake;
+			// convert to string so JSON encoding works correctly.
+			if b, ok := values[i].([]byte); ok {
+				row[col] = string(b)
+			} else {
+				row[col] = values[i]
+			}
+		}
+		results = append(results, row)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":    results,
+		"total":   total,
+		"limit":   limit,
+		"offset":  offset,
+		"columns": columns,
+	})
+}
+
+// adminMCPExportHandler exports MCP analytics data as CSV.
+// GET /api/admin/mcp/export?table=chat_questions&search=...
+func adminMCPExportHandler(w http.ResponseWriter, r *http.Request) {
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	tableName := r.URL.Query().Get("table")
+	columns, ok := mcpTableColumns[tableName]
+	if !ok {
+		http.Error(w, "Invalid table name", http.StatusBadRequest)
+		return
+	}
+
+	search := r.URL.Query().Get("search")
+
+	var whereClauses []string
+	if search != "" {
+		for _, col := range columns {
+			whereClauses = append(whereClauses, fmt.Sprintf("CAST(%s AS VARCHAR) ILIKE '%%%s%%'", col, escapeLike(search)))
+		}
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " OR ")
+	}
+
+	// Use LEFT() workaround for long text columns (same DuckLake driver bug as data handler)
+	exportLongTextCols := map[string]bool{"question": true, "answer": true, "generated_query": true, "user_agent": true}
+	exportCastCols := make([]string, len(columns))
+	for i, col := range columns {
+		if exportLongTextCols[col] {
+			exportCastCols[i] = fmt.Sprintf("LEFT(%s, 100000) AS %s", col, col)
+		} else {
+			exportCastCols[i] = col
+		}
+	}
+	colList := strings.Join(exportCastCols, ", ")
+	query := fmt.Sprintf("SELECT %s FROM %s %s ORDER BY timestamp DESC", colList, tableName, whereSQL)
+
+	rows, err := duckDB.Query(query)
+	if err != nil {
+		log.Printf("admin mcp export error: %v", err)
+		http.Error(w, "Query failed", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.csv", tableName))
+
+	writer := csv.NewWriter(w)
+	writer.Write(columns) // header row
+
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		ptrs := make([]interface{}, len(columns))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			continue
+		}
+		record := make([]string, len(columns))
+		for i, v := range values {
+			if v == nil {
+				record[i] = ""
+			} else if b, ok := v.([]byte); ok {
+				record[i] = string(b)
+			} else {
+				record[i] = fmt.Sprintf("%v", v)
+			}
+		}
+		writer.Write(record)
+	}
+	writer.Flush()
+}
+
+// mcpTableColumns defines the valid tables and their columns for the admin MCP page.
+var mcpTableColumns = map[string][]string{
+	"chat_questions": {
+		"id", "timestamp", "question", "answer", "source", "model",
+		"ip_address", "country", "is_mobile", "os", "browser",
+		"user_agent", "accept_language", "referer",
+		"session_id", "history_length", "cloudfront", "client_timestamp",
+	},
+	"mcp_query_log": {
+		"tool_name", "timestamp", "duration_ms", "result_count",
+		"client", "user_id", "user_email",
+	},
+	"mcp_ai_query_log": {
+		"user_id", "user_email", "session_id", "timestamp",
+		"tool_name", "generated_query", "duration_ms",
+		"commit_hash", "error",
+	},
+}
+
+func isValidColumn(col string, validCols []string) bool {
+	for _, c := range validCols {
+		if c == col {
+			return true
+		}
+	}
+	return false
+}
+
+// adminMCPDeleteHandler deletes rows from MCP analytics tables.
+// DELETE /api/admin/mcp/delete?table=chat_questions&ids=123,456,789
+// DELETE /api/admin/mcp/delete?table=chat_questions&all=true&search=...
+func adminMCPDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	tableName := r.URL.Query().Get("table")
+	columns, ok := mcpTableColumns[tableName]
+	if !ok {
+		http.Error(w, "Invalid table name", http.StatusBadRequest)
+		return
+	}
+
+	// Determine the ID/key column for each table
+	keyCol := mcpTableKeyColumn[tableName]
+
+	if r.URL.Query().Get("all") == "true" {
+		// Delete all (optionally filtered by search)
+		search := r.URL.Query().Get("search")
+		var whereClauses []string
+		if search != "" {
+			for _, col := range columns {
+				whereClauses = append(whereClauses, fmt.Sprintf("CAST(%s AS VARCHAR) ILIKE '%%%s%%'", col, escapeLike(search)))
+			}
+		}
+		whereSQL := ""
+		if len(whereClauses) > 0 {
+			whereSQL = "WHERE " + strings.Join(whereClauses, " OR ")
+		}
+
+		query := fmt.Sprintf("DELETE FROM %s %s", tableName, whereSQL)
+		result, err := duckDB.Exec(query)
+		if err != nil {
+			log.Printf("admin mcp delete all error: %v", err)
+			http.Error(w, "Delete failed", http.StatusInternalServerError)
+			return
+		}
+		affected, _ := result.RowsAffected()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"deleted": affected})
+		return
+	}
+
+	// Delete specific rows by key values
+	ids := r.URL.Query().Get("ids")
+	if ids == "" {
+		http.Error(w, "Missing ids parameter", http.StatusBadRequest)
+		return
+	}
+
+	idList := strings.Split(ids, ",")
+	placeholders := make([]string, len(idList))
+	for i := range idList {
+		placeholders[i] = "'" + escapeLike(strings.TrimSpace(idList[i])) + "'"
+	}
+
+	query := fmt.Sprintf("DELETE FROM %s WHERE CAST(%s AS VARCHAR) IN (%s)",
+		tableName, keyCol, strings.Join(placeholders, ","))
+	result, err := duckDB.Exec(query)
+	if err != nil {
+		log.Printf("admin mcp delete error: %v", err)
+		http.Error(w, "Delete failed", http.StatusInternalServerError)
+		return
+	}
+	affected, _ := result.RowsAffected()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"deleted": affected})
+}
+
+// mcpTableKeyColumn maps each table to its primary key / unique identifier column
+var mcpTableKeyColumn = map[string]string{
+	"chat_questions":   "id",
+	"mcp_query_log":    "timestamp",
+	"mcp_ai_query_log": "timestamp",
+}
+
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, "'", "''")
+	s = strings.ReplaceAll(s, "%", "")
+	s = strings.ReplaceAll(s, "_", "")
+	return s
+}

--- a/cmd/unified-server/chat_logging.go
+++ b/cmd/unified-server/chat_logging.go
@@ -61,20 +61,53 @@ func logChatQuestion(r *http.Request, question, source, model, sessionID string,
 	return id
 }
 
-// logChatAnswer updates a chat_questions row with the AI's response (async).
-func logChatAnswer(rowID int64, answer string) {
-	if !duckDBAvailable() || rowID == 0 {
+// logChatQuestionWithAnswer inserts a complete chat_questions row including the answer.
+// DuckLake UPDATE silently corrupts large string values, so we do a single INSERT with all fields.
+func logChatQuestionWithAnswer(r *http.Request, question, source, model, sessionID string, historyLen int, clientTimestamp string, answer string) {
+	if !duckDBAvailable() {
 		return
+	}
+
+	if len(question) > 5000 {
+		question = question[:5000]
 	}
 	if len(answer) > 50000 {
 		answer = answer[:50000]
 	}
-	go func() {
-		_, err := duckDB.Exec(`UPDATE chat_questions SET answer = ? WHERE id = ?`, answer, rowID)
-		if err != nil {
-			log.Printf("chat_questions answer update error: %v", err)
-		}
-	}()
+
+	ip := getClientIP(r)
+	ua := r.Header.Get("User-Agent")
+	isMobile, osName, browser := parseUserAgent(ua)
+	country := r.Header.Get("CloudFront-Viewer-Country")
+	acceptLang := r.Header.Get("Accept-Language")
+	if len(acceptLang) > 200 {
+		acceptLang = acceptLang[:200]
+	}
+	referer := r.Header.Get("Referer")
+	isCloudFront := r.Header.Get("CloudFront-Viewer-Country") != "" ||
+		r.Header.Get("CloudFront-Forwarded-Proto") != "" ||
+		r.Header.Get("X-Amz-Cf-Id") != ""
+
+	var clientTS interface{}
+	if clientTimestamp != "" {
+		clientTS = clientTimestamp
+	}
+
+	id := time.Now().UnixNano()
+
+	_, err := duckDB.Exec(`
+		INSERT INTO chat_questions (
+			id, question, answer, source, ip_address, user_agent, is_mobile,
+			os, browser, country, accept_language, referer,
+			session_id, history_length, model, cloudfront, client_timestamp
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, question, answer, source, ip, ua, isMobile,
+		osName, browser, country, acceptLang, referer,
+		sessionID, historyLen, model, isCloudFront, clientTS,
+	)
+	if err != nil {
+		log.Printf("chat_questions insert (with answer) error: %v", err)
+	}
 }
 
 // getClientIP extracts the client IP from the request, respecting proxy headers.

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -5148,10 +5148,23 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 		.import-status.success { background: #4CAF50; color: white; }
 		.import-status.error { background: #f44336; color: white; }
 		.import-status.info { background: #2196F3; color: white; }
+		/* Admin tab bar */
+		.admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+		.admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+		.admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+		.admin-tabs a.active { background: #2196F3; color: white; }
+		.admin-tabs span.disabled { color: var(--text-muted); cursor: not-allowed; font-style: italic; }
 	</style>
 </head>
 <body>
 	<h1>File Uploads Administration</h1>
+	<div class="admin-tabs">
+		<a href="/admin/users` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Users</a>
+		<a href="/admin/uploads` + func() string { if password != "" { return "?password=" + password } ; return "" }() + `" class="active">Uploads</a>
+		<a href="/api/admin/tracks` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Tracks</a>
+		<a href="/admin/mcp` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">MCP Analytics</a>
+		<span class="disabled">Realtime</span>
+	</div>
 	<div class="nav">
 		<div class="nav-left">
 			<a href="/api/admin/tracks?password=` + password + `">All Tracks</a>
@@ -6466,10 +6479,23 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 		.sortable.desc::after { content: '▼'; opacity: 1; }
 		.filter-input { width: 100%; padding: 4px 8px; border: 1px solid var(--border-color); border-radius: 3px; background: var(--bg-card); color: var(--text-primary); font-size: 0.85em; box-sizing: border-box; }
 		.filter-row th { background: var(--bg-card); padding: 8px 12px; }
+		/* Admin tab bar */
+		.admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+		.admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+		.admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+		.admin-tabs a.active { background: #2196F3; color: white; }
+		.admin-tabs span.disabled { color: var(--text-muted); cursor: not-allowed; font-style: italic; }
 	</style>
 </head>
 <body>
 	<h1>All Tracks Administration</h1>
+	<div class="admin-tabs">
+		<a href="/admin/users` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Users</a>
+		<a href="/admin/uploads` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Uploads</a>
+		<a href="/api/admin/tracks` + func() string { if password != "" { return "?password=" + password }; return "" }() + `" class="active">Tracks</a>
+		<a href="/admin/mcp` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">MCP Analytics</a>
+		<span class="disabled">Realtime</span>
+	</div>
 	<div class="nav">
 		<div class="nav-left">
 			<a href="/api/admin/tracks?password=` + password + `">All Tracks</a>
@@ -8867,6 +8893,44 @@ func main() {
 			}
 			// Forward to the API endpoint which handles the uploads listing
 			adminUploadsHandler(w, r)
+		}))
+
+		// Serve admin MCP analytics page
+		http.HandleFunc("/admin/mcp", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, private")
+			w.Header().Set("Pragma", "no-cache")
+			w.Header().Set("Expires", "0")
+
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			data, err := content.ReadFile("public_html/admin-mcp.html")
+			if err != nil {
+				http.Error(w, "Admin MCP page not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(data)
+		}))
+
+		// MCP analytics API endpoints
+		http.HandleFunc("/api/admin/mcp/data", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			adminMCPDataHandler(w, r)
+		}))
+		http.HandleFunc("/api/admin/mcp/export", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			adminMCPExportHandler(w, r)
+		}))
+		http.HandleFunc("/api/admin/mcp/delete", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			adminMCPDeleteHandler(w, r)
 		}))
 
 	}

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -206,7 +206,13 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		if source == "" {
 			source = "web-chat"
 		}
-		chatRowID := logChatQuestion(r, chatReq.Message, source, model, "", len(chatReq.History), chatReq.ClientTimestamp)
+		// Capture request metadata now; the full row (with answer) is inserted after the AI responds
+		chatReqRef := r
+		chatQuestion := chatReq.Message
+		chatSource := source
+		chatModel := model
+		chatHistory := len(chatReq.History)
+		chatClientTS := chatReq.ClientTimestamp
 		var answerText strings.Builder
 
 		mc, err := mcpclient.NewStreamableHttpClient(mcpURL)
@@ -312,7 +318,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 			})
 		}
 
-		logChatAnswer(chatRowID, strings.TrimSpace(answerText.String()))
+		logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, strings.TrimSpace(answerText.String()))
 
 		writeChunkBuffered(w, chunk{Type: "done"}, &buffer, isCloudFront)
 		if isCloudFront {

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>MCP Analytics - Safecast Admin</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
+  <link rel="manifest" href="/static/images/site.webmanifest">
+  <style>
+    :root {
+      --bg-primary: #f5f5f5;
+      --bg-card: white;
+      --text-primary: #333;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-color: #ddd;
+      --link-color: #0066cc;
+      --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --th-bg: #424242;
+      --hover-bg: #f9f9f9;
+      --btn-border-radius: 8px;
+      --tab-active-bg: #2196F3;
+      --tab-active-text: white;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1a1a1a;
+        --bg-card: #2b2b2b;
+        --text-primary: #eee;
+        --text-secondary: #aaa;
+        --text-muted: #777;
+        --border-color: #444;
+        --link-color: #90caf9;
+        --shadow: 0 1px 3px rgba(255,255,255,0.1);
+        --th-bg: #616161;
+        --hover-bg: #333;
+        --tab-active-bg: #1976D2;
+        color-scheme: dark;
+      }
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); padding: 20px; }
+    h1 { margin-bottom: 15px; font-size: 1.6em; }
+
+    /* Admin tab bar */
+    .admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+    .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+    .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
+    .admin-tabs span.disabled { color: var(--text-muted); cursor: not-allowed; font-style: italic; }
+
+    /* Sub-tabs for table selection */
+    .sub-tabs { display: flex; gap: 0; margin-bottom: 15px; border-bottom: 2px solid var(--border-color); }
+    .sub-tabs button { padding: 8px 20px; border: none; background: none; color: var(--text-secondary); font-size: 0.95em; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; font-weight: 500; }
+    .sub-tabs button:hover { color: var(--text-primary); }
+    .sub-tabs button.active { color: var(--tab-active-bg); border-bottom-color: var(--tab-active-bg); }
+
+    /* Controls bar */
+    .controls { display: flex; gap: 10px; align-items: center; margin-bottom: 15px; flex-wrap: wrap; }
+    .controls input[type="text"] { padding: 8px 12px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); font-size: 0.95em; min-width: 250px; }
+    .controls button { padding: 8px 16px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); cursor: pointer; font-size: 0.95em; }
+    .controls button:hover { background: var(--hover-bg); }
+    .controls .export-btn { background: #4CAF50; color: white; border-color: #4CAF50; }
+    .controls .export-btn:hover { background: #388E3C; }
+
+    /* Summary */
+    .summary { margin-bottom: 10px; color: var(--text-secondary); font-size: 0.9em; }
+
+    /* Data table */
+    .table-wrap { overflow-x: auto; background: var(--bg-card); border-radius: 8px; box-shadow: var(--shadow); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+    th { background: var(--th-bg); color: white; padding: 10px 12px; text-align: left; white-space: nowrap; position: sticky; top: 0; }
+    td { padding: 8px 12px; border-bottom: 1px solid var(--border-color); max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    td.wrap { white-space: normal; word-break: break-word; }
+    tr:hover { background: var(--hover-bg); }
+    .sortable { cursor: pointer; user-select: none; position: relative; padding-right: 20px; }
+    .sortable:hover { background: rgba(255,255,255,0.1); }
+    .sortable::after { content: '\21C5'; position: absolute; right: 4px; opacity: 0.5; }
+    .sortable.asc::after { content: '\25B2'; opacity: 1; }
+    .sortable.desc::after { content: '\25BC'; opacity: 1; }
+
+    /* Expandable cell */
+    td.expandable { cursor: pointer; }
+    td.expandable:hover { white-space: normal; overflow: visible; position: relative; z-index: 10; background: var(--bg-card); box-shadow: var(--shadow); }
+
+    /* Pagination */
+    .pagination { display: flex; gap: 5px; align-items: center; justify-content: center; margin-top: 15px; flex-wrap: wrap; }
+    .pagination button { padding: 6px 12px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); color: var(--text-primary); cursor: pointer; }
+    .pagination button:hover { background: var(--hover-bg); }
+    .pagination button.active { background: var(--tab-active-bg); color: white; border-color: var(--tab-active-bg); }
+    .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .pagination select { padding: 6px 8px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); color: var(--text-primary); }
+
+    .no-data { text-align: center; padding: 40px; color: var(--text-muted); }
+    .loading { text-align: center; padding: 40px; color: var(--text-muted); }
+    .checkbox-col { width: 40px; text-align: center; }
+    .controls .delete-btn { background: #f44336; color: white; border-color: #f44336; }
+    .controls .delete-btn:hover { background: #d32f2f; }
+    .controls .delete-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Modal for viewing full content */
+    .modal-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; }
+    .modal-overlay.visible { display: flex; align-items: center; justify-content: center; }
+    .modal { background: var(--bg-card); border-radius: 12px; padding: 20px; max-width: 800px; width: 90%; max-height: 80vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,0.3); }
+    .modal h3 { margin-bottom: 10px; }
+    .modal pre { white-space: pre-wrap; word-break: break-word; font-size: 0.9em; line-height: 1.5; background: var(--bg-primary); padding: 15px; border-radius: 8px; max-height: 60vh; overflow-y: auto; }
+    .modal button { margin-top: 15px; padding: 8px 20px; background: var(--tab-active-bg); color: white; border: none; border-radius: var(--btn-border-radius); cursor: pointer; }
+  </style>
+</head>
+<body>
+
+<h1>MCP Analytics</h1>
+
+<div class="admin-tabs" id="adminTabs"></div>
+
+<div class="sub-tabs">
+  <button class="active" onclick="switchTable('chat_questions')">Chat Questions</button>
+  <button onclick="switchTable('mcp_query_log')">Tool Usage</button>
+  <button onclick="switchTable('mcp_ai_query_log')">AI Query Log</button>
+</div>
+
+<div class="controls">
+  <input type="text" id="searchInput" placeholder="Search across all fields..." onkeydown="if(event.key==='Enter')doSearch()">
+  <button onclick="doSearch()">Search</button>
+  <button onclick="clearSearch()">Clear</button>
+  <button class="export-btn" onclick="exportCSV()">Export CSV</button>
+  <button class="delete-btn" id="deleteSelectedBtn" onclick="deleteSelected()" disabled>Delete Selected</button>
+  <button class="delete-btn" id="deleteAllBtn" onclick="deleteAll()">Delete All</button>
+  <span class="summary" id="summary"></span>
+</div>
+
+<div class="table-wrap">
+  <div class="loading" id="loading">Loading...</div>
+  <table id="dataTable" style="display:none">
+    <thead id="tableHead"></thead>
+    <tbody id="tableBody"></tbody>
+  </table>
+  <div class="no-data" id="noData" style="display:none">No data found</div>
+</div>
+
+<div class="pagination" id="pagination"></div>
+
+<div class="modal-overlay" id="modalOverlay" onclick="closeModal()">
+  <div class="modal" onclick="event.stopPropagation()">
+    <h3 id="modalTitle">Details</h3>
+    <pre id="modalContent"></pre>
+    <button onclick="closeModal()">Close</button>
+  </div>
+</div>
+
+<script>
+const PASSWORD = new URLSearchParams(window.location.search).get('password') || '';
+const AUTH_PARAM = PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '';
+
+// Column display names
+const COLUMN_LABELS = {
+  id: 'ID', timestamp: 'Timestamp', question: 'Question', answer: 'Answer',
+  source: 'Source', model: 'Model', ip_address: 'IP', country: 'Country',
+  is_mobile: 'Mobile', os: 'OS', browser: 'Browser', user_agent: 'User Agent',
+  accept_language: 'Language', referer: 'Referer', session_id: 'Session',
+  history_length: 'History', cloudfront: 'CF', client_timestamp: 'Client Time',
+  tool_name: 'Tool', duration_ms: 'Duration (ms)', result_count: 'Results',
+  client: 'Client', user_id: 'User ID', user_email: 'Email',
+  generated_query: 'Query', commit_hash: 'Commit', error: 'Error'
+};
+
+// Columns that should be expandable (long text)
+const EXPANDABLE = new Set(['question', 'answer', 'generated_query', 'user_agent', 'accept_language', 'referer']);
+
+let currentTable = 'chat_questions';
+let currentSort = 'timestamp';
+let currentOrder = 'desc';
+let currentSearch = '';
+let currentOffset = 0;
+let currentLimit = 50;
+let totalRows = 0;
+let currentData = [];
+let currentColumns = [];
+
+const KEY_COLUMNS = {
+  'chat_questions': 'id',
+  'mcp_query_log': 'timestamp',
+  'mcp_ai_query_log': 'timestamp'
+};
+
+// Build admin tabs
+function buildAdminTabs() {
+  const tabs = [
+    { label: 'Users', href: '/admin/users' },
+    { label: 'Uploads', href: '/admin/uploads' },
+    { label: 'Tracks', href: '/api/admin/tracks' },
+    { label: 'MCP Analytics', href: '/admin/mcp', active: true },
+    { label: 'Realtime', disabled: true }
+  ];
+  const container = document.getElementById('adminTabs');
+  tabs.forEach(t => {
+    if (t.disabled) {
+      container.innerHTML += `<span class="disabled">${t.label}</span>`;
+    } else {
+      const href = t.href + (PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '');
+      container.innerHTML += `<a href="${href}" class="${t.active ? 'active' : ''}">${t.label}</a>`;
+    }
+  });
+}
+
+function switchTable(table) {
+  currentTable = table;
+  currentOffset = 0;
+  currentSort = 'timestamp';
+  currentOrder = 'desc';
+
+  // Update sub-tab active state
+  document.querySelectorAll('.sub-tabs button').forEach(btn => {
+    btn.classList.toggle('active', btn.textContent === {
+      'chat_questions': 'Chat Questions',
+      'mcp_query_log': 'Tool Usage',
+      'mcp_ai_query_log': 'AI Query Log'
+    }[table]);
+  });
+
+  fetchData();
+}
+
+function doSearch() {
+  currentSearch = document.getElementById('searchInput').value.trim();
+  currentOffset = 0;
+  fetchData();
+}
+
+function clearSearch() {
+  document.getElementById('searchInput').value = '';
+  currentSearch = '';
+  currentOffset = 0;
+  fetchData();
+}
+
+function exportCSV() {
+  let url = '/api/admin/mcp/export?table=' + currentTable;
+  if (PASSWORD) url += '&password=' + encodeURIComponent(PASSWORD);
+  if (currentSearch) url += '&search=' + encodeURIComponent(currentSearch);
+  window.location.href = url;
+}
+
+function sortBy(col) {
+  if (currentSort === col) {
+    currentOrder = currentOrder === 'desc' ? 'asc' : 'desc';
+  } else {
+    currentSort = col;
+    currentOrder = 'desc';
+  }
+  currentOffset = 0;
+  fetchData();
+}
+
+async function fetchData() {
+  const loading = document.getElementById('loading');
+  const table = document.getElementById('dataTable');
+  const noData = document.getElementById('noData');
+
+  loading.style.display = 'block';
+  table.style.display = 'none';
+  noData.style.display = 'none';
+
+  let url = `/api/admin/mcp/data?table=${currentTable}&limit=${currentLimit}&offset=${currentOffset}&sort=${currentSort}&order=${currentOrder}`;
+  if (PASSWORD) url += '&password=' + encodeURIComponent(PASSWORD);
+  if (currentSearch) url += '&search=' + encodeURIComponent(currentSearch);
+
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      if (resp.status === 401) {
+        loading.textContent = 'Unauthorized - please login as admin or provide password';
+        return;
+      }
+      // Try to parse error JSON
+      try {
+        const errJson = await resp.json();
+        if (errJson.error) {
+          loading.textContent = errJson.error;
+          return;
+        }
+      } catch {}
+      if (resp.status === 503) {
+        loading.textContent = 'DuckDB analytics not available. Ensure DUCKLAKE_PG_URL is configured and ducklake_catalog database exists.';
+        return;
+      }
+      throw new Error('HTTP ' + resp.status);
+    }
+
+    const json = await resp.json();
+    totalRows = json.total;
+    const columns = json.columns || [];
+    const data = json.data || [];
+
+    loading.style.display = 'none';
+
+    if (data.length === 0) {
+      noData.style.display = 'block';
+      document.getElementById('summary').textContent = 'No results';
+      document.getElementById('pagination').innerHTML = '';
+      return;
+    }
+
+    // Store current data for delete operations
+    currentData = data;
+    currentColumns = columns;
+
+    // Build header
+    const thead = document.getElementById('tableHead');
+    const keyCol = KEY_COLUMNS[currentTable];
+    let headerHTML = '<tr><th class="checkbox-col"><input type="checkbox" onchange="toggleAll(this)"></th>';
+    columns.forEach(col => {
+      const label = COLUMN_LABELS[col] || col;
+      const sortClass = currentSort === col ? (currentOrder === 'asc' ? 'sortable asc' : 'sortable desc') : 'sortable';
+      headerHTML += `<th class="${sortClass}" onclick="sortBy('${col}')">${label}</th>`;
+    });
+    headerHTML += '</tr>';
+    thead.innerHTML = headerHTML;
+
+    // Build body
+    const tbody = document.getElementById('tableBody');
+    let bodyHTML = '';
+    data.forEach((row, idx) => {
+      const keyVal = row[keyCol];
+      bodyHTML += `<tr><td class="checkbox-col"><input type="checkbox" class="row-cb" value="${keyVal}" onchange="updateDeleteBtn()"></td>`;
+      columns.forEach(col => {
+        let val = row[col];
+        if (val === null || val === undefined) val = '';
+        const strVal = String(val);
+        if (EXPANDABLE.has(col) && strVal.length > 60) {
+          const preview = strVal.substring(0, 60) + '...';
+          bodyHTML += `<td class="expandable" title="Click to expand" onclick="showModal('${COLUMN_LABELS[col] || col}', ${JSON.stringify(strVal).replace(/'/g, "&#39;")})">${escapeHtml(preview)}</td>`;
+        } else if (col === 'is_mobile' || col === 'cloudfront') {
+          bodyHTML += `<td>${val ? 'Yes' : (val === false ? 'No' : '')}</td>`;
+        } else if (col === 'timestamp' || col === 'client_timestamp') {
+          bodyHTML += `<td>${formatTimestamp(strVal)}</td>`;
+        } else {
+          bodyHTML += `<td>${escapeHtml(strVal)}</td>`;
+        }
+      });
+      bodyHTML += '</tr>';
+    });
+    tbody.innerHTML = bodyHTML;
+    table.style.display = 'table';
+    updateDeleteBtn();
+
+    // Summary
+    const page = Math.floor(currentOffset / currentLimit) + 1;
+    const totalPages = Math.ceil(totalRows / currentLimit);
+    document.getElementById('summary').textContent = `${totalRows} total rows | Page ${page} of ${totalPages}`;
+
+    // Pagination
+    buildPagination(totalPages, page);
+
+  } catch (err) {
+    loading.textContent = 'Error loading data: ' + err.message;
+  }
+}
+
+function buildPagination(totalPages, currentPage) {
+  const container = document.getElementById('pagination');
+  let html = '';
+
+  html += `<button ${currentPage <= 1 ? 'disabled' : ''} onclick="goToPage(1)">First</button>`;
+  html += `<button ${currentPage <= 1 ? 'disabled' : ''} onclick="goToPage(${currentPage - 1})">Prev</button>`;
+
+  // Page number buttons (show max 7)
+  let start = Math.max(1, currentPage - 3);
+  let end = Math.min(totalPages, start + 6);
+  start = Math.max(1, end - 6);
+
+  for (let i = start; i <= end; i++) {
+    html += `<button class="${i === currentPage ? 'active' : ''}" onclick="goToPage(${i})">${i}</button>`;
+  }
+
+  html += `<button ${currentPage >= totalPages ? 'disabled' : ''} onclick="goToPage(${currentPage + 1})">Next</button>`;
+  html += `<button ${currentPage >= totalPages ? 'disabled' : ''} onclick="goToPage(${totalPages})">Last</button>`;
+
+  html += ` <select onchange="changeLimit(this.value)">`;
+  [25, 50, 100, 200].forEach(n => {
+    html += `<option value="${n}" ${n === currentLimit ? 'selected' : ''}>${n} per page</option>`;
+  });
+  html += `</select>`;
+
+  container.innerHTML = html;
+}
+
+function goToPage(page) {
+  currentOffset = (page - 1) * currentLimit;
+  fetchData();
+}
+
+function changeLimit(val) {
+  currentLimit = parseInt(val);
+  currentOffset = 0;
+  fetchData();
+}
+
+function showModal(title, content) {
+  document.getElementById('modalTitle').textContent = title;
+  document.getElementById('modalContent').textContent = content;
+  document.getElementById('modalOverlay').classList.add('visible');
+}
+
+function closeModal() {
+  document.getElementById('modalOverlay').classList.remove('visible');
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts;
+    return d.toLocaleString();
+  } catch { return ts; }
+}
+
+function toggleAll(master) {
+  document.querySelectorAll('.row-cb').forEach(cb => { cb.checked = master.checked; });
+  updateDeleteBtn();
+}
+
+function updateDeleteBtn() {
+  const checked = document.querySelectorAll('.row-cb:checked').length;
+  const btn = document.getElementById('deleteSelectedBtn');
+  btn.disabled = checked === 0;
+  btn.textContent = checked > 0 ? `Delete Selected (${checked})` : 'Delete Selected';
+}
+
+async function deleteSelected() {
+  const checked = document.querySelectorAll('.row-cb:checked');
+  if (checked.length === 0) return;
+  if (!confirm(`Delete ${checked.length} selected row(s)?`)) return;
+
+  const ids = Array.from(checked).map(cb => cb.value).join(',');
+  let url = `/api/admin/mcp/delete?table=${currentTable}&ids=${encodeURIComponent(ids)}`;
+  if (PASSWORD) url += '&password=' + encodeURIComponent(PASSWORD);
+
+  try {
+    const resp = await fetch(url, { method: 'DELETE' });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const json = await resp.json();
+    alert(`Deleted ${json.deleted} row(s)`);
+    fetchData();
+  } catch (err) {
+    alert('Delete failed: ' + err.message);
+  }
+}
+
+async function deleteAll() {
+  const scope = currentSearch ? 'all filtered rows' : 'ALL rows';
+  if (!confirm(`Delete ${scope} from ${currentTable}? This cannot be undone.`)) return;
+
+  let url = `/api/admin/mcp/delete?table=${currentTable}&all=true`;
+  if (PASSWORD) url += '&password=' + encodeURIComponent(PASSWORD);
+  if (currentSearch) url += '&search=' + encodeURIComponent(currentSearch);
+
+  try {
+    const resp = await fetch(url, { method: 'DELETE' });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const json = await resp.json();
+    alert(`Deleted ${json.deleted} row(s)`);
+    fetchData();
+  } catch (err) {
+    alert('Delete failed: ' + err.message);
+  }
+}
+
+// Init
+document.addEventListener('DOMContentLoaded', () => {
+  buildAdminTabs();
+  fetchData();
+});
+
+// Keyboard shortcut: Escape closes modal
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeModal();
+});
+</script>
+</body>
+</html>

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -148,10 +148,18 @@
     .search-btn:hover { background: #1976D2; }
     .clear-search-btn { background: var(--border-color); color: var(--text-primary); border: none; padding: 5px 12px; border-radius: var(--btn-border-radius); cursor: pointer; margin-left: 5px; }
     .clear-search-btn:hover { opacity: 0.8; }
+    /* Admin tab bar */
+    .admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+    .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+    .admin-tabs a.active { background: #2196F3; color: white; }
+    .admin-tabs span.disabled { color: var(--text-muted); cursor: not-allowed; font-style: italic; }
   </style>
 </head>
 <body>
   <h1>User Administration</h1>
+
+  <div class="admin-tabs" id="adminTabs"></div>
 
   <div class="nav">
     <div class="nav-left">
@@ -330,7 +338,28 @@
     }
 
     // Check authentication on page load
+    function buildAdminTabs() {
+      const pw = new URLSearchParams(window.location.search).get('password') || '';
+      const tabs = [
+        { label: 'Users', href: '/admin/users', active: true },
+        { label: 'Uploads', href: '/admin/uploads' },
+        { label: 'Tracks', href: '/api/admin/tracks' },
+        { label: 'MCP Analytics', href: '/admin/mcp' },
+        { label: 'Realtime', disabled: true }
+      ];
+      const container = document.getElementById('adminTabs');
+      tabs.forEach(t => {
+        if (t.disabled) {
+          container.innerHTML += '<span class="disabled">' + t.label + '</span>';
+        } else {
+          const href = t.href + (pw ? '?password=' + encodeURIComponent(pw) : '');
+          container.innerHTML += '<a href="' + href + '" class="' + (t.active ? 'active' : '') + '">' + t.label + '</a>';
+        }
+      });
+    }
+
     window.addEventListener('DOMContentLoaded', async function() {
+      buildAdminTabs();
       // Check if user is authenticated via session
       try {
         const response = await fetch('/api/user/profile');

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -2258,11 +2258,8 @@ body, html {
     <a href="/profile" style="padding: 4px 10px; background: #4CAF50; border: none; border-radius: var(--btn-border-radius, 8px); color: white; font-size: 11px; text-decoration: none;">
       Profile
     </a>
-    <a id="adminUsersBtn" href="/admin/users" style="display: none; padding: 4px 10px; background: #2196F3; border: none; border-radius: var(--btn-border-radius, 8px); color: white; font-size: 11px; text-decoration: none;">
-      Admin Users
-    </a>
-    <a id="adminTracksBtn" href="/admin/uploads" style="display: none; padding: 4px 10px; background: #FF9800; border: none; border-radius: var(--btn-border-radius, 8px); color: white; font-size: 11px; text-decoration: none;">
-      Admin Uploads
+    <a id="adminBtn" href="/admin/users" style="display: none; padding: 4px 10px; background: #2196F3; border: none; border-radius: var(--btn-border-radius, 8px); color: white; font-size: 11px; text-decoration: none;">
+      Admin
     </a>
     <button onclick="logout()" style="padding: 4px 10px; background: #f44336; border: none; border-radius: var(--btn-border-radius, 8px); cursor: pointer; color: white; font-size: 11px;">
       Logout
@@ -2319,8 +2316,7 @@ body, html {
         const loginBtn = document.getElementById('loginButton');
         const userMenu = document.getElementById('userMenu');
         const userMenuName = document.getElementById('userMenuName');
-        const adminUsersBtn = document.getElementById('adminUsersBtn');
-        const adminTracksBtn = document.getElementById('adminTracksBtn');
+        const adminBtn = document.getElementById('adminBtn');
 
         if (loginBtn) loginBtn.style.display = 'none';
         if (userMenu) {
@@ -2330,13 +2326,11 @@ body, html {
           }
         }
 
-        // Show admin buttons only for admin users
+        // Show admin button only for admin users
         if (currentUser && currentUser.is_admin) {
-          if (adminUsersBtn) adminUsersBtn.style.display = 'inline-block';
-          if (adminTracksBtn) adminTracksBtn.style.display = 'inline-block';
+          if (adminBtn) adminBtn.style.display = 'inline-block';
         } else {
-          if (adminUsersBtn) adminUsersBtn.style.display = 'none';
-          if (adminTracksBtn) adminTracksBtn.style.display = 'none';
+          if (adminBtn) adminBtn.style.display = 'none';
         }
       }
 


### PR DESCRIPTION
## Summary
- New admin page at `/admin/mcp` to browse DuckLake analytics tables (chat_questions, mcp_query_log, mcp_ai_query_log) with search, sort, pagination, CSV export, and row deletion
- Tabbed navigation across all admin pages: Users | Uploads | Tracks | MCP Analytics | Realtime (placeholder)
- Consolidated map header admin buttons ("Admin Users" + "Admin Uploads") into single "Admin" button
- Fixed DuckLake answer storage corruption by using single INSERT instead of UPDATE
- Fixed DuckLake Go driver read bug with large VARCHAR values using LEFT() workaround

## Test plan
- [ ] Visit `/admin/mcp` — verify all 3 sub-tabs show data
- [ ] Test search, sort, pagination, CSV export
- [ ] Test delete (selected rows and bulk)
- [ ] Verify tab bar appears on Users, Uploads, Tracks pages
- [ ] Verify single "Admin" button on map for admin users
- [ ] Verify chat answers display correctly in the admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)