### PR TITLE
fix: make Edit/Delete/Reset buttons visible in admin users table

### DIFF
--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -77,7 +77,8 @@
     .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
     .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
     .summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: var(--btn-border-radius); box-shadow: var(--shadow); }
-    table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); table-layout: fixed; }
+    .table-wrapper { overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); }
     th { background: var(--th-bg); color: white; padding: 12px; text-align: left; font-weight: 600; overflow: hidden; text-overflow: ellipsis; position: relative; }
     td { padding: 6px 8px; border-bottom: 1px solid var(--border-color); overflow: hidden; text-overflow: ellipsis; }
     .resize-handle { position: absolute; right: 0; top: 0; width: 5px; height: 100%; cursor: col-resize; background: transparent; z-index: 1; }
@@ -133,7 +134,8 @@
     .btn-warning:hover { background: #fb8c00; }
     .btn-edit { background: #2196F3; color: white; border: none; padding: 5px 10px; border-radius: var(--btn-border-radius); cursor: pointer; font-size: 0.85em; margin: 0 2px; }
     .btn-edit:hover { background: #1976D2; }
-    .actions-cell { white-space: nowrap; }
+    .actions-cell { white-space: normal; min-width: 180px; }
+    .actions-cell button { margin: 2px; }
     .api-key-cell { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: monospace; font-size: 0.85em; }
     .message { padding: 12px; margin-bottom: 15px; border-radius: var(--btn-border-radius); display: none; }
     .message.success { background: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
@@ -206,6 +208,7 @@
     <p>Click "Add User" to create your first user</p>
   </div>
 
+  <div class="table-wrapper">
   <table id="usersTable" style="display: none;">
     <thead>
       <tr>
@@ -240,6 +243,7 @@
     <tbody id="usersTableBody">
     </tbody>
   </table>
+  </div>
 
   <div id="pagination" class="pagination" style="display: none;">
     <div class="pagination-info">


### PR DESCRIPTION
## Summary
- The Edit, Reset Password, and Delete buttons in the Actions column were pushed off-screen
- Root cause: `table-layout: fixed` + `white-space: nowrap` on the actions cell made the buttons overflow past the viewport
- Fix: removed `table-layout: fixed`, allow action buttons to wrap, added horizontal scroll wrapper

## Test plan
- [ ] Verify Edit, Reset Password, and Delete buttons are visible in the Actions column
- [ ] Click Edit and verify the edit modal opens with user data

🤖 Generated with [Claude Code](https://claude.com/claude-code)