### PR TITLE
feat: fix insight sort, collapsible notes, add admin tabs for cached data

### DIFF
--- a/cmd/unified-server/admin_mcp.go
+++ b/cmd/unified-server/admin_mcp.go
@@ -51,10 +51,14 @@ func adminMCPDataHandler(w http.ResponseWriter, r *http.Request) {
 
 	sortCol := r.URL.Query().Get("sort")
 	if !isValidColumn(sortCol, columns) {
-		// Default sort column: use "created_at" for mcp_query_log, "timestamp" for others
-		if tableName == "mcp_query_log" {
+		switch tableName {
+		case "mcp_query_log":
 			sortCol = "created_at"
-		} else {
+		case "qa_embeddings":
+			sortCol = "feedback_score"
+		case "location_knowledge":
+			sortCol = "created_at"
+		default:
 			sortCol = "timestamp"
 		}
 	}
@@ -232,8 +236,11 @@ func adminMCPExportHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	colList := strings.Join(exportCastCols, ", ")
 	orderCol := "timestamp"
-	if tableName == "mcp_query_log" {
+	switch tableName {
+	case "mcp_query_log", "location_knowledge":
 		orderCol = "created_at"
+	case "qa_embeddings":
+		orderCol = "feedback_score"
 	}
 	query := fmt.Sprintf("SELECT %s FROM %s %s ORDER BY %s DESC", colList, tableName, whereSQL, orderCol)
 
@@ -292,6 +299,12 @@ var mcpTableColumns = map[string][]string{
 		"user_id", "user_email", "session_id", "timestamp",
 		"tool_name", "generated_query", "duration_ms",
 		"commit_hash", "error",
+	},
+	"qa_embeddings": {
+		"id", "chat_id", "question", "answer", "feedback_score",
+	},
+	"location_knowledge": {
+		"id", "lat", "lon", "radius_m", "note", "source_chat_id", "created_at",
 	},
 }
 
@@ -399,6 +412,8 @@ var mcpTableKeyColumn = map[string]string{
 	"chat_questions":   "id",
 	"mcp_query_log":    "created_at",
 	"mcp_ai_query_log": "timestamp",
+	"qa_embeddings":    "id",
+	"location_knowledge": "id",
 }
 
 // mcpEditableColumns defines which columns can be edited per table.
@@ -408,6 +423,8 @@ var mcpEditableColumns = map[string][]string{
 	"chat_questions":   {"question", "answer", "source", "model", "country", "browser", "os"},
 	"mcp_query_log":    {"params", "client_info"},
 	"mcp_ai_query_log": {"generated_query", "error"},
+	"qa_embeddings":    {"question", "answer"},
+	"location_knowledge": {"note", "lat", "lon", "radius_m"},
 }
 
 // adminMCPUpdateHandler updates editable fields of a single row.

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -148,6 +148,8 @@
   <button class="active" onclick="switchTable('chat_questions')">Chat Questions</button>
   <button onclick="switchTable('mcp_query_log')">Tool Usage</button>
   <button onclick="switchTable('mcp_ai_query_log')">AI Query Log</button>
+  <button onclick="switchTable('qa_embeddings')">Cached Insights</button>
+  <button onclick="switchTable('location_knowledge')">Location Notes</button>
 </div>
 
 <div class="controls">
@@ -205,11 +207,14 @@ const COLUMN_LABELS = {
   client: 'Client', user_id: 'User ID', user_email: 'Email',
   created_at: 'Timestamp', client_info: 'Client', params: 'Params',
   generated_query: 'Query', commit_hash: 'Commit', error: 'Error',
-  thumbs_up: '👍', thumbs_down: '👎'
+  thumbs_up: '👍', thumbs_down: '👎',
+  chat_id: 'Chat ID', feedback_score: 'Score',
+  lat: 'Lat', lon: 'Lon', radius_m: 'Radius (m)', note: 'Note',
+  source_chat_id: 'Source Chat'
 };
 
 // Columns that should be expandable (long text)
-const EXPANDABLE = new Set(['question', 'answer', 'generated_query', 'user_agent', 'accept_language', 'referer', 'params']);
+const EXPANDABLE = new Set(['question', 'answer', 'generated_query', 'user_agent', 'accept_language', 'referer', 'params', 'note']);
 
 let currentTable = 'chat_questions';
 let currentSort = 'timestamp';
@@ -224,13 +229,17 @@ let currentColumns = [];
 const KEY_COLUMNS = {
   'chat_questions': 'id',
   'mcp_query_log': 'created_at',
-  'mcp_ai_query_log': 'timestamp'
+  'mcp_ai_query_log': 'timestamp',
+  'qa_embeddings': 'id',
+  'location_knowledge': 'id'
 };
 
 const EDITABLE_COLUMNS = {
   'chat_questions':   ['question', 'answer', 'source', 'model', 'country', 'browser', 'os'],
   'mcp_query_log':    ['params', 'client_info'],
-  'mcp_ai_query_log': ['generated_query', 'error']
+  'mcp_ai_query_log': ['generated_query', 'error'],
+  'qa_embeddings':    ['question', 'answer'],
+  'location_knowledge': ['note', 'lat', 'lon', 'radius_m']
 };
 
 let editRowIndex = null;
@@ -337,7 +346,9 @@ function switchTable(table) {
     btn.classList.toggle('active', btn.textContent === {
       'chat_questions': 'Chat Questions',
       'mcp_query_log': 'Tool Usage',
-      'mcp_ai_query_log': 'AI Query Log'
+      'mcp_ai_query_log': 'AI Query Log',
+      'qa_embeddings': 'Cached Insights',
+      'location_knowledge': 'Location Notes'
     }[table]);
   });
 

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10959,13 +10959,37 @@ function selectHomeSearchResult(result, query) {
           wrap.appendChild(nlbl);
           data.location_notes.forEach(function(n) {
             var nc = document.createElement('div');
-            nc.style.cssText = 'background:var(--control-bg);border:1px solid var(--modal-border);border-left:3px solid #4caf50;border-radius:8px;padding:10px 12px;font-size:12px;';
-            nc.className = 'ai-bubble';
-            nc.innerHTML = md(n.note);
+            nc.style.cssText = 'background:var(--control-bg);border:1px solid var(--modal-border);border-left:3px solid #4caf50;border-radius:10px;padding:12px 14px;display:flex;flex-direction:column;gap:6px;';
+
+            var noteBody = document.createElement('div');
+            noteBody.className = 'ai-bubble';
+            noteBody.style.cssText = 'font-size:12px;max-height:80px;overflow:hidden;transition:max-height .3s;mask-image:linear-gradient(to bottom,black 50%,transparent 100%);-webkit-mask-image:linear-gradient(to bottom,black 50%,transparent 100%);';
+            noteBody.innerHTML = md(n.note);
+
+            var nFooter = document.createElement('div');
+            nFooter.style.cssText = 'display:flex;align-items:center;justify-content:space-between;padding-top:4px;border-top:1px solid var(--modal-border);';
+
             var co = document.createElement('div');
-            co.style.cssText = 'font-size:10px;opacity:.5;margin-top:4px;';
+            co.style.cssText = 'font-size:10px;opacity:.5;';
             co.textContent = n.lat.toFixed(4) + ', ' + n.lon.toFixed(4);
-            nc.appendChild(co);
+
+            var nExpand = document.createElement('button');
+            nExpand.className = 'ti-expand-btn';
+            nExpand.textContent = 'Show more';
+            nExpand.onclick = (function(el, btn) {
+              return function() {
+                var expanded = el.style.maxHeight === 'none';
+                el.style.maxHeight = expanded ? '80px' : 'none';
+                el.style.maskImage = expanded ? 'linear-gradient(to bottom,black 50%,transparent 100%)' : 'none';
+                el.style.webkitMaskImage = el.style.maskImage;
+                btn.textContent = expanded ? 'Show more' : 'Show less';
+              };
+            })(noteBody, nExpand);
+
+            nFooter.appendChild(co);
+            nFooter.appendChild(nExpand);
+            nc.appendChild(noteBody);
+            nc.appendChild(nFooter);
             wrap.appendChild(nc);
           });
         }

--- a/cmd/unified-server/track_insights.go
+++ b/cmd/unified-server/track_insights.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"safecast-new-map/pkg/database"
 )
@@ -123,20 +124,18 @@ func insightsByEmbedding(ctx context.Context, bounds database.Bounds, trackID st
 		candidates = append(candidates, scored{e, cosineSimilarity(embedding, e.Embedding)})
 	}
 
-	// Partial sort: bring top-5 to the front.
-	// Primary: feedback_score descending (most-voted first).
-	// Tie-break: cosine similarity descending.
+	// Sort: primary = feedback_score descending, tie-break = cosine similarity descending.
+	sort.Slice(candidates, func(i, j int) bool {
+		fi, fj := candidates[i].e.FeedbackScore, candidates[j].e.FeedbackScore
+		if fi != fj {
+			return fi > fj
+		}
+		return candidates[i].score > candidates[j].score
+	})
+
 	limit := 5
 	if len(candidates) < limit {
 		limit = len(candidates)
-	}
-	for i := 0; i < limit; i++ {
-		for j := i + 1; j < len(candidates); j++ {
-			iScore, jScore := candidates[i].e.FeedbackScore, candidates[j].e.FeedbackScore
-			if jScore > iScore || (jScore == iScore && candidates[j].score > candidates[i].score) {
-				candidates[i], candidates[j] = candidates[j], candidates[i]
-			}
-		}
 	}
 
 	for _, c := range candidates[:limit] {


### PR DESCRIPTION
## Summary

- **Sort fix**: replaced buggy manual partial-sort with `sort.Slice` — highest thumbs-up count now reliably appears first in cached track insights
- **Collapsible location notes**: location notes in the insights panel now start collapsed (80px) with Show more / Show less, matching Q&A card behaviour
- **Admin tabs for cached data**: MCP Analytics page gains two new tabs:
  - **Cached Insights** (`qa_embeddings`) — view, edit, delete cached Q&A with feedback scores
  - **Location Notes** (`location_knowledge`) — view, edit, delete geographic notes
  - Previously, deleting from Chat Questions did not remove insights because they live in these separate tables

## Test plan

- [ ] Open a track with multiple cached insights — highest-voted response appears first
- [ ] Location notes start collapsed; "Show more" expands them
- [ ] Admin MCP → Cached Insights tab shows `qa_embeddings` rows with delete/edit
- [ ] Admin MCP → Location Notes tab shows `location_knowledge` rows with delete/edit
- [ ] Deleting rows from Cached Insights removes them from the track insights panel on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)