### PR TITLE
fix: add consistent Back to Map button to all admin pages

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -5109,6 +5109,8 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 		.nav a:hover { text-decoration: underline; }
 		.back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: 4px; text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
 		.back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
+		.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+		.page-header h1 { margin: 0; }
 		.summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); }
 		table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); }
 		th { background: var(--th-bg); color: white; padding: 12px; text-align: left; font-weight: 600; }
@@ -5149,7 +5151,7 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 		.import-status.error { background: #f44336; color: white; }
 		.import-status.info { background: #2196F3; color: white; }
 		/* Admin tab bar */
-		.admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+		.admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
 		.admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
 		.admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
 		.admin-tabs a.active { background: #2196F3; color: white; }
@@ -5157,7 +5159,10 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 	</style>
 </head>
 <body>
-	<h1>File Uploads Administration</h1>
+	<div class="page-header">
+		<h1>File Uploads Administration</h1>
+		<a href="/" class="back-to-map-btn">Back to Map</a>
+	</div>
 	<div class="admin-tabs">
 		<a href="/admin/users` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Users</a>
 		<a href="/admin/uploads` + func() string { if password != "" { return "?password=" + password } ; return "" }() + `" class="active">Uploads</a>
@@ -5172,7 +5177,6 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 			<button class="view-selected-btn" id="viewSelectedBtn" onclick="viewSelected()" disabled>View Selected on Map</button>
 			<button class="delete-selected-btn" id="deleteSelectedBtn" onclick="deleteSelected()" disabled>Delete Selected</button>
 		</div>
-		<a href="/" class="back-to-map-btn">Back to Map</a>
 	</div>
 	<div class="import-form">
 		<h3>Import from Safecast API</h3>
@@ -6448,6 +6452,8 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 		.nav a:hover { text-decoration: underline; }
 		.back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: 4px; text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
 		.back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
+		.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+		.page-header h1 { margin: 0; }
 		.summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); }
 		table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); }
 		th { background: var(--th-bg); color: white; padding: 12px; text-align: left; font-weight: 600; }
@@ -6480,7 +6486,7 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 		.filter-input { width: 100%; padding: 4px 8px; border: 1px solid var(--border-color); border-radius: 3px; background: var(--bg-card); color: var(--text-primary); font-size: 0.85em; box-sizing: border-box; }
 		.filter-row th { background: var(--bg-card); padding: 8px 12px; }
 		/* Admin tab bar */
-		.admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+		.admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
 		.admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
 		.admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
 		.admin-tabs a.active { background: #2196F3; color: white; }
@@ -6488,7 +6494,10 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 	</style>
 </head>
 <body>
-	<h1>All Tracks Administration</h1>
+	<div class="page-header">
+		<h1>All Tracks Administration</h1>
+		<a href="/" class="back-to-map-btn">Back to Map</a>
+	</div>
 	<div class="admin-tabs">
 		<a href="/admin/users` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Users</a>
 		<a href="/admin/uploads` + func() string { if password != "" { return "?password=" + password }; return "" }() + `">Uploads</a>
@@ -6504,7 +6513,6 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 			<button class="view-selected-btn" id="viewSelectedBtn" onclick="viewSelected()" disabled>View Selected on Map</button>
 			<button class="delete-selected-btn" id="deleteSelectedBtn" onclick="deleteSelected()" disabled>Delete Selected</button>
 		</div>
-		<a href="/" class="back-to-map-btn">Back to Map</a>
 	</div>
 	<div class="summary">
 		<strong>Total Tracks:</strong> ` + strconv.Itoa(totalCount) + ` tracks

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -45,7 +45,7 @@
     h1 { margin-bottom: 15px; font-size: 1.6em; }
 
     /* Admin tab bar */
-    .admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
     .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
     .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
     .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
@@ -114,11 +114,18 @@
     .modal h3 { margin-bottom: 10px; }
     .modal pre { white-space: pre-wrap; word-break: break-word; font-size: 0.9em; line-height: 1.5; background: var(--bg-primary); padding: 15px; border-radius: 8px; max-height: 60vh; overflow-y: auto; }
     .modal button { margin-top: 15px; padding: 8px 20px; background: var(--tab-active-bg); color: white; border: none; border-radius: var(--btn-border-radius); cursor: pointer; }
+    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+    .page-header h1 { margin: 0; }
+    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
+    .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
   </style>
 </head>
 <body>
 
-<h1>MCP Analytics</h1>
+<div class="page-header">
+  <h1>MCP Analytics</h1>
+  <a href="/" class="back-to-map-btn">Back to Map</a>
+</div>
 
 <div class="admin-tabs" id="adminTabs"></div>
 

--- a/cmd/unified-server/public_html/admin-realtime.html
+++ b/cmd/unified-server/public_html/admin-realtime.html
@@ -45,7 +45,7 @@
     h1 { margin-bottom: 15px; font-size: 1.6em; }
 
     /* Admin tab bar */
-    .admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
     .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
     .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
     .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
@@ -107,11 +107,18 @@
     .modal h3 { margin-bottom: 10px; }
     .modal pre { white-space: pre-wrap; word-break: break-word; font-size: 0.9em; line-height: 1.5; background: var(--bg-primary); padding: 15px; border-radius: 8px; max-height: 60vh; overflow-y: auto; }
     .modal button { margin-top: 15px; padding: 8px 20px; background: var(--tab-active-bg); color: white; border: none; border-radius: var(--btn-border-radius); cursor: pointer; }
+    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+    .page-header h1 { margin: 0; }
+    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
+    .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
   </style>
 </head>
 <body>
 
-<h1>Realtime Devices</h1>
+<div class="page-header">
+  <h1>Realtime Devices</h1>
+  <a href="/" class="back-to-map-btn">Back to Map</a>
+</div>
 
 <div class="admin-tabs" id="adminTabs"></div>
 

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -72,6 +72,8 @@
     .nav-left { display: flex; align-items: center; gap: 15px; }
     .nav a { color: var(--link-color); text-decoration: none; }
     .nav a:hover { text-decoration: underline; }
+    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+    .page-header h1 { margin: 0; }
     .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
     .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
     .summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: var(--btn-border-radius); box-shadow: var(--shadow); }
@@ -151,7 +153,7 @@
     .clear-search-btn { background: var(--border-color); color: var(--text-primary); border: none; padding: 5px 12px; border-radius: var(--btn-border-radius); cursor: pointer; margin-left: 5px; }
     .clear-search-btn:hover { opacity: 0.8; }
     /* Admin tab bar */
-    .admin-tabs { display: flex; gap: 2px; margin-bottom: 20px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
     .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
     .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
     .admin-tabs a.active { background: #2196F3; color: white; }
@@ -159,7 +161,10 @@
   </style>
 </head>
 <body>
-  <h1>User Administration</h1>
+  <div class="page-header">
+    <h1>User Administration</h1>
+    <a href="/" class="back-to-map-btn">Back to Map</a>
+  </div>
 
   <div class="admin-tabs" id="adminTabs"></div>
 
@@ -168,7 +173,6 @@
       <button class="add-user-btn" onclick="openAddUserModal()">Add User</button>
       <button class="delete-selected-btn" id="deleteSelectedBtn" onclick="deleteSelectedUsers()" style="display:none;">Delete Selected</button>
     </div>
-    <a href="/" class="back-to-map-btn">Back to Map</a>
   </div>
 
   <div class="summary" id="summary">


### PR DESCRIPTION
## Summary
- Add "Back to Map" button to MCP Analytics and Realtime admin pages (previously missing)
- Move button to page header (top right, next to h1) for consistent placement across all pages
- Adjust tab bar spacing: add 10px top margin and reduce bottom margin from 20px to 10px

## Test plan
- [x] Verified all admin pages: Users, Uploads, Tracks, MCP Analytics, Realtime
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)