### PR TITLE
feat: track insights RAG sidebar + MCP analytics inline editing

### DIFF
--- a/cmd/unified-server/admin_mcp.go
+++ b/cmd/unified-server/admin_mcp.go
@@ -401,6 +401,74 @@ var mcpTableKeyColumn = map[string]string{
 	"mcp_ai_query_log": "timestamp",
 }
 
+// mcpEditableColumns defines which columns can be edited per table.
+// Only text/content fields are included — IDs, timestamps, and computed
+// columns (thumbs_up/thumbs_down) are intentionally excluded.
+var mcpEditableColumns = map[string][]string{
+	"chat_questions":   {"question", "answer", "source", "model", "country", "browser", "os"},
+	"mcp_query_log":    {"params", "client_info"},
+	"mcp_ai_query_log": {"generated_query", "error"},
+}
+
+// adminMCPUpdateHandler updates editable fields of a single row.
+// PUT /api/admin/mcp/update?table=chat_questions&id=<key_value>
+// Body: JSON object with field names → new string values.
+func adminMCPUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	tableName := r.URL.Query().Get("table")
+	if _, ok := mcpTableColumns[tableName]; !ok {
+		http.Error(w, "Invalid table name", http.StatusBadRequest)
+		return
+	}
+	keyVal := r.URL.Query().Get("id")
+	if keyVal == "" {
+		http.Error(w, "Missing id parameter", http.StatusBadRequest)
+		return
+	}
+
+	var payload map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Build SET clause using only whitelisted editable columns.
+	var setClauses []string
+	var args []interface{}
+	for _, col := range mcpEditableColumns[tableName] {
+		if val, ok := payload[col]; ok {
+			setClauses = append(setClauses, fmt.Sprintf("%s = ?", col))
+			args = append(args, val)
+		}
+	}
+	if len(setClauses) == 0 {
+		http.Error(w, "No editable fields provided", http.StatusBadRequest)
+		return
+	}
+
+	keyCol := mcpTableKeyColumn[tableName]
+	args = append(args, keyVal)
+	query := fmt.Sprintf("UPDATE %s SET %s WHERE CAST(%s AS VARCHAR) = ?",
+		tableName, strings.Join(setClauses, ", "), keyCol)
+
+	if _, err := duckDB.Exec(query, args...); err != nil {
+		log.Printf("admin mcp update error: %v", err)
+		http.Error(w, "Update failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"}) //nolint:errcheck
+}
+
 func escapeLike(s string) string {
 	s = strings.ReplaceAll(s, "'", "''")
 	s = strings.ReplaceAll(s, "%", "")

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -10129,6 +10129,12 @@ func main() {
 			}
 			adminMCPDeleteHandler(w, r)
 		}))
+		http.HandleFunc("/api/admin/mcp/update", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {
+			if !checkAdminAccess(w, r) {
+				return
+			}
+			adminMCPUpdateHandler(w, r)
+		}))
 
 		// Serve admin Realtime page and API endpoints
 		http.HandleFunc("/admin/realtime", authManager.OptionalAuth(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -5401,7 +5401,9 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 		<div class="nav-left">
 			<button class="view-selected-btn" id="viewSelectedBtn" onclick="viewSelected()" disabled>View Selected on Map</button>
 			<button class="delete-selected-btn" id="deleteSelectedBtn" onclick="deleteSelected()" disabled>Delete Selected</button>
+			<button class="import-btn" onclick="importSafecastMeta()" id="importSafecastBtn" style="margin-left:10px;">Import Safecast API Metadata</button>
 		</div>
+		<div id="importMetaStatus" style="font-size:0.85em;color:var(--text-secondary);margin-top:4px;"></div>
 	</div>
 	<div class="import-form">
 		<h3>Import from Safecast API</h3>
@@ -6019,6 +6021,37 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 
 		function closeEditUpload() {
 			document.getElementById('editUploadModal').classList.remove('open');
+		}
+
+		function importSafecastMeta() {
+			if (!confirm('Fetch track names and comments from the old Safecast API for all imported tracks? This may take a minute.')) return;
+			const password = new URLSearchParams(window.location.search).get('password');
+			const btn = document.getElementById('importSafecastBtn');
+			const status = document.getElementById('importMetaStatus');
+			btn.disabled = true;
+			btn.textContent = 'Importing…';
+			status.textContent = 'Fetching metadata from api.safecast.org…';
+			fetch('/api/admin/tracks/import-safecast', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ password })
+			})
+			.then(r => r.json())
+			.then(data => {
+				btn.disabled = false;
+				btn.textContent = 'Import Safecast API Metadata';
+				if (data.ok) {
+					status.textContent = 'Done: ' + data.updated + ' track(s) updated.';
+					setTimeout(() => window.location.reload(), 1500);
+				} else {
+					status.textContent = 'Error: ' + (data.error || 'unknown');
+				}
+			})
+			.catch(err => {
+				btn.disabled = false;
+				btn.textContent = 'Import Safecast API Metadata';
+				status.textContent = 'Error: ' + err;
+			});
 		}
 
 		async function saveEditUpload() {

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -567,6 +567,11 @@ func RegisterMCP() {
 	mux.HandleFunc("/api/feedback", feedbackHandler)
 	http.HandleFunc("/api/feedback", feedbackHandler)
 
+	// Track insights: register on main mux (port 8765) using Go 1.22 pattern routing.
+	// The specific pattern "GET /api/track/{id}/insights" takes precedence over the
+	// pkg/httpapi catch-all "/api/track/" handler.
+	http.HandleFunc("GET /api/track/{id}/insights", trackInsightsHandler)
+
 	if apiKey != "" {
 		chatHandler := handleWebChat(mcpURL, apiKey, model)
 

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -114,6 +114,21 @@
     .modal h3 { margin-bottom: 10px; }
     .modal pre { white-space: pre-wrap; word-break: break-word; font-size: 0.9em; line-height: 1.5; background: var(--bg-primary); padding: 15px; border-radius: 8px; max-height: 60vh; overflow-y: auto; }
     .modal button { margin-top: 15px; padding: 8px 20px; background: var(--tab-active-bg); color: white; border: none; border-radius: var(--btn-border-radius); cursor: pointer; }
+
+    /* Edit modal */
+    .edit-modal { background: var(--bg-card); border-radius: 12px; padding: 24px; max-width: 700px; width: 90%; max-height: 85vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,0.3); }
+    .edit-modal h3 { margin-bottom: 16px; font-size: 1.1em; }
+    .edit-field { margin-bottom: 14px; }
+    .edit-field label { display: block; font-size: 0.82em; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: .04em; margin-bottom: 5px; }
+    .edit-field textarea, .edit-field input[type="text"] { width: 100%; padding: 8px 10px; border: 1px solid var(--border-color); border-radius: 6px; background: var(--bg-primary); color: var(--text-primary); font-size: 0.9em; font-family: inherit; resize: vertical; }
+    .edit-field textarea { min-height: 80px; }
+    .edit-btn-row { display: flex; gap: 10px; justify-content: flex-end; margin-top: 8px; }
+    .btn-cancel { padding: 8px 18px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); cursor: pointer; font-size: 0.9em; }
+    .btn-save { padding: 8px 18px; border: none; border-radius: var(--btn-border-radius); background: #4CAF50; color: white; cursor: pointer; font-size: 0.9em; font-weight: 600; }
+    .btn-save:disabled { opacity: 0.5; cursor: not-allowed; }
+    td.actions-col { white-space: nowrap; }
+    .btn-row-edit { padding: 3px 10px; font-size: 0.8em; border: 1px solid #e65100; border-radius: 4px; background: #ff6d00; color: white; cursor: pointer; }
+    .btn-row-edit:hover { background: #e65100; }
     .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
     .page-header h1 { margin: 0; }
     .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
@@ -164,6 +179,17 @@
   </div>
 </div>
 
+<div class="modal-overlay" id="editModalOverlay" onclick="closeEditModal()">
+  <div class="edit-modal" onclick="event.stopPropagation()">
+    <h3>Edit Row</h3>
+    <div id="editFields"></div>
+    <div class="edit-btn-row">
+      <button class="btn-cancel" onclick="closeEditModal()">Cancel</button>
+      <button class="btn-save" id="editSaveBtn" onclick="saveEdit()">Save</button>
+    </div>
+  </div>
+</div>
+
 <script>
 const PASSWORD = new URLSearchParams(window.location.search).get('password') || '';
 const AUTH_PARAM = PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '';
@@ -200,6 +226,84 @@ const KEY_COLUMNS = {
   'mcp_query_log': 'created_at',
   'mcp_ai_query_log': 'timestamp'
 };
+
+const EDITABLE_COLUMNS = {
+  'chat_questions':   ['question', 'answer', 'source', 'model', 'country', 'browser', 'os'],
+  'mcp_query_log':    ['params', 'client_info'],
+  'mcp_ai_query_log': ['generated_query', 'error']
+};
+
+let editRowIndex = null;
+
+function editRow(idx) {
+  const row = currentData[idx];
+  if (!row) return;
+  editRowIndex = idx;
+  const editableCols = EDITABLE_COLUMNS[currentTable] || [];
+  const container = document.getElementById('editFields');
+  container.innerHTML = '';
+  editableCols.forEach(col => {
+    const val = row[col] !== null && row[col] !== undefined ? String(row[col]) : '';
+    const isLong = EXPANDABLE.has(col);
+    const label = COLUMN_LABELS[col] || col;
+    const div = document.createElement('div');
+    div.className = 'edit-field';
+    if (isLong) {
+      div.innerHTML = `<label>${label}</label><textarea id="ef_${col}" rows="5">${escapeHtml(val)}</textarea>`;
+    } else {
+      div.innerHTML = `<label>${label}</label><input type="text" id="ef_${col}" value="${escapeHtml(val)}">`;
+    }
+    container.appendChild(div);
+  });
+  document.getElementById('editModalOverlay').classList.add('visible');
+  const first = container.querySelector('textarea, input');
+  if (first) first.focus();
+}
+
+function closeEditModal() {
+  document.getElementById('editModalOverlay').classList.remove('visible');
+  editRowIndex = null;
+}
+
+async function saveEdit() {
+  if (editRowIndex === null) return;
+  const row = currentData[editRowIndex];
+  const keyCol = KEY_COLUMNS[currentTable];
+  const keyVal = row[keyCol];
+  const editableCols = EDITABLE_COLUMNS[currentTable] || [];
+
+  const payload = {};
+  editableCols.forEach(col => {
+    const el = document.getElementById('ef_' + col);
+    if (el) payload[col] = el.value;
+  });
+
+  const saveBtn = document.getElementById('editSaveBtn');
+  saveBtn.disabled = true;
+  saveBtn.textContent = 'Saving…';
+
+  let url = `/api/admin/mcp/update?table=${currentTable}&id=${encodeURIComponent(String(keyVal))}`;
+  if (PASSWORD) url += '&password=' + encodeURIComponent(PASSWORD);
+
+  try {
+    const resp = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text || 'HTTP ' + resp.status);
+    }
+    closeEditModal();
+    fetchData();
+  } catch (err) {
+    alert('Save failed: ' + err.message);
+  } finally {
+    saveBtn.disabled = false;
+    saveBtn.textContent = 'Save';
+  }
+}
 
 // Build admin tabs
 function buildAdminTabs() {
@@ -328,7 +432,9 @@ async function fetchData() {
     // Build header
     const thead = document.getElementById('tableHead');
     const keyCol = KEY_COLUMNS[currentTable];
+    const hasEditable = (EDITABLE_COLUMNS[currentTable] || []).length > 0;
     let headerHTML = '<tr><th class="checkbox-col"><input type="checkbox" onchange="toggleAll(this)"></th>';
+    if (hasEditable) headerHTML += '<th style="width:60px"></th>';
     columns.forEach(col => {
       const label = COLUMN_LABELS[col] || col;
       const sortClass = currentSort === col ? (currentOrder === 'asc' ? 'sortable asc' : 'sortable desc') : 'sortable';
@@ -337,6 +443,7 @@ async function fetchData() {
     headerHTML += '</tr>';
     // Filter row
     headerHTML += '<tr class="filter-row"><th></th>';
+    if (hasEditable) headerHTML += '<th></th>';
     columns.forEach(col => {
       const label = COLUMN_LABELS[col] || col;
       headerHTML += `<th><input type="text" class="filter-input" placeholder="${label}..." onkeyup="filterTable()"></th>`;
@@ -350,6 +457,7 @@ async function fetchData() {
     data.forEach((row, idx) => {
       const keyVal = row[keyCol];
       bodyHTML += `<tr><td class="checkbox-col"><input type="checkbox" class="row-cb" value="${keyVal}" onchange="updateDeleteBtn()"></td>`;
+      if (hasEditable) bodyHTML += `<td class="actions-col"><button class="btn-row-edit" onclick="editRow(${idx})">Edit</button></td>`;
       columns.forEach(col => {
         let val = row[col];
         if (val === null || val === undefined) val = '';
@@ -579,9 +687,9 @@ document.addEventListener('DOMContentLoaded', () => {
   fetchData();
 });
 
-// Keyboard shortcut: Escape closes modal
+// Keyboard shortcut: Escape closes modals
 document.addEventListener('keydown', e => {
-  if (e.key === 'Escape') closeModal();
+  if (e.key === 'Escape') { closeModal(); closeEditModal(); }
 });
 </script>
 </body>

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -4037,10 +4037,25 @@ document.addEventListener('DOMContentLoaded', function () {
             map.fitBounds(trackBounds);
           }
         }
-        // Load RAG insights for this track in the sidebar.
-        if (typeof window.fetchTrackInsights === 'function') {
-          window.fetchTrackInsights(currentTrackID);
-        }
+        // Auto-open AI panel with cached insights if any exist for this track.
+        fetch('/api/track/' + encodeURIComponent(currentTrackID) + '/insights')
+          .then(function(r) { return r.json(); })
+          .then(function(ins) {
+            var hasData = (ins.insights && ins.insights.length > 0) ||
+                          (ins.location_notes && ins.location_notes.length > 0);
+            if (hasData && window.aiOpenPanel && window.aiAddMessageUI) {
+              window.aiOpenPanel();
+              var bubble = window.aiAddMessageUI('bot', '');
+              bubble.innerHTML = '';
+              // Re-use buildInsightBlock if already defined, otherwise defer.
+              if (window.buildInsightBlock) {
+                bubble.appendChild(window.buildInsightBlock(ins));
+              } else {
+                window._pendingInsights = { bubble: bubble, data: ins };
+              }
+            }
+          })
+          .catch(function() {});
       })
       .catch(function(err) {
         console.error('Error fetching track bounds:', err);
@@ -4479,6 +4494,12 @@ function createDateRangeSlider(){
 
   btnY.onclick = () => switchMode('year');
   btnM.onclick = () => switchMode('month');
+
+  // Show track insights pill button only in track view
+  var trackInsightsBtn = document.getElementById('track-insights-btn');
+  if (isTrackView && trackInsightsBtn) {
+    trackInsightsBtn.style.display = 'block';
+  }
 
   // Show back button only in track view
   if (isTrackView && btnBack) {
@@ -9802,6 +9823,8 @@ function selectHomeSearchResult(result, query) {
       top: 10px;
       left: -470px;
       width: 450px;
+      min-width: 280px;
+      max-width: 90vw;
       height: calc(100% - 20px);
       background: var(--modal-bg);
       color: var(--modal-text);
@@ -9813,15 +9836,28 @@ function selectHomeSearchResult(result, query) {
       border: var(--modal-border);
       font-family: var(--font-family-base);
       margin-left: 10px;
+      transition: left 0.3s ease;
     }
 
     #safecast-ai-panel.open {
       left: 10px;
     }
 
-    #safecast-ai-panel.expanded {
-      width: 700px;
-      max-width: 90vw;
+    /* Drag handle on the right edge */
+    #ai-panel-resize-handle {
+      position: absolute;
+      top: 0;
+      right: -4px;
+      width: 8px;
+      height: 100%;
+      cursor: ew-resize;
+      z-index: 10;
+      border-radius: 0 12px 12px 0;
+    }
+
+    #ai-panel-resize-handle:hover,
+    #ai-panel-resize-handle.dragging {
+      background: rgba(128,128,128,.25);
     }
 
     .ai-panel-header {
@@ -9850,7 +9886,6 @@ function selectHomeSearchResult(result, query) {
       gap: 8px;
     }
 
-    #safecast-ai-expand,
     #safecast-ai-close {
       background: none;
       border: none;
@@ -9864,7 +9899,6 @@ function selectHomeSearchResult(result, query) {
       transition: opacity 0.2s;
     }
 
-    #safecast-ai-expand:hover,
     #safecast-ai-close:hover {
       opacity: 1;
     }
@@ -10160,8 +10194,34 @@ function selectHomeSearchResult(result, query) {
       align-self: center;
     }
 
-    /* ── Track Insights Sidebar ────────────────────────────────── */
+    /* ── Track Insights button (pill, above AI toggle) ─────────── */
+    #track-insights-btn {
+      display: none;
+      position: fixed;
+      bottom: 90px;
+      left: 10px;
+      padding: 10px 18px;
+      background: #4caf50;
+      color: #fff;
+      font-weight: 700;
+      font-size: 13px;
+      border: none;
+      border-radius: 24px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+      cursor: pointer;
+      z-index: 2000;
+      white-space: nowrap;
+      transition: background 0.2s, transform 0.2s;
+    }
+    #track-insights-btn:hover { background: #388e3c; transform: scale(1.02); }
+    #track-insights-btn.loading { opacity: 0.7; cursor: wait; }
+
+    /* ── Track Insights right panel (hidden — kept for legacy) ─── */
     #track-insights-panel {
+      display: none !important;
+    }
+    /* ── (original panel CSS kept below but panel is hidden) ────── */
+    #track-insights-panel-unused {
       position: fixed;
       top: 10px;
       right: -470px;
@@ -10337,7 +10397,12 @@ function selectHomeSearchResult(result, query) {
     .ti-ask-btn:hover { background: #388e3c; }
   </style>
 
-  <!-- Track Insights Sidebar — shown automatically in single-track view -->
+  <!-- Track Insights pill button — visible only in single-track view -->
+  <button id="track-insights-btn" aria-label="Ask AI about this track">
+    Ask AI about this track
+  </button>
+
+  <!-- Track Insights right panel (hidden, replaced by left AI panel flow) -->
   <div id="track-insights-panel">
     <div class="ti-header">
       <div class="ti-header-text">
@@ -10360,21 +10425,13 @@ function selectHomeSearchResult(result, query) {
   </button>
 
   <div id="safecast-ai-panel">
+    <div id="ai-panel-resize-handle"></div>
     <div class="ai-panel-header">
       <div class="ai-panel-header-text">
         <h3>{{translate "ai_title"}}</h3>
         <span>{{translate "ai_subtitle"}}</span>
       </div>
       <div class="ai-header-actions">
-        <button id="safecast-ai-expand" title="{{translate "ai_expand"}}" aria-label="{{translate "ai_expand"}}">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
-            stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="15 3 21 3 21 9"></polyline>
-            <polyline points="9 21 3 21 3 15"></polyline>
-            <line x1="21" y1="3" x2="14" y2="10"></line>
-            <line x1="3" y1="21" x2="10" y2="14"></line>
-          </svg>
-        </button>
         <button id="safecast-ai-close" title="{{translate "ai_close"}}" aria-label="{{translate "ai_close"}}">&times;</button>
       </div>
     </div>
@@ -10431,47 +10488,58 @@ function selectHomeSearchResult(result, query) {
         }
       });
 
-      const expandBtn = document.getElementById('safecast-ai-expand');
-
-      closeBtn.addEventListener('click', () => {
+      function closePanel() {
         panel.classList.remove('open');
-        panel.classList.remove('expanded');
         setTimeout(() => {
-          if (typeof map !== 'undefined' && map.invalidateSize) {
-            map.invalidateSize();
-          }
+          if (typeof map !== 'undefined' && map.invalidateSize) map.invalidateSize();
         }, 300);
+      }
+
+      closeBtn.addEventListener('click', closePanel);
+
+      // Click outside to close
+      document.addEventListener('click', (e) => {
+        if (!panel.classList.contains('open')) return;
+        if (panel.contains(e.target)) return;
+        // Ignore clicks on the toggle button and the insights pill button
+        const toggle = document.getElementById('safecast-ai-toggle');
+        const insightsBtn = document.getElementById('track-insights-btn');
+        if (toggle && toggle.contains(e.target)) return;
+        if (insightsBtn && insightsBtn.contains(e.target)) return;
+        closePanel();
+      }, true);
+
+      // Drag-to-resize right edge
+      const resizeHandle = document.getElementById('ai-panel-resize-handle');
+      let _resizing = false, _resizeStartX = 0, _resizeStartW = 0;
+
+      resizeHandle.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        _resizing = true;
+        _resizeStartX = e.clientX;
+        _resizeStartW = panel.offsetWidth;
+        resizeHandle.classList.add('dragging');
+        document.body.style.cursor = 'ew-resize';
+        document.body.style.userSelect = 'none';
+        // Disable transition during drag for instant feedback
+        panel.style.transition = 'none';
       });
 
-      expandBtn.addEventListener('click', () => {
-        panel.classList.toggle('expanded');
-        const isExpanded = panel.classList.contains('expanded');
-        expandBtn.title = isExpanded ? translate('ai_collapse') : translate('ai_expand');
+      document.addEventListener('mousemove', (e) => {
+        if (!_resizing) return;
+        const delta = e.clientX - _resizeStartX;
+        const newW = Math.max(280, Math.min(window.innerWidth * 0.9, _resizeStartW + delta));
+        panel.style.width = newW + 'px';
+      });
 
-        // Update icon based on state
-        if (isExpanded) {
-          expandBtn.innerHTML = `
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="4 14 10 14 10 20"></polyline>
-              <polyline points="20 10 14 10 14 4"></polyline>
-              <line x1="14" y1="10" x2="21" y2="3"></line>
-              <line x1="3" y1="21" x2="10" y2="14"></line>
-            </svg>`;
-        } else {
-          expandBtn.innerHTML = `
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <polyline points="9 21 3 21 3 15"></polyline>
-              <line x1="21" y1="3" x2="14" y2="10"></line>
-              <line x1="3" y1="21" x2="10" y2="14"></line>
-            </svg>`;
-        }
-
-        setTimeout(() => {
-          if (typeof map !== 'undefined' && map.invalidateSize) {
-            map.invalidateSize();
-          }
-        }, 300);
+      document.addEventListener('mouseup', () => {
+        if (!_resizing) return;
+        _resizing = false;
+        resizeHandle.classList.remove('dragging');
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        panel.style.transition = '';
+        if (typeof map !== 'undefined' && map.invalidateSize) map.invalidateSize();
       });
 
       // Auto-grow textarea
@@ -10794,189 +10862,164 @@ function selectHomeSearchResult(result, query) {
         });
       }
 
-      // Expose so the Track Insights sidebar can reuse the same renderer.
+      // Expose renderers for the Track Insights button script.
       window.markdownToHTML = markdownToHTML;
+      window.aiAddMessageUI  = addMessageUI;
+      window.aiOpenPanel     = function() { panel.classList.add('open'); if (!initialMessageAdded) { addMessageUI('bot', translate('ai_greeting')); initialMessageAdded = true; } };
+      window.aiSubmitText    = function(text) { msgInput.value = text; form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true })); };
     })();
   </script>
 
-  <!-- Track Insights Sidebar JS -->
+  <!-- Track Insights button JS -->
   <script>
     (function () {
-      const panel   = document.getElementById('track-insights-panel');
-      const body    = document.getElementById('ti-body');
-      const closeBtn = document.getElementById('ti-close');
-      const askBtn  = document.getElementById('ti-ask-btn');
+      var btn = document.getElementById('track-insights-btn');
+      if (!btn) return;
 
-      // Open / close helpers
-      function openPanel()  { panel.classList.add('open'); }
-      function closePanel() { panel.classList.remove('open'); }
+      var md = function(t) { return (window.markdownToHTML || function(s){ return s; })(t); };
 
-      closeBtn.addEventListener('click', closePanel);
+      function buildInsightBlock(data) {
+        var wrap = document.createElement('div');
+        wrap.style.cssText = 'display:flex;flex-direction:column;gap:12px;width:100%;';
 
-      // "Ask AI about this track" — pre-fills the AI chat and opens it.
-      askBtn.addEventListener('click', function () {
-        var trackID = (typeof currentTrackID !== 'undefined') ? currentTrackID : '';
-        var msg = trackID
-          ? 'Tell me about the radiation measurements on track ' + trackID
-          : 'Tell me about the radiation measurements on this track';
+        var hdr = document.createElement('div');
+        hdr.style.cssText = 'font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;opacity:.5;';
+        hdr.textContent = 'Cached Track Insights (' + data.insights.length + ')';
+        wrap.appendChild(hdr);
 
-        var aiMsg    = document.getElementById('ai-msg');
-        var aiPanel  = document.getElementById('safecast-ai-panel');
-        var aiToggle = document.getElementById('safecast-ai-toggle');
-        var aiForm   = document.getElementById('ai-form');
+        data.insights.forEach(function(ins) {
+          var card = document.createElement('div');
+          card.style.cssText = 'background:var(--control-bg);border:1px solid var(--modal-border);border-radius:10px;padding:12px 14px;display:flex;flex-direction:column;gap:6px;';
 
-        if (!aiMsg || !aiPanel || !aiForm) return;
+          var q = document.createElement('div');
+          q.style.cssText = 'font-size:12px;font-weight:600;opacity:.7;';
+          q.textContent = ins.question;
 
-        // Open the AI panel if not already open.
-        if (!aiPanel.classList.contains('open')) {
-          aiToggle && aiToggle.click();
-        }
+          var a = document.createElement('div');
+          a.className = 'ai-bubble';
+          a.style.cssText = 'font-size:12px;max-height:120px;overflow:hidden;transition:max-height .3s;mask-image:linear-gradient(to bottom,black 60%,transparent 100%);-webkit-mask-image:linear-gradient(to bottom,black 60%,transparent 100%);';
+          a.innerHTML = md(ins.answer);
 
-        // Set the message text and trigger submit.
-        aiMsg.value = msg;
-        aiMsg.dispatchEvent(new Event('input')); // resize textarea
-        aiForm.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
-      });
+          var footer = document.createElement('div');
+          footer.style.cssText = 'display:flex;align-items:center;gap:6px;margin-top:4px;padding-top:4px;border-top:1px solid var(--modal-border);';
 
-      // Render a single insight card with formatted markdown answer.
-      function renderInsight(ins) {
-        var card = document.createElement('div');
-        card.className = 'ti-card';
+          var score = ins.feedback_score || 0;
 
-        var q = document.createElement('div');
-        q.className = 'ti-card-question';
-        q.textContent = ins.question;
+          function scoreBadge(n) {
+            return n ? ' <span style="display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 3px;border-radius:8px;background:rgba(128,128,128,.18);font-size:10px;font-weight:700;vertical-align:middle;line-height:1;">' + n + '</span>' : '';
+          }
 
-        var a = document.createElement('div');
-        a.className = 'ti-card-answer ai-bubble';
-        var render = window.markdownToHTML || function(t) { return t.replace(/</g,'&lt;'); };
-        a.innerHTML = render(ins.answer);
+          var upBtn = document.createElement('button');
+          upBtn.className = 'ai-feedback-btn' + (score > 0 ? ' active' : '');
+          upBtn.title = 'Helpful';
+          upBtn.innerHTML = '&#128077;' + scoreBadge(score > 0 ? score : 0);
 
-        var footer = document.createElement('div');
-        footer.className = 'ti-card-footer';
+          var downBtn = document.createElement('button');
+          downBtn.className = 'ai-feedback-btn' + (score < 0 ? ' active' : '');
+          downBtn.title = 'Not helpful';
+          downBtn.innerHTML = '&#128078;' + scoreBadge(score < 0 ? Math.abs(score) : 0);
 
-        var expandBtn = document.createElement('button');
-        expandBtn.className = 'ti-expand-btn';
-        expandBtn.textContent = 'Show more';
-        expandBtn.addEventListener('click', function () {
-          var expanded = a.classList.toggle('expanded');
-          expandBtn.textContent = expanded ? 'Show less' : 'Show more';
+          function makeVote(s, up, dn, sc) {
+            return function() {
+              fetch('/api/feedback', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({chat_id: ins.chat_id, score: s}) });
+              up.disabled = dn.disabled = true;
+              if (s === 1) { up.innerHTML = '&#128077;' + scoreBadge(sc+1); up.classList.add('active'); }
+              else         { dn.innerHTML = '&#128078;' + scoreBadge(Math.abs(sc-1)); dn.classList.add('active'); }
+            };
+          }
+          upBtn.onclick   = makeVote(1,  upBtn, downBtn, score);
+          downBtn.onclick = makeVote(-1, upBtn, downBtn, score);
+
+          var expandBtn = document.createElement('button');
+          expandBtn.className = 'ti-expand-btn';
+          expandBtn.textContent = 'Show more';
+          expandBtn.onclick = (function(el, exBtn) {
+            return function() {
+              var expanded = el.style.maxHeight === 'none';
+              el.style.maxHeight = expanded ? '120px' : 'none';
+              el.style.maskImage = expanded ? 'linear-gradient(to bottom,black 60%,transparent 100%)' : 'none';
+              el.style.webkitMaskImage = el.style.maskImage;
+              exBtn.textContent = expanded ? 'Show more' : 'Show less';
+            };
+          })(a, expandBtn);
+
+          footer.appendChild(upBtn);
+          footer.appendChild(downBtn);
+          footer.appendChild(expandBtn);
+          card.appendChild(q);
+          card.appendChild(a);
+          card.appendChild(footer);
+          wrap.appendChild(card);
         });
 
-        // Reuse the existing /api/feedback endpoint for thumbs.
-        var upBtn = document.createElement('button');
-        upBtn.className = 'ai-feedback-btn';
-        upBtn.title = 'Helpful';
-        upBtn.innerHTML = '&#128077;';
-
-        var downBtn = document.createElement('button');
-        downBtn.className = 'ai-feedback-btn';
-        downBtn.title = 'Not helpful';
-        downBtn.innerHTML = '&#128078;';
-
-        function vote(score) {
-          fetch('/api/feedback', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ chat_id: ins.chat_id, score: score })
+        if (data.location_notes && data.location_notes.length > 0) {
+          var nlbl = document.createElement('div');
+          nlbl.style.cssText = 'font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;opacity:.5;margin-top:4px;';
+          nlbl.textContent = 'Location Notes (' + data.location_notes.length + ')';
+          wrap.appendChild(nlbl);
+          data.location_notes.forEach(function(n) {
+            var nc = document.createElement('div');
+            nc.style.cssText = 'background:var(--control-bg);border:1px solid var(--modal-border);border-left:3px solid #4caf50;border-radius:8px;padding:10px 12px;font-size:12px;';
+            nc.className = 'ai-bubble';
+            nc.innerHTML = md(n.note);
+            var co = document.createElement('div');
+            co.style.cssText = 'font-size:10px;opacity:.5;margin-top:4px;';
+            co.textContent = n.lat.toFixed(4) + ', ' + n.lon.toFixed(4);
+            nc.appendChild(co);
+            wrap.appendChild(nc);
           });
-          upBtn.disabled = true;
-          downBtn.disabled = true;
-          (score === 1 ? upBtn : downBtn).classList.add('active');
         }
-        upBtn.addEventListener('click', function () { vote(1); });
-        downBtn.addEventListener('click', function () { vote(-1); });
-
-        footer.appendChild(upBtn);
-        footer.appendChild(downBtn);
-        footer.appendChild(expandBtn);
-
-        card.appendChild(q);
-        card.appendChild(a);
-        card.appendChild(footer);
-        return card;
+        return wrap;
       }
 
-      // Render a location note card with formatted markdown and expand/collapse.
-      function renderNote(note) {
-        var card = document.createElement('div');
-        card.className = 'ti-note-card';
-
-        var text = document.createElement('div');
-        text.className = 'ti-card-answer ai-bubble';
-        var render = window.markdownToHTML || function(t) { return t.replace(/</g, '&lt;'); };
-        text.innerHTML = render(note.note);
-
-        var footer = document.createElement('div');
-        footer.className = 'ti-card-footer';
-
-        var coords = document.createElement('div');
-        coords.className = 'ti-note-coords';
-        coords.textContent = note.lat.toFixed(4) + ', ' + note.lon.toFixed(4);
-
-        var expandBtn = document.createElement('button');
-        expandBtn.className = 'ti-expand-btn';
-        expandBtn.textContent = 'Show more';
-        expandBtn.addEventListener('click', function () {
-          var expanded = text.classList.toggle('expanded');
-          expandBtn.textContent = expanded ? 'Show less' : 'Show more';
-        });
-
-        footer.appendChild(coords);
-        footer.appendChild(expandBtn);
-
-        card.appendChild(text);
-        card.appendChild(footer);
-        return card;
-      }
-
-      // Fetch and render insights for the given track ID.
-      function fetchTrackInsights(trackID) {
+      btn.addEventListener('click', function () {
+        var trackID = (typeof currentTrackID !== 'undefined') ? currentTrackID : '';
         if (!trackID) return;
-        body.innerHTML = '<div class="ti-loading">Loading insights&hellip;</div>';
-        openPanel();
+
+        btn.classList.add('loading');
+        btn.textContent = 'Loading…';
 
         fetch('/api/track/' + encodeURIComponent(trackID) + '/insights')
-          .then(function (r) { return r.json(); })
-          .then(function (data) {
-            body.innerHTML = '';
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            btn.classList.remove('loading');
+            btn.textContent = 'Ask AI about this track';
 
-            var hasContent = false;
+            if (!window.aiOpenPanel) return;
+            window.aiOpenPanel();
 
-            if (data.insights && data.insights.length > 0) {
-              hasContent = true;
-              var label = document.createElement('div');
-              label.className = 'ti-section-label';
-              label.textContent = 'Cached knowledge (' + data.insights.length + ')';
-              body.appendChild(label);
-              data.insights.forEach(function (ins) {
-                body.appendChild(renderInsight(ins));
-              });
-            }
+            var hasInsights = data.insights && data.insights.length > 0;
+            var hasNotes    = data.location_notes && data.location_notes.length > 0;
 
-            if (data.location_notes && data.location_notes.length > 0) {
-              hasContent = true;
-              var label2 = document.createElement('div');
-              label2.className = 'ti-section-label';
-              label2.style.marginTop = '8px';
-              label2.textContent = 'Location notes (' + data.location_notes.length + ')';
-              body.appendChild(label2);
-              data.location_notes.forEach(function (n) {
-                body.appendChild(renderNote(n));
-              });
-            }
-
-            if (!hasContent) {
-              body.innerHTML = '<div class="ti-empty">No cached insights yet for this area.<br>Ask the AI a question to build up knowledge here.</div>';
+            if (hasInsights || hasNotes) {
+              if (window.aiAddMessageUI) {
+                var bubble = window.aiAddMessageUI('bot', '');
+                bubble.innerHTML = '';
+                bubble.appendChild(buildInsightBlock(data));
+              }
+            } else {
+              var msg = 'Tell me about the radiation measurements on track ' + trackID;
+              if (window.aiSubmitText) window.aiSubmitText(msg);
             }
           })
-          .catch(function () {
-            body.innerHTML = '<div class="ti-empty">Could not load insights.</div>';
+          .catch(function() {
+            btn.classList.remove('loading');
+            btn.textContent = 'Ask AI about this track';
+            if (window.aiOpenPanel) window.aiOpenPanel();
+            var msg = 'Tell me about the radiation measurements on track ' + (typeof currentTrackID !== 'undefined' ? currentTrackID : '');
+            if (window.aiSubmitText) window.aiSubmitText(msg);
           });
-      }
+      });
 
-      // Expose so the track-init code can call it after bounds are loaded.
-      window.fetchTrackInsights = fetchTrackInsights;
+      // Expose globally so auto-open code in bounds fetch can call it.
+      window.buildInsightBlock = buildInsightBlock;
+
+      // Handle pending auto-open if fetch completed before this script ran.
+      if (window._pendingInsights) {
+        var p = window._pendingInsights;
+        p.bubble.appendChild(buildInsightBlock(p.data));
+        window._pendingInsights = null;
+      }
     })();
   </script>
 

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10897,20 +10897,36 @@ function selectHomeSearchResult(result, query) {
         return card;
       }
 
-      // Render a location note card.
+      // Render a location note card with formatted markdown and expand/collapse.
       function renderNote(note) {
         var card = document.createElement('div');
         card.className = 'ti-note-card';
 
         var text = document.createElement('div');
-        text.textContent = note.note;
+        text.className = 'ti-card-answer ai-bubble';
+        var render = window.markdownToHTML || function(t) { return t.replace(/</g, '&lt;'); };
+        text.innerHTML = render(note.note);
+
+        var footer = document.createElement('div');
+        footer.className = 'ti-card-footer';
 
         var coords = document.createElement('div');
         coords.className = 'ti-note-coords';
         coords.textContent = note.lat.toFixed(4) + ', ' + note.lon.toFixed(4);
 
+        var expandBtn = document.createElement('button');
+        expandBtn.className = 'ti-expand-btn';
+        expandBtn.textContent = 'Show more';
+        expandBtn.addEventListener('click', function () {
+          var expanded = text.classList.toggle('expanded');
+          expandBtn.textContent = expanded ? 'Show less' : 'Show more';
+        });
+
+        footer.appendChild(coords);
+        footer.appendChild(expandBtn);
+
         card.appendChild(text);
-        card.appendChild(coords);
+        card.appendChild(footer);
         return card;
       }
 

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -4037,6 +4037,10 @@ document.addEventListener('DOMContentLoaded', function () {
             map.fitBounds(trackBounds);
           }
         }
+        // Load RAG insights for this track in the sidebar.
+        if (typeof window.fetchTrackInsights === 'function') {
+          window.fetchTrackInsights(currentTrackID);
+        }
       })
       .catch(function(err) {
         console.error('Error fetching track bounds:', err);
@@ -10155,7 +10159,198 @@ function selectHomeSearchResult(result, query) {
       border-radius: 6px;
       align-self: center;
     }
+
+    /* ── Track Insights Sidebar ────────────────────────────────── */
+    #track-insights-panel {
+      position: fixed;
+      top: 10px;
+      right: -470px;
+      width: 450px;
+      height: calc(100% - 20px);
+      background: var(--modal-bg);
+      color: var(--modal-text);
+      box-shadow: -4px 0 20px rgba(0, 0, 0, 0.3);
+      z-index: 2001;
+      display: flex;
+      flex-direction: column;
+      border-radius: 12px;
+      border: var(--modal-border);
+      font-family: var(--font-family-base);
+      margin-right: 10px;
+      transition: right 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    #track-insights-panel.open {
+      right: 10px;
+    }
+    .ti-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--modal-border);
+      flex-shrink: 0;
+    }
+    .ti-header-text h3 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--modal-text);
+    }
+    .ti-header-text span {
+      font-size: 11px;
+      color: var(--modal-text);
+      opacity: 0.7;
+      display: block;
+    }
+    #ti-close {
+      background: none;
+      border: none;
+      color: var(--modal-text);
+      opacity: 0.7;
+      font-size: 20px;
+      cursor: pointer;
+      padding: 4px 6px;
+      line-height: 1;
+      border-radius: 6px;
+      transition: opacity 0.2s;
+    }
+    #ti-close:hover { opacity: 1; }
+    .ti-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .ti-loading {
+      text-align: center;
+      padding: 40px 0;
+      color: var(--modal-text);
+      opacity: 0.5;
+      font-size: 13px;
+    }
+    .ti-empty {
+      text-align: center;
+      padding: 40px 20px;
+      color: var(--modal-text);
+      opacity: 0.5;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .ti-section-label {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--modal-text);
+      opacity: 0.5;
+      margin-bottom: 2px;
+    }
+    .ti-card {
+      background: var(--control-bg);
+      border: 1px solid var(--modal-border);
+      border-radius: 10px;
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .ti-card-question {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--modal-text);
+      line-height: 1.4;
+    }
+    .ti-card-answer {
+      font-size: 12px;
+      color: var(--modal-text);
+      line-height: 1.6;
+      max-height: 120px;
+      overflow: hidden;
+      transition: max-height 0.3s ease;
+      mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+      -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+    }
+    .ti-card-answer.expanded {
+      max-height: 2000px;
+      mask-image: none;
+      -webkit-mask-image: none;
+    }
+    /* Scale down markdown headings inside insight cards */
+    .ti-card-answer h1 { font-size: 14px !important; margin: 10px 0 4px !important; }
+    .ti-card-answer h2 { font-size: 13px !important; margin: 8px 0 4px !important; }
+    .ti-card-answer h3 { font-size: 12px !important; margin: 6px 0 3px !important; font-weight: 600; }
+    .ti-card-answer p  { margin: 0 0 6px 0; }
+    .ti-card-answer ul, .ti-card-answer ol { margin: 4px 0 6px 16px; padding: 0; }
+    .ti-card-answer li { margin: 2px 0; }
+    .ti-card-answer strong { font-weight: 600; }
+    .ti-card-footer {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 4px;
+      padding-top: 4px;
+      border-top: 1px solid var(--modal-border);
+    }
+    .ti-expand-btn {
+      font-size: 11px;
+      background: none;
+      border: none;
+      color: #4caf50;
+      cursor: pointer;
+      padding: 0;
+      margin-left: auto;
+    }
+    .ti-expand-btn:hover { text-decoration: underline; }
+    .ti-note-card {
+      background: var(--control-bg);
+      border: 1px solid var(--modal-border);
+      border-left: 3px solid #4caf50;
+      border-radius: 8px;
+      padding: 10px 12px;
+      font-size: 12px;
+      color: var(--modal-text);
+      opacity: 0.9;
+      line-height: 1.5;
+    }
+    .ti-note-coords {
+      font-size: 10px;
+      color: var(--modal-text);
+      opacity: 0.5;
+      margin-top: 4px;
+    }
+    .ti-ask-btn {
+      flex-shrink: 0;
+      margin: 0 20px 20px;
+      background: #4caf50;
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 11px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s;
+      width: calc(100% - 0px);
+    }
+    .ti-ask-btn:hover { background: #388e3c; }
   </style>
+
+  <!-- Track Insights Sidebar — shown automatically in single-track view -->
+  <div id="track-insights-panel">
+    <div class="ti-header">
+      <div class="ti-header-text">
+        <h3>Track Insights</h3>
+        <span>Cached AI knowledge for this area</span>
+      </div>
+      <button id="ti-close" title="Close" aria-label="Close insights panel">&times;</button>
+    </div>
+    <div class="ti-body" id="ti-body">
+      <div class="ti-loading">Loading insights&hellip;</div>
+    </div>
+    <button class="ti-ask-btn" id="ti-ask-btn">Ask AI about this track</button>
+  </div>
 
   <button id="safecast-ai-toggle" aria-label="{{translate "ai_open"}}">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10598,6 +10793,174 @@ function selectHomeSearchResult(result, query) {
           finish(false);
         });
       }
+
+      // Expose so the Track Insights sidebar can reuse the same renderer.
+      window.markdownToHTML = markdownToHTML;
+    })();
+  </script>
+
+  <!-- Track Insights Sidebar JS -->
+  <script>
+    (function () {
+      const panel   = document.getElementById('track-insights-panel');
+      const body    = document.getElementById('ti-body');
+      const closeBtn = document.getElementById('ti-close');
+      const askBtn  = document.getElementById('ti-ask-btn');
+
+      // Open / close helpers
+      function openPanel()  { panel.classList.add('open'); }
+      function closePanel() { panel.classList.remove('open'); }
+
+      closeBtn.addEventListener('click', closePanel);
+
+      // "Ask AI about this track" — pre-fills the AI chat and opens it.
+      askBtn.addEventListener('click', function () {
+        var trackID = (typeof currentTrackID !== 'undefined') ? currentTrackID : '';
+        var msg = trackID
+          ? 'Tell me about the radiation measurements on track ' + trackID
+          : 'Tell me about the radiation measurements on this track';
+
+        var aiMsg    = document.getElementById('ai-msg');
+        var aiPanel  = document.getElementById('safecast-ai-panel');
+        var aiToggle = document.getElementById('safecast-ai-toggle');
+        var aiForm   = document.getElementById('ai-form');
+
+        if (!aiMsg || !aiPanel || !aiForm) return;
+
+        // Open the AI panel if not already open.
+        if (!aiPanel.classList.contains('open')) {
+          aiToggle && aiToggle.click();
+        }
+
+        // Set the message text and trigger submit.
+        aiMsg.value = msg;
+        aiMsg.dispatchEvent(new Event('input')); // resize textarea
+        aiForm.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+      });
+
+      // Render a single insight card with formatted markdown answer.
+      function renderInsight(ins) {
+        var card = document.createElement('div');
+        card.className = 'ti-card';
+
+        var q = document.createElement('div');
+        q.className = 'ti-card-question';
+        q.textContent = ins.question;
+
+        var a = document.createElement('div');
+        a.className = 'ti-card-answer ai-bubble';
+        var render = window.markdownToHTML || function(t) { return t.replace(/</g,'&lt;'); };
+        a.innerHTML = render(ins.answer);
+
+        var footer = document.createElement('div');
+        footer.className = 'ti-card-footer';
+
+        var expandBtn = document.createElement('button');
+        expandBtn.className = 'ti-expand-btn';
+        expandBtn.textContent = 'Show more';
+        expandBtn.addEventListener('click', function () {
+          var expanded = a.classList.toggle('expanded');
+          expandBtn.textContent = expanded ? 'Show less' : 'Show more';
+        });
+
+        // Reuse the existing /api/feedback endpoint for thumbs.
+        var upBtn = document.createElement('button');
+        upBtn.className = 'ai-feedback-btn';
+        upBtn.title = 'Helpful';
+        upBtn.innerHTML = '&#128077;';
+
+        var downBtn = document.createElement('button');
+        downBtn.className = 'ai-feedback-btn';
+        downBtn.title = 'Not helpful';
+        downBtn.innerHTML = '&#128078;';
+
+        function vote(score) {
+          fetch('/api/feedback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ chat_id: ins.chat_id, score: score })
+          });
+          upBtn.disabled = true;
+          downBtn.disabled = true;
+          (score === 1 ? upBtn : downBtn).classList.add('active');
+        }
+        upBtn.addEventListener('click', function () { vote(1); });
+        downBtn.addEventListener('click', function () { vote(-1); });
+
+        footer.appendChild(upBtn);
+        footer.appendChild(downBtn);
+        footer.appendChild(expandBtn);
+
+        card.appendChild(q);
+        card.appendChild(a);
+        card.appendChild(footer);
+        return card;
+      }
+
+      // Render a location note card.
+      function renderNote(note) {
+        var card = document.createElement('div');
+        card.className = 'ti-note-card';
+
+        var text = document.createElement('div');
+        text.textContent = note.note;
+
+        var coords = document.createElement('div');
+        coords.className = 'ti-note-coords';
+        coords.textContent = note.lat.toFixed(4) + ', ' + note.lon.toFixed(4);
+
+        card.appendChild(text);
+        card.appendChild(coords);
+        return card;
+      }
+
+      // Fetch and render insights for the given track ID.
+      function fetchTrackInsights(trackID) {
+        if (!trackID) return;
+        body.innerHTML = '<div class="ti-loading">Loading insights&hellip;</div>';
+        openPanel();
+
+        fetch('/api/track/' + encodeURIComponent(trackID) + '/insights')
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            body.innerHTML = '';
+
+            var hasContent = false;
+
+            if (data.insights && data.insights.length > 0) {
+              hasContent = true;
+              var label = document.createElement('div');
+              label.className = 'ti-section-label';
+              label.textContent = 'Cached knowledge (' + data.insights.length + ')';
+              body.appendChild(label);
+              data.insights.forEach(function (ins) {
+                body.appendChild(renderInsight(ins));
+              });
+            }
+
+            if (data.location_notes && data.location_notes.length > 0) {
+              hasContent = true;
+              var label2 = document.createElement('div');
+              label2.className = 'ti-section-label';
+              label2.style.marginTop = '8px';
+              label2.textContent = 'Location notes (' + data.location_notes.length + ')';
+              body.appendChild(label2);
+              data.location_notes.forEach(function (n) {
+                body.appendChild(renderNote(n));
+              });
+            }
+
+            if (!hasContent) {
+              body.innerHTML = '<div class="ti-empty">No cached insights yet for this area.<br>Ask the AI a question to build up knowledge here.</div>';
+            }
+          })
+          .catch(function () {
+            body.innerHTML = '<div class="ti-empty">Could not load insights.</div>';
+          });
+      }
+
+      // Expose so the track-init code can call it after bounds are loaded.
+      window.fetchTrackInsights = fetchTrackInsights;
     })();
   </script>
 

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -241,6 +241,36 @@ func extractLocationKnowledge(chatID int64) {
 	}
 }
 
+// loadQAEmbeddingsForTrack fetches positively-rated Q&A rows that mention
+// the given track ID in the question or answer text.
+func loadQAEmbeddingsForTrack(trackID string) ([]qaEntry, error) {
+	like := "%" + trackID + "%"
+	rows, err := duckDB.Query(
+		`SELECT id, question, answer, embedding, feedback_score FROM qa_embeddings
+		 WHERE feedback_score > 0
+		 AND (question LIKE ? OR answer LIKE ?)`,
+		like, like,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []qaEntry
+	for rows.Next() {
+		var e qaEntry
+		var embJSON string
+		if err := rows.Scan(&e.ID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
+			continue
+		}
+		if err := json.Unmarshal([]byte(embJSON), &e.Embedding); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
 // loadQAEmbeddings fetches Q&A rows from DuckLake.
 // If positiveOnly is true, only rows with feedback_score > 0 are returned.
 func loadQAEmbeddings(positiveOnly bool) ([]qaEntry, error) {

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -203,7 +203,10 @@ func RecordFeedback(chatID int64, score int) error {
 	return nil
 }
 
-var coordRegexp = regexp.MustCompile(`(-?\d{1,3}\.\d{3,})[,\s]+(-?\d{1,3}\.\d{3,})`)
+// coordRegexp matches pairs of decimal numbers that look like lat/lon.
+// It handles both compact forms ("45.4248, -75.094") and the verbose
+// "Latitude: 45.4248..., Longitude: -75.094..." format the LLM often produces.
+var coordRegexp = regexp.MustCompile(`(-?\d{1,3}\.\d{3,})[^\d\-\n]{0,20}?(-?\d{1,3}\.\d{3,})`)
 
 // extractLocationKnowledge looks for lat/lon coordinates in the answer and
 // stores a note in location_knowledge so future questions about that area

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -37,7 +37,8 @@ const (
 
 // qaEntry is a row from qa_embeddings.
 type qaEntry struct {
-	ID            int64
+	ID            int64 // internal row id (time.Now().UnixNano())
+	ChatID        int64 // chat_id sent to the frontend for feedback linkage
 	Question      string
 	Answer        string
 	Embedding     []float32
@@ -246,7 +247,7 @@ func extractLocationKnowledge(chatID int64) {
 func loadQAEmbeddingsForTrack(trackID string) ([]qaEntry, error) {
 	like := "%" + trackID + "%"
 	rows, err := duckDB.Query(
-		`SELECT id, question, answer, embedding, feedback_score FROM qa_embeddings
+		`SELECT id, chat_id, question, answer, embedding, feedback_score FROM qa_embeddings
 		 WHERE feedback_score > 0
 		 AND (question LIKE ? OR answer LIKE ?)`,
 		like, like,
@@ -260,7 +261,7 @@ func loadQAEmbeddingsForTrack(trackID string) ([]qaEntry, error) {
 	for rows.Next() {
 		var e qaEntry
 		var embJSON string
-		if err := rows.Scan(&e.ID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
+		if err := rows.Scan(&e.ID, &e.ChatID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
 			continue
 		}
 		if err := json.Unmarshal([]byte(embJSON), &e.Embedding); err != nil {
@@ -274,7 +275,7 @@ func loadQAEmbeddingsForTrack(trackID string) ([]qaEntry, error) {
 // loadQAEmbeddings fetches Q&A rows from DuckLake.
 // If positiveOnly is true, only rows with feedback_score > 0 are returned.
 func loadQAEmbeddings(positiveOnly bool) ([]qaEntry, error) {
-	query := `SELECT id, question, answer, embedding, feedback_score FROM qa_embeddings`
+	query := `SELECT id, chat_id, question, answer, embedding, feedback_score FROM qa_embeddings`
 	if positiveOnly {
 		query += ` WHERE feedback_score > 0`
 	}
@@ -288,7 +289,7 @@ func loadQAEmbeddings(positiveOnly bool) ([]qaEntry, error) {
 	for rows.Next() {
 		var e qaEntry
 		var embJSON string
-		if err := rows.Scan(&e.ID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
+		if err := rows.Scan(&e.ID, &e.ChatID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
 			continue
 		}
 		if err := json.Unmarshal([]byte(embJSON), &e.Embedding); err != nil {

--- a/cmd/unified-server/track_insights.go
+++ b/cmd/unified-server/track_insights.go
@@ -1,0 +1,183 @@
+// track_insights.go — GET /api/track/{id}/insights
+//
+// Returns cached RAG responses (Q&A pairs with positive feedback) that are
+// spatially or semantically relevant to the given track, plus curated
+// location_knowledge notes that fall within the track's bounding box.
+//
+// Relevance ranking:
+//  1. Hard filter: only qa_embeddings with feedback_score > 0.
+//  2. Semantic similarity: embed "radiation measurements near <centroid>"
+//     and cosine-compare against stored embeddings (threshold = ragContextThreshold).
+//  3. Return top 5 by similarity score.
+//  4. Location notes: location_knowledge rows whose (lat, lon) falls inside bbox.
+//
+// Registration: http.HandleFunc("GET /api/track/{id}/insights", trackInsightsHandler)
+// in mcp_register.go, registered on http.DefaultServeMux (port 8765).
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"safecast-new-map/pkg/database"
+)
+
+// trackInsight is a single cached Q&A relevant to the track.
+type trackInsight struct {
+	ChatID          int64   `json:"chat_id"`
+	Question        string  `json:"question"`
+	Answer          string  `json:"answer"`
+	SimilarityScore float32 `json:"similarity_score"`
+	FeedbackScore   int     `json:"feedback_score"`
+}
+
+// trackLocationNote is a curated geographic note near the track.
+type trackLocationNote struct {
+	Lat          float64 `json:"lat"`
+	Lon          float64 `json:"lon"`
+	Note         string  `json:"note"`
+	SourceChatID int64   `json:"source_chat_id,omitempty"`
+}
+
+// trackInsightsResponse is the JSON payload for GET /api/track/{id}/insights.
+type trackInsightsResponse struct {
+	TrackID       string              `json:"track_id"`
+	Insights      []trackInsight      `json:"insights"`
+	LocationNotes []trackLocationNote `json:"location_notes"`
+}
+
+// trackInsightsHandler serves GET /api/track/{id}/insights.
+// Registered on http.DefaultServeMux via mcp_register.go using Go 1.22 pattern routing.
+func trackInsightsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	trackID := r.PathValue("id")
+	if trackID == "" {
+		writeError(w, http.StatusBadRequest, "track id required")
+		return
+	}
+
+	if !dbAvailable() {
+		writeError(w, http.StatusServiceUnavailable, "database not available")
+		return
+	}
+
+	// 1. Load bounding box from PostgreSQL.
+	bounds, found, err := db.GetTrackBounds(ctx, trackID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not load track bounds")
+		return
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "track not found")
+		return
+	}
+
+	resp := trackInsightsResponse{
+		TrackID:       trackID,
+		Insights:      insightsByEmbedding(ctx, bounds),
+		LocationNotes: locationNotesInBbox(bounds),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
+}
+
+// insightsByEmbedding returns the top-5 positively-rated Q&A pairs whose
+// embeddings are most similar to a query generated from the track centroid.
+func insightsByEmbedding(ctx context.Context, bounds database.Bounds) []trackInsight {
+	out := []trackInsight{}
+	if !duckDBAvailable() {
+		return out
+	}
+
+	centerLat := (bounds.MinLat + bounds.MaxLat) / 2
+	centerLon := (bounds.MinLon + bounds.MaxLon) / 2
+	autoQuery := fmt.Sprintf("radiation measurements near %.3f %.3f", centerLat, centerLon)
+
+	// getEmbedding ignores ctx (local feature-hash implementation).
+	embedding, err := getEmbedding(ctx, autoQuery)
+	if err != nil || len(embedding) == 0 {
+		return out
+	}
+
+	entries, err := loadQAEmbeddings(true) // positiveOnly = true
+	if err != nil {
+		return out
+	}
+
+	type scored struct {
+		e     qaEntry
+		score float32
+	}
+	// Include ALL positively-rated entries; the centroid auto-query is too
+	// generic to reach ragContextThreshold (0.50) against natural-language
+	// questions. We still rank by similarity so the most topically relevant
+	// results float to the top.
+	var candidates []scored
+	for _, e := range entries {
+		candidates = append(candidates, scored{e, cosineSimilarity(embedding, e.Embedding)})
+	}
+
+	// Partial sort: bring top-5 to the front.
+	limit := 5
+	if len(candidates) < limit {
+		limit = len(candidates)
+	}
+	for i := 0; i < limit; i++ {
+		for j := i + 1; j < len(candidates); j++ {
+			if candidates[j].score > candidates[i].score {
+				candidates[i], candidates[j] = candidates[j], candidates[i]
+			}
+		}
+	}
+
+	for _, c := range candidates[:limit] {
+		ans := c.e.Answer
+		if len(ans) > 800 {
+			ans = ans[:800] + "…"
+		}
+		out = append(out, trackInsight{
+			ChatID:          c.e.ID,
+			Question:        c.e.Question,
+			Answer:          ans,
+			SimilarityScore: c.score,
+			FeedbackScore:   c.e.FeedbackScore,
+		})
+	}
+	return out
+}
+
+// locationNotesInBbox returns location_knowledge rows whose point falls
+// inside the track bounding box.
+func locationNotesInBbox(bounds database.Bounds) []trackLocationNote {
+	out := []trackLocationNote{}
+	if !duckDBAvailable() {
+		return out
+	}
+
+	rows, err := duckDB.Query(
+		`SELECT lat, lon, note, source_chat_id FROM location_knowledge
+		 WHERE lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?
+		 ORDER BY created_at DESC LIMIT 20`,
+		bounds.MinLat, bounds.MaxLat, bounds.MinLon, bounds.MaxLon,
+	)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var n trackLocationNote
+		var srcID sql.NullInt64
+		if rows.Scan(&n.Lat, &n.Lon, &n.Note, &srcID) == nil {
+			if srcID.Valid {
+				n.SourceChatID = srcID.Int64
+			}
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/cmd/unified-server/track_insights.go
+++ b/cmd/unified-server/track_insights.go
@@ -137,14 +137,10 @@ func insightsByEmbedding(ctx context.Context, bounds database.Bounds, trackID st
 	}
 
 	for _, c := range candidates[:limit] {
-		ans := c.e.Answer
-		if len(ans) > 800 {
-			ans = ans[:800] + "…"
-		}
 		out = append(out, trackInsight{
-			ChatID:          c.e.ID,
+			ChatID:          c.e.ChatID,
 			Question:        c.e.Question,
-			Answer:          ans,
+			Answer:          c.e.Answer,
 			SimilarityScore: c.score,
 			FeedbackScore:   c.e.FeedbackScore,
 		})

--- a/cmd/unified-server/track_insights.go
+++ b/cmd/unified-server/track_insights.go
@@ -78,7 +78,7 @@ func trackInsightsHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp := trackInsightsResponse{
 		TrackID:       trackID,
-		Insights:      insightsByEmbedding(ctx, bounds),
+		Insights:      insightsByEmbedding(ctx, bounds, trackID),
 		LocationNotes: locationNotesInBbox(bounds),
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -87,7 +87,7 @@ func trackInsightsHandler(w http.ResponseWriter, r *http.Request) {
 
 // insightsByEmbedding returns the top-5 positively-rated Q&A pairs whose
 // embeddings are most similar to a query generated from the track centroid.
-func insightsByEmbedding(ctx context.Context, bounds database.Bounds) []trackInsight {
+func insightsByEmbedding(ctx context.Context, bounds database.Bounds, trackID string) []trackInsight {
 	out := []trackInsight{}
 	if !duckDBAvailable() {
 		return out
@@ -103,7 +103,9 @@ func insightsByEmbedding(ctx context.Context, bounds database.Bounds) []trackIns
 		return out
 	}
 
-	entries, err := loadQAEmbeddings(true) // positiveOnly = true
+	// Load only Q&A that reference this specific track ID so the sidebar
+	// doesn't show insights from unrelated tracks.
+	entries, err := loadQAEmbeddingsForTrack(trackID)
 	if err != nil {
 		return out
 	}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -346,6 +346,60 @@ Rules are saved in `/etc/iptables/rules.v4` and restored automatically on reboot
 
 > **Background:** In March 2026 the BSI (via Hetzner abuse) flagged port 5432 as publicly accessible. The root cause was `listen_addresses` including the public IP. Both the config and firewall were fixed and the rules persisted.
 
+## Database Migrations
+
+### Running Migrations on Production
+
+Migration SQL files are in `migrations/`. Run them directly via SSH:
+
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
+  "psql -h 127.0.0.1 -U postgres -d safecast -f -" < migrations/your_migration.sql
+```
+
+Or for inline changes:
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
+  "psql -h 127.0.0.1 -U postgres -d safecast -c 'ALTER TABLE uploads ADD COLUMN IF NOT EXISTS comment VARCHAR;'"
+```
+
+### Columns Added Since Initial Import (Apr 2026)
+
+The following columns were added to the `uploads` table after the initial Safecast API import and must be migrated manually on any fresh production database:
+
+| Column | Migration file | Notes |
+|--------|---------------|-------|
+| `name` | `add_upload_metadata.sql` | Display name; back-filled from `filename` |
+| `notes` | `add_upload_metadata.sql` | Admin-only internal notes |
+| `comment` | *(inline)* | User comment from old Safecast API |
+
+After adding `name`/`comment`, back-fill from the old Safecast API (see below).
+
+### Back-filling Metadata from the Old Safecast API
+
+The admin Uploads page has an **"Import Safecast API Metadata"** button that fetches `name` and `comment` for all `safecast-api` tracks from `api.safecast.org`. For new imports this is automatic; the button is only needed as a one-time backfill for rows that existed before the columns were added.
+
+#### ⚠️ CloudFront timeout
+
+The button makes a synchronous browser request. CloudFront cuts connections after ~60 seconds, which only processes ~1,000 tracks before the request is killed. For a full backfill (~47k tracks, ~15 min), **run directly on the server via SSH** to bypass CloudFront:
+
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 \
+  "curl -s -X POST 'http://localhost:8765/api/admin/tracks/import-safecast' \
+   -H 'Content-Type: application/json' \
+   -d '{\"password\":\"ADMIN_PASSWORD\"}' \
+   --max-time 1800"
+```
+
+Expected response: `{"ok":true,"total":46380,"updated":46380}`
+
+The admin password is in the systemd service file:
+```bash
+ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 "systemctl cat safecast-new-map | grep admin-password"
+```
+
+**Note:** Many tracks have no comment in the old API (the uploader never wrote one) — this is normal. Only tracks where the uploader provided a description will have a non-empty `comment`.
+
 ## Related Documentation
 
 - [CloudFront Setup Guide](cloudfront-setup.md) - Initial CloudFront configuration

--- a/docs/track-detail-rag-sidebar.md
+++ b/docs/track-detail-rag-sidebar.md
@@ -1,0 +1,240 @@
+# Track-Detail RAG Insights Sidebar
+
+**Status:** Proposed  
+**Date:** 2026-04-02
+
+## Overview
+
+When a user enters "single track mode" (`/trackid/{id}`), a sidebar panel appears alongside the map showing cached RAG/MCP responses that are spatially and contextually relevant to the current track. The goal is to surface "what we already know" about the measurement area and session without requiring the user to ask a question manually.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Browser["Browser: map.html (isTrackView=true)"]
+        A[User navigates to /trackid/12345] --> B[JS: initTrackView]
+        B --> C[fetch /api/tracks/bounds]
+        C --> D[map.fitBounds + show sidebar]
+        D --> E[fetch /api/track/12345/insights]
+        E --> F[Render InsightsSidebar]
+        F --> G[Cached Q&A cards with thumbs up/down]
+        F --> H[Location Knowledge notes]
+        F --> I[Ask follow-up CTA - prefilled chat]
+    end
+
+    subgraph Server["Go Server: unified-server"]
+        E --> J[handleTrackInsights]
+        J --> K[Load track bbox from PostgreSQL]
+        K --> L[Query qa_embeddings where feedback_score > 0]
+        K --> M[Query location_knowledge within track bbox]
+        L --> N[Rank by spatial overlap and semantic similarity]
+        M --> N
+        N --> O[Return JSON: insights array]
+    end
+
+    subgraph RAG_Cache["DuckDB / DuckLake"]
+        L --> QA[(qa_embeddings)]
+        M --> LK[(location_knowledge)]
+    end
+
+    subgraph Chat["Chat Sidebar reused"]
+        I --> P[POST /chat with track_id, bbox, date]
+        P --> Q[handleWebChat + RAG context]
+        Q --> R[Stream response back]
+        R --> F
+    end
+```
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as map.html JS
+    participant S as Go Server
+    participant D as DuckDB/DuckLake
+    participant P as PostgreSQL
+
+    U->>M: Navigate to /trackid/12345
+    M->>S: GET /api/tracks/bounds?trackIDs=12345
+    S->>P: SELECT bbox for track 12345
+    P-->>S: min_lat, max_lat, min_lon, max_lon
+    S-->>M: bounds JSON
+    M->>M: fitBounds() + render sidebar skeleton
+
+    M->>S: GET /api/track/12345/insights
+    S->>D: SELECT qa_embeddings WHERE feedback_score > 0
+    S->>D: SELECT location_knowledge WHERE point IN bbox
+    S->>S: cosine_similarity + filter score >= 0.50
+    D-->>S: relevant Q&A + location notes
+    S-->>M: insights and location_notes JSON
+
+    M->>M: Render insight cards in sidebar
+
+    opt User clicks Ask about this track
+        U->>M: click CTA button
+        M->>S: POST /chat with track_context id, bbox, stats
+        S->>S: prepend track context to system prompt
+        S-->>M: NDJSON stream
+        M->>M: Append new card to sidebar
+    end
+```
+
+---
+
+## Relevance Ranking
+
+Insights are ranked by a combination of three signals:
+
+| Signal | Weight | Method |
+|---|---|---|
+| **Positive feedback gate** | Hard filter | Only surface `qa_embeddings` with `feedback_score > 0` |
+| **Spatial overlap** | High | `location_knowledge` rows whose `(lat, lon, radius_m)` intersects the track bounding box |
+| **Semantic similarity** | Medium | Auto-generate a query like `"radiation levels near [bbox centroid] on [track date]"`, embed it, cosine-compare against `qa_embeddings` (threshold ≥ 0.50) |
+| **Recency** | Tiebreak | Newer entries ranked higher when similarity scores are equal |
+
+---
+
+## New Backend Components
+
+### `GET /api/track/{id}/insights`
+
+New endpoint in [rest_tracks.go](../cmd/unified-server/rest_tracks.go).
+
+**Request:** `GET /api/track/12345/insights`
+
+**Response:**
+```json
+{
+  "track_id": 12345,
+  "insights": [
+    {
+      "chat_id": 789,
+      "question": "What radiation levels were measured near Fukushima in 2014?",
+      "answer": "Measurements in this area showed...",
+      "similarity_score": 0.82,
+      "feedback_score": 1
+    }
+  ],
+  "location_notes": [
+    {
+      "lat": 37.42,
+      "lon": 141.03,
+      "note": "Near Fukushima exclusion zone boundary. Elevated background expected.",
+      "source_chat_id": 456
+    }
+  ]
+}
+```
+
+### `handleTrackInsights()`
+
+New function in [semantic_cache.go](../cmd/unified-server/semantic_cache.go) (or a new `track_insights.go`).
+
+Logic:
+1. Load track bounding box from PostgreSQL
+2. Auto-generate a representative query string from track metadata (bbox centroid, date, detector type)
+3. Embed the query string using existing `getEmbedding()`
+4. Load all `qa_embeddings` where `feedback_score > 0` from DuckLake
+5. Compute cosine similarity; keep results ≥ 0.50, return top 5
+6. Load all `location_knowledge` rows whose point falls within the track bbox
+7. Return merged, ranked result
+
+### Track Context Injection
+
+When the user clicks "Ask about this track", the `POST /chat` body includes a `track_context` field:
+
+```json
+{
+  "message": "Tell me about the radiation levels on this track",
+  "track_context": {
+    "id": 12345,
+    "bbox": { "min_lat": 37.1, "max_lat": 37.5, "min_lon": 140.8, "max_lon": 141.2 },
+    "date": "2014-08-15",
+    "detector": "bGeigie Nano",
+    "measurement_count": 842
+  }
+}
+```
+
+`handleWebChat()` in [mcp_register.go](../cmd/unified-server/mcp_register.go) prepends this as structured context in the system prompt, grounding the LLM response in the specific track.
+
+---
+
+## New Frontend Components
+
+All changes go in [map.html](../cmd/unified-server/public_html/map.html).
+
+### Sidebar Panel
+
+- Mirrors the existing chat sidebar layout
+- Shown only when `isTrackView=true`
+- Positioned on the right side of the map, collapsible
+
+### Insight Card
+
+- Displays: question, answer (truncated with expand), similarity score badge, thumbs up/down
+- Reuses the existing `/api/feedback` endpoint for user scoring
+
+### Auto-load Trigger
+
+- `fetchTrackInsights(currentTrackID)` fires after `fitBounds()` completes
+- Shows a loading skeleton while fetching
+- Falls back gracefully if no cached insights exist ("No cached insights yet for this area")
+
+### "Ask about this track" Button
+
+- Pre-populates the chat with a context-aware prompt
+- Opens or expands the chat/sidebar panel
+- Passes `track_context` in the request body
+
+---
+
+## Existing Infrastructure Reused
+
+| Component | File | Reuse |
+|---|---|---|
+| Semantic cache lookup | `semantic_cache.go` | `getEmbedding()`, cosine similarity logic |
+| Feedback recording | `mcp_register.go:handleFeedback()` | Unchanged — insight cards use same endpoint |
+| Chat streaming | `mcp_register.go:handleWebChat()` | Extended to accept `track_context` |
+| Track bounds | `rest_tracks.go:handleTrackBounds()` | Called internally by insights handler |
+| DuckLake tables | `duckdb_analytics.go` | `qa_embeddings`, `location_knowledge` — no schema changes needed |
+
+---
+
+## Phased Implementation
+
+### Phase 1 — Read-only sidebar
+
+- New `GET /api/track/{id}/insights` endpoint
+- `handleTrackInsights()` with spatial + semantic ranking
+- Sidebar HTML/CSS in map.html (visible when `isTrackView=true`)
+- Auto-fetch and render cached Q&A cards on track load
+
+### Phase 2 — Interactive follow-up
+
+- "Ask about this track" CTA that pre-fills `/chat` with track context
+- `handleWebChat()` extended to accept and inject `track_context`
+- New chat responses on a track view are tagged with `track_id` in `chat_questions` table
+
+### Phase 3 — Richer signals
+
+- Display `location_knowledge` notes as map pins overlaid on the track view
+- "Why relevant" tooltip showing the similarity score
+- Positive feedback on a track insight auto-tags `location_knowledge` with the track's bbox centroid, creating a compounding knowledge loop
+
+---
+
+## Key File Locations
+
+| File | Role |
+|---|---|
+| [cmd/unified-server/rest_tracks.go](../cmd/unified-server/rest_tracks.go) | New `/api/track/{id}/insights` endpoint |
+| [cmd/unified-server/semantic_cache.go](../cmd/unified-server/semantic_cache.go) | `handleTrackInsights()` ranking logic |
+| [cmd/unified-server/mcp_register.go](../cmd/unified-server/mcp_register.go) | `handleWebChat()` track context injection |
+| [cmd/unified-server/duckdb_analytics.go](../cmd/unified-server/duckdb_analytics.go) | DuckLake table schema (no changes needed) |
+| [cmd/unified-server/public_html/map.html](../cmd/unified-server/public_html/map.html) | Sidebar UI + JS |


### PR DESCRIPTION
## Summary

- **Track Insights sidebar**: when a track has cached RAG/AI responses (positive feedback), the AI panel auto-opens on page load and displays them — formatted Q&A cards with expand/collapse and vote badges
- **Drag-to-resize AI panel**: replaced expand button with draggable right edge; click outside panel closes it
- **Vote persistence fix**: feedback clicks on cached insights now correctly update the DB (`chat_id` column was being confused with internal `id`)
- **MCP Analytics inline editing**: orange Edit button per row opens a modal to edit content fields (question, answer, source, model, params, etc.) via new `PUT /api/admin/mcp/update` endpoint with column whitelist

## Test plan

- [ ] Open a track that has had AI questions asked about it (with thumbs-up) — AI panel should auto-open with cached insights
- [ ] Drag the right edge of the AI panel to resize it
- [ ] Click outside the AI panel — it should close
- [ ] Click 👍/👎 on a cached insight card, refresh page — count should persist
- [ ] Visit `/admin/mcp?password=admin123`, click orange Edit button on a Chat Questions row, edit question/answer, save — verify change appears in table

🤖 Generated with [Claude Code](https://claude.com/claude-code)