### PR TITLE
fix: unify chat_id so feedback votes match chat_questions rows

### DIFF
--- a/cmd/unified-server/chat_logging.go
+++ b/cmd/unified-server/chat_logging.go
@@ -63,7 +63,9 @@ func logChatQuestion(r *http.Request, question, source, model, sessionID string,
 
 // logChatQuestionWithAnswer inserts a complete chat_questions row including the answer.
 // DuckLake UPDATE silently corrupts large string values, so we do a single INSERT with all fields.
-func logChatQuestionWithAnswer(r *http.Request, question, source, model, sessionID string, historyLen int, clientTimestamp string, answer string) {
+// chatID must be the same value sent to the frontend as chat_id in the "done" event so that
+// feedback votes (POST /api/feedback) can be joined back to this row.
+func logChatQuestionWithAnswer(r *http.Request, question, source, model, sessionID string, historyLen int, clientTimestamp string, answer string, chatID int64) {
 	if !duckDBAvailable() {
 		return
 	}
@@ -93,7 +95,7 @@ func logChatQuestionWithAnswer(r *http.Request, question, source, model, session
 		clientTS = clientTimestamp
 	}
 
-	id := time.Now().UnixNano()
+	id := chatID
 
 	_, err := duckDB.Exec(`
 		INSERT INTO chat_questions (

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -292,7 +292,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 				if isCloudFront {
 					flushBuffer(w, buffer)
 				}
-				logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, cachedAnswer)
+				logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, cachedAnswer, embeddingChatID)
 				return
 			}
 		}
@@ -413,7 +413,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		}
 
 		finalAnswer := strings.TrimSpace(answerText.String())
-		logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, finalAnswer)
+		logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, finalAnswer, embeddingChatID)
 
 		// 3. Async: store Q&A + embedding in semantic cache for future lookups.
 		if len(embedding) > 0 && finalAnswer != "" {


### PR DESCRIPTION
## Summary
- `chat_questions.id` was generated with a separate `time.Now().UnixNano()` call, independent of `embeddingChatID` sent to the frontend
- `chat_feedback.chat_id` (from the browser) therefore never matched `chat_questions.id` in the LEFT JOIN
- Fix: pass `embeddingChatID` (UnixMilli, safe for JS) into `logChatQuestionWithAnswer` so both tables share the same ID

## Test plan
- [ ] Ask a question in the map widget or assistant
- [ ] Click 👍 or 👎
- [ ] Check Admin → MCP Analytics → Chat Questions — count should be > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)