### PR TITLE
fix: restore admin user management API endpoints

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -9163,6 +9163,41 @@ func main() {
 			}
 		}))
 
+		// Admin user management API endpoints
+		http.HandleFunc("/api/admin/users/create", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			authManager.AdminCreateUserHandler(w, r)
+		}))
+		http.HandleFunc("/api/admin/users/", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			// Route to appropriate handler based on path suffix and method
+			path := r.URL.Path
+			if strings.HasSuffix(path, "/reset-password") {
+				authManager.AdminResetUserPasswordHandler(w, r)
+			} else if strings.HasSuffix(path, "/regenerate-api-key") {
+				authManager.AdminRegenerateAPIKeyHandler(w, r)
+			} else {
+				switch r.Method {
+				case http.MethodPut, http.MethodPatch:
+					authManager.AdminUpdateUserHandler(w, r)
+				case http.MethodDelete:
+					authManager.AdminDeleteUserHandler(w, r)
+				default:
+					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				}
+			}
+		}))
+		http.HandleFunc("/api/admin/users", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			authManager.AdminListUsersHandler(w, r)
+		}))
+
 	}
 
 	// Upload endpoint - protected with auth if required

--- a/pkg/auth/admin_handlers.go
+++ b/pkg/auth/admin_handlers.go
@@ -199,9 +199,11 @@ func (m *Manager) AdminUpdateUserHandler(w http.ResponseWriter, r *http.Request)
 	var req struct {
 		Email         *string `json:"email"`
 		Username      *string `json:"username"`
+		Password      *string `json:"password"`
 		IsActive      *bool   `json:"is_active"`
 		IsAdmin       *bool   `json:"is_admin"`
 		EmailVerified *bool   `json:"email_verified"`
+		ExternalID    *string `json:"external_id"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -249,6 +251,22 @@ func (m *Manager) AdminUpdateUserHandler(w http.ResponseWriter, r *http.Request)
 
 	if req.EmailVerified != nil {
 		targetUser.EmailVerified = *req.EmailVerified
+	}
+
+	if req.ExternalID != nil {
+		targetUser.ExternalID = *req.ExternalID
+	}
+
+	// Update password if provided
+	if req.Password != nil && *req.Password != "" {
+		if err := ValidatePassword(*req.Password); err != nil {
+			writeJSON(w, map[string]string{"error": err.Error()}, http.StatusBadRequest)
+			return
+		}
+		if err := UpdateUserPassword(r.Context(), m.DB, m.DBDriver, targetUserID, *req.Password); err != nil {
+			writeJSON(w, map[string]string{"error": "Failed to update password"}, http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Update user in database


### PR DESCRIPTION
## Summary
- The API routes for `/api/admin/users` were never wired up when the codebase was consolidated into `cmd/unified-server/`, so all user edit/create/delete operations from the admin UI returned 404
- Added route registrations for: list, create, update, delete, reset-password, and regenerate-api-key
- Enhanced the update handler to also accept `password` and `external_id` fields that the frontend sends

## Test plan
- [ ] Open `/admin/users` and verify the user list loads
- [ ] Click "Edit" on a user and verify the modal opens with pre-populated data
- [ ] Save an edit and verify the changes persist
- [ ] Test "Add User", "Delete", "Reset Password", and "Make Admin" / "Remove Admin" buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)