### PR TITLE
fix: respect ?lang= query parameter for language switching

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -1908,17 +1908,20 @@ func seedTranslationsDB(fs embed.FS, filename string) {
 }
 
 func getPreferredLanguage(r *http.Request) string {
-	langHeader := r.Header.Get("Accept-Language")
-	if langHeader == "" {
-		return "en"
-	}
-
 	// Поддерживаемые языки (добавлены: da, fa)
 	supported := map[string]struct{}{
 		"en": {}, "zh": {}, "es": {}, "hi": {}, "ar": {}, "fr": {}, "ru": {}, "pt": {}, "de": {}, "ja": {}, "tr": {}, "it": {},
 		"ko": {}, "pl": {}, "uk": {}, "mn": {}, "no": {}, "fi": {}, "ka": {}, "sv": {}, "he": {}, "nl": {}, "el": {}, "hu": {},
 		"cs": {}, "ro": {}, "th": {}, "vi": {}, "id": {}, "ms": {}, "bg": {}, "lt": {}, "et": {}, "lv": {}, "sl": {},
 		"da": {}, "fa": {},
+	}
+
+	// Check ?lang= query parameter first (explicit override)
+	if langParam := r.URL.Query().Get("lang"); langParam != "" {
+		code := strings.ToLower(strings.TrimSpace(langParam))
+		if _, ok := supported[code]; ok {
+			return code
+		}
 	}
 
 	// Нормализация/синонимы: приводим варианты к поддерживаемым базовым кодам
@@ -1942,6 +1945,12 @@ func getPreferredLanguage(r *http.Request) string {
 		// Португальский варианты → "pt"
 		"pt-br": "pt",
 		"pt-pt": "pt",
+	}
+
+	// Fall back to Accept-Language header
+	langHeader := r.Header.Get("Accept-Language")
+	if langHeader == "" {
+		return "en"
 	}
 
 	langs := strings.Split(langHeader, ",")


### PR DESCRIPTION
## Summary
- `getPreferredLanguage()` only checked the `Accept-Language` header, ignoring `?lang=` URL parameter
- After PR #33 filtered `TranslationsJSON` to just the detected language + English, the client-side `?lang=` override stopped working since `translations["ja"]` wasn't in the filtered set
- Now the server checks `?lang=` query parameter first, so the correct language is included in both server-side rendering and the embedded JS translations

## Test plan
- [ ] Visit `https://simplemap.safecast.org/?lang=ja` — UI should render in Japanese
- [ ] Visit `https://simplemap.safecast.org/?lang=de` — UI should render in German
- [ ] Visit `https://simplemap.safecast.org/` — should use browser's Accept-Language as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)