### PR TITLE
fix: seed missing translation keys on startup

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -1856,17 +1856,7 @@ func seedTranslationsDB(fs embed.FS, filename string) {
 		return
 	}
 
-	var count int
-	err := db.DB.QueryRow("SELECT COUNT(*) FROM translations").Scan(&count)
-	if err != nil {
-		log.Printf("[i18n] Cannot check translations table: %v", err)
-		return
-	}
-	if count > 0 {
-		return // already seeded
-	}
-
-	// Load from file
+	// Load from file — always check for missing keys (not just empty table)
 	file, err := fs.Open(filename)
 	if err != nil {
 		log.Printf("[i18n] Cannot open translation file for seeding: %v", err)
@@ -1912,7 +1902,9 @@ func seedTranslationsDB(fs embed.FS, filename string) {
 		return
 	}
 
-	log.Printf("[i18n] Seeded %d translations into database from embedded file", inserted)
+	if inserted > 0 {
+		log.Printf("[i18n] Seeded %d new translations into database from embedded file", inserted)
+	}
 }
 
 func getPreferredLanguage(r *http.Request) string {


### PR DESCRIPTION
## Summary
- Fix AI widget showing raw keys like `ai_greeting` instead of translated text
- Root cause: the translation seeder skipped entirely if the DB already had any rows, so new keys added in PR #29 were never inserted
- Now always inserts missing keys from embedded JSON using `ON CONFLICT DO NOTHING`
- Existing translations are preserved, only missing keys are added

## Test plan
- [ ] Deploy and verify AI widget shows greeting text instead of `ai_greeting`
- [ ] Verify placeholder text appears in the AI input field
- [ ] Check server logs for `[i18n] Seeded N new translations` on first startup after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)