### PR TITLE
docs: translations language selection, performance, and branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ Translations are stored in PostgreSQL and loaded into memory at startup. The adm
 
 All UI components are translated: map legend, AI assistant widget, login/register modals, search bar, spectrum viewer, profile page, and coordinate input dialog.
 
+**How it works:**
+- **Language selection:** The `?lang=` URL parameter takes priority, then the browser's `Accept-Language` header, defaulting to English
+- **Incremental seeding:** On startup, any new keys in the embedded `translations.json` are inserted into the DB (`ON CONFLICT DO NOTHING` preserves existing edits)
+- **Performance:** Only the active language + English fallback are embedded in the page HTML (~30KB vs ~850KB for all 30 languages), keeping the AI widget within Claude's token limits
+- **Branding:** "Safecast" must remain untranslated as a brand name in all languages
+
 ---
 
 ## User Authentication & API Keys
@@ -482,7 +488,7 @@ Customize map views with URL parameters:
 | `coloring`                             | safecast, chicha                | Scientific gradient vs. safety bins            |
 | `unit`                                 | uSv, uR                         | Display units (microsieverts or microroentgen) |
 | `legend`                               | 1, 0                            | Show/hide legend                               |
-| `lang`                                 | en, ja, de, fr, etc. (29 langs) | Interface language                             |
+| `lang`                                 | en, ja, de, fr, etc. (29 langs) | Interface language (server-side + client-side)  |
 | `layer`                                | OpenStreetMap, Google Satellite | Base map                                       |
 | `show`                                 | rt                              | Filter to show only realtime sensors           |
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -188,19 +188,43 @@ Both the unified server and MCP server use DuckLake for analytics (tool usage lo
 
 ## Translations (i18n)
 
-Translations are stored in PostgreSQL (`translations` table) and loaded into memory at startup. The table is auto-created and seeded from the embedded `translations.json` if empty.
+Translations are stored in PostgreSQL (`translations` table) and loaded into memory at startup.
 
-**Run the extended UI translations migration:**
-```bash
-ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
-  "psql -h 127.0.0.1 -U postgres -d safecast -f /tmp/add_ui_translations.sql"
-```
+### How Seeding Works
+
+On every startup, `seedTranslationsDB()` reads the embedded `translations.json` and inserts any missing keys using `ON CONFLICT DO NOTHING`. This means:
+- New translation keys added to `translations.json` are automatically seeded on next deploy
+- Existing DB values (including admin edits) are never overwritten
+- No manual migration is needed when adding new keys
+
+### Language Selection Priority
+
+1. `?lang=` URL parameter (e.g., `/?lang=ja`) — checked first, server-side
+2. `Accept-Language` HTTP header from the browser
+3. Falls back to English (`en`)
+
+### Performance: Filtered TranslationsJSON
+
+Only the active language + English fallback are embedded in the page HTML (`TranslationsJSON`), reducing the payload from ~850KB (all 30 languages) to ~30KB. This keeps the AI assistant widget within Claude's 200K token context limit. Server-side template rendering (`{{translate "key"}}`) still uses the full translations map.
+
+### Branding Rule
+
+"Safecast" must remain untranslated as a brand name in all languages. Never translate it to local equivalents.
 
 **Admin UI:** `/admin/translations` — edit translations live, then click "Reload into Memory" to apply without restart.
 
 **Supported languages (29):** ar, bg, cs, da, de, el, en, es, fa, fi, fr, he, hi, hu, id, it, ja, ko, ms, nl, no, pl, pt, ru, sv, th, tr, uk, vi, zh
 
 **Translated components:** Map legend, AI assistant widget, login/register/forgot-password modals, user menu, search bar, spectrum viewer, coordinate input dialog, profile page.
+
+### Fixing Translations via SQL
+
+To fix a translation directly in the production DB:
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
+  "psql -h 127.0.0.1 -U postgres -d safecast -c \"UPDATE translations SET value = 'New value' WHERE language_code='ja' AND key='title'\""
+```
+Then restart the service to reload: `systemctl restart safecast-new-map`
 
 ## Server Configuration
 


### PR DESCRIPTION
## Summary
- **README.md**: Added "How it works" subsection to Translation Management covering:
  - `?lang=` URL parameter priority (server-side, not just client-side)
  - Incremental seeding with `ON CONFLICT DO NOTHING`
  - Filtered TranslationsJSON (~30KB vs ~850KB) for AI widget token limits
  - Safecast branding rule (never translate the brand name)
- **DEPLOYMENT.md**: Expanded i18n section with:
  - Seeding mechanics explanation
  - Language selection priority chain
  - Performance rationale for filtered translations
  - Branding rule
  - SQL instructions for fixing translations in production

## Test plan
- [ ] Review docs for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)