### PR TITLE
fix: switch web-chat model from Sonnet to Haiku

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           DUCKLAKE_DATA_PATH: ${{ secrets.DUCKLAKE_DATA_PATH }}
         run: |
           ssh -i ~/.ssh/deploy_key root@65.108.24.131 \
-            "printf 'DATABASE_URL=${DATABASE_URL}\nDUCKLAKE_PG_URL=${DUCKLAKE_PG_URL}\nDUCKLAKE_DATA_PATH=${DUCKLAKE_DATA_PATH}\nMCP_HINTS_DIR=/root/safecast-mcp-server/hints\nANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\nCLAUDE_MODEL=claude-sonnet-4-5\nMCP_BASE_URL=https://simplemap.safecast.org/mcp\n' > /root/safecast-mcp-server/.env"
+            "printf 'DATABASE_URL=${DATABASE_URL}\nDUCKLAKE_PG_URL=${DUCKLAKE_PG_URL}\nDUCKLAKE_DATA_PATH=${DUCKLAKE_DATA_PATH}\nMCP_HINTS_DIR=/root/safecast-mcp-server/hints\nANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}\nCLAUDE_MODEL=claude-haiku-4-5-20251001\nMCP_BASE_URL=https://simplemap.safecast.org/mcp\n' > /root/safecast-mcp-server/.env"
 
       - name: Restart service with new config
         run: |

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ DUCKLAKE_DATA_PATH="/var/lib/safecast/ducklake/" \
 # With AI web chat (requires Anthropic API key)
 DATABASE_URL="postgres://..." \
 ANTHROPIC_API_KEY="your-key" \
-CLAUDE_MODEL="claude-sonnet-4-5" \
+CLAUDE_MODEL="claude-haiku-4-5-20251001" \
 ./safecast-new-map
 ```
 

--- a/cmd/web-chat/main.go
+++ b/cmd/web-chat/main.go
@@ -484,7 +484,7 @@ func main() {
 	}
 	model := os.Getenv("CLAUDE_MODEL")
 	if model == "" {
-		model = "claude-sonnet-4-5"
+		model = "claude-haiku-4-5-20251001"
 	}
 	mcpURL := os.Getenv("MCP_URL")
 	if mcpURL == "" {

--- a/cmd/web-chat/main.go.nvidia
+++ b/cmd/web-chat/main.go.nvidia
@@ -32,7 +32,7 @@ func main() {
 		}
 		model = os.Getenv("CLAUDE_MODEL")
 		if model == "" {
-			model = "claude-sonnet-4-5"
+			model = "claude-haiku-4-5-20251001"
 		}
 		log.Printf("Using Anthropic Claude API: model=%s", model)
 	}


### PR DESCRIPTION
## Summary
- Switch the Claude model used by web-chat from `claude-sonnet-4-5` to `claude-haiku-4-5-20251001` to reduce API costs
- Updated default fallback in `cmd/web-chat/main.go` and nvidia variant
- Updated deploy workflow `.env` and README docs

## Test plan
- [ ] Verify deploy workflow sets correct model in `.env`
- [ ] Confirm web-chat responses still work with Haiku model

🤖 Generated with [Claude Code](https://claude.com/claude-code)