### PR TITLE
docs: update docs for translations/i18n system

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Natural background radiation is typically low and safe. This map helps identify 
 **Advanced Capabilities**
 - Gamma spectrum analysis (.spe, .n42 formats)
 - User authentication with API key support
-- Admin panel for content moderation
+- Admin panel for content moderation and translation management
 - Comprehensive authentication logging
 - Short link generation for sharing
-- Multi-language interface
+- Multi-language interface (29 languages) with PostgreSQL-backed translations and admin UI
 - Auto-update system
 
 ---
@@ -295,11 +295,28 @@ Enable the admin panel with:
 ./safecast-new-map -admin-password your-secure-password
 ```
 
-**Admin capabilities:**
-- View all uploads and tracks
-- Delete inappropriate content
-- Monitor system statistics
-- Manage user contributions
+Access the admin panel at `/admin/users?password=your-secure-password` or log in as an admin user.
+
+**Admin pages:**
+
+| Page | URL | Description |
+|------|-----|-------------|
+| Users | `/admin/users` | Manage user accounts, roles, and API keys |
+| Uploads | `/admin/uploads` | View uploads, import from Safecast API, delete tracks |
+| MCP Analytics | `/admin/mcp` | Monitor MCP tool usage and AI query logs |
+| Realtime | `/admin/realtime` | Manage real-time sensor device data |
+| Translations | `/admin/translations` | Edit, add, and delete UI translations for all 29 languages |
+
+### Translation Management
+
+Translations are stored in PostgreSQL and loaded into memory at startup. The admin translations page provides:
+- Filter by language (29 languages: ar, bg, cs, da, de, el, en, es, fa, fi, fr, he, hi, hu, id, it, ja, ko, ms, nl, no, pl, pt, ru, sv, th, tr, uk, vi, zh)
+- Search across keys and values
+- Inline editing with save
+- Add new translation keys
+- **Reload into Memory** button to apply changes without restarting the server
+
+All UI components are translated: map legend, AI assistant widget, login/register modals, search bar, spectrum viewer, profile page, and coordinate input dialog.
 
 ---
 
@@ -433,7 +450,10 @@ Add user authentication to existing databases:
 ```bash
 psql -h 127.0.0.1 -U postgres -d safecast -f migrations/create_users_table.sql
 psql -h 127.0.0.1 -U postgres -d safecast -f migrations/link_historical_uploads_to_users.sql
+psql -h 127.0.0.1 -U postgres -d safecast -f migrations/add_ui_translations.sql
 ```
+
+**Note:** The translations table is auto-created at startup and seeded from the embedded `translations.json` if no DB rows exist. The `add_ui_translations.sql` migration adds the extended UI translations (AI widget, auth modals, search, spectrum, profile page).
 
 **Key columns in users table:**
 - `id` - Unique user identifier
@@ -462,7 +482,7 @@ Customize map views with URL parameters:
 | `coloring`                             | safecast, chicha                | Scientific gradient vs. safety bins            |
 | `unit`                                 | uSv, uR                         | Display units (microsieverts or microroentgen) |
 | `legend`                               | 1, 0                            | Show/hide legend                               |
-| `lang`                                 | en, ru, ja, etc.                | Interface language                             |
+| `lang`                                 | en, ja, de, fr, etc. (29 langs) | Interface language                             |
 | `layer`                                | OpenStreetMap, Google Satellite | Base map                                       |
 | `show`                                 | rt                              | Filter to show only realtime sensors           |
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -186,6 +186,22 @@ Both the unified server and MCP server use DuckLake for analytics (tool usage lo
 
 **Shared tables:** `chat_questions`, `mcp_query_log`, `mcp_ai_query_log`
 
+## Translations (i18n)
+
+Translations are stored in PostgreSQL (`translations` table) and loaded into memory at startup. The table is auto-created and seeded from the embedded `translations.json` if empty.
+
+**Run the extended UI translations migration:**
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
+  "psql -h 127.0.0.1 -U postgres -d safecast -f /tmp/add_ui_translations.sql"
+```
+
+**Admin UI:** `/admin/translations` — edit translations live, then click "Reload into Memory" to apply without restart.
+
+**Supported languages (29):** ar, bg, cs, da, de, el, en, es, fa, fi, fr, he, hi, hu, id, it, ja, ko, ms, nl, no, pl, pt, ru, sv, th, tr, uk, vi, zh
+
+**Translated components:** Map legend, AI assistant widget, login/register/forgot-password modals, user menu, search bar, spectrum viewer, coordinate input dialog, profile page.
+
 ## Server Configuration
 
 ### Service Details

--- a/docs/architecture-overview.mmd
+++ b/docs/architecture-overview.mmd
@@ -24,11 +24,14 @@ flowchart TB
         Fetcher["bGeigie Auto-Sync\n(-safecast-fetcher)"]
         RTPoller["Real-time Sensor Poller\n(-safecast-realtime)"]
         SpecParser["Spectrum Parser\n.n42 / .spe / .rctrk formats\n→ channels + calibration"]
+        I18n["i18n / Translations\n29 languages · DB-backed\nAdmin UI: /admin/translations"]
+        AdminPages["Admin Panel\nUsers · Uploads · MCP Analytics\nRealtime · Translations"]
   end
  subgraph DB["🗄️ PostgreSQL + PostGIS"]
         markers["markers table\n(bGeigie tracks + spectrum locations)"]
         realtime["realtime_measurements\n(fixed sensors)"]
         spectra["spectra table\n(channels[], calibration, raw_data\nlinked to markers via marker_id)"]
+        translations["translations table\n(language_code, key, value\n29 languages × 279 keys)"]
   end
  subgraph WebChat["Web Chat — cmd/web-chat (port 3334)"]
         ChatUI["Chat Interface\n(HTML + JavaScript)"]
@@ -66,4 +69,5 @@ flowchart TB
     SpecParser -- "markers + spectra rows" --> markers
     SpecParser -- "channels[] + calibration\n+ raw_data (BYTEA)" --> spectra
     Fixed -- "real-time readings" --> RTPoller
+    I18n -- "load at startup\nreload via admin" --> translations
     GH_All -- rsync → IP direct --> Server


### PR DESCRIPTION
## Summary
- **README.md**: Expand admin section with table of all 5 admin pages, add translation management documentation, update `lang` parameter to reflect 29 languages, add translations migration to database migrations section
- **architecture-overview.mmd**: Add i18n/translations component, translations DB table, admin panel node, and DB connection arrow
- **DEPLOYMENT.md**: Add translations section with migration command, admin UI URL, list of supported languages and translated components

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify Mermaid diagram renders with new nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)