### PR TITLE
fix: remove duplicate admin user routes causing startup panic

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -9163,41 +9163,6 @@ func main() {
 			}
 		}))
 
-		// Admin user management API endpoints
-		http.HandleFunc("/api/admin/users/create", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
-			if !checkAdminAccess(w, r) {
-				return
-			}
-			authManager.AdminCreateUserHandler(w, r)
-		}))
-		http.HandleFunc("/api/admin/users/", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
-			if !checkAdminAccess(w, r) {
-				return
-			}
-			// Route to appropriate handler based on path suffix and method
-			path := r.URL.Path
-			if strings.HasSuffix(path, "/reset-password") {
-				authManager.AdminResetUserPasswordHandler(w, r)
-			} else if strings.HasSuffix(path, "/regenerate-api-key") {
-				authManager.AdminRegenerateAPIKeyHandler(w, r)
-			} else {
-				switch r.Method {
-				case http.MethodPut, http.MethodPatch:
-					authManager.AdminUpdateUserHandler(w, r)
-				case http.MethodDelete:
-					authManager.AdminDeleteUserHandler(w, r)
-				default:
-					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-				}
-			}
-		}))
-		http.HandleFunc("/api/admin/users", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
-			if !checkAdminAccess(w, r) {
-				return
-			}
-			authManager.AdminListUsersHandler(w, r)
-		}))
-
 	}
 
 	// Upload endpoint - protected with auth if required


### PR DESCRIPTION
## Summary
- Removes the duplicate `/api/admin/users` route registrations added in #39
- These routes were already registered in `pkg/httpapi/register.go`, causing a panic on startup: `pattern "/api/admin/users" conflicts with pattern "/api/admin/users"`
- The `AdminUpdateUserHandler` enhancement (password + external_id support) from #39 is preserved in `pkg/auth/admin_handlers.go`

## Test plan
- [ ] Verify service starts without panic
- [ ] Verify admin user management works (list, edit, create, delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)