### PR TITLE
feat: sort track insights by thumbs-up count

### DIFF
--- a/cmd/unified-server/track_insights.go
+++ b/cmd/unified-server/track_insights.go
@@ -124,13 +124,16 @@ func insightsByEmbedding(ctx context.Context, bounds database.Bounds, trackID st
 	}
 
 	// Partial sort: bring top-5 to the front.
+	// Primary: feedback_score descending (most-voted first).
+	// Tie-break: cosine similarity descending.
 	limit := 5
 	if len(candidates) < limit {
 		limit = len(candidates)
 	}
 	for i := 0; i < limit; i++ {
 		for j := i + 1; j < len(candidates); j++ {
-			if candidates[j].score > candidates[i].score {
+			iScore, jScore := candidates[i].e.FeedbackScore, candidates[j].e.FeedbackScore
+			if jScore > iScore || (jScore == iScore && candidates[j].score > candidates[i].score) {
 				candidates[i], candidates[j] = candidates[j], candidates[i]
 			}
 		}


### PR DESCRIPTION
## Summary

- Cached track insights are now ordered by `feedback_score` descending — the response with the most thumbs-up votes appears at the top
- Cosine similarity is used as a tie-breaker when scores are equal

## Test plan

- [ ] Open a track with multiple cached insights that have different vote counts — highest-voted response should appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)