### PR TITLE
fix: add nginx route for /api/track/{id}/insights to map server

### DIFF
--- a/docs/cloudfront-mcp-setup.md
+++ b/docs/cloudfront-mcp-setup.md
@@ -93,6 +93,8 @@ server {
     location = /api/extreme   { proxy_pass http://localhost:3333/api/extreme; ... }
     location /api/info/       { proxy_pass http://localhost:3333/api/info/; ... }
     location /api/gpt/        { proxy_pass http://localhost:3333/api/gpt/; ... }
+    # Track insights lives on the map server (8765), must come BEFORE the broad /api/track/ rule
+    location ~ ^/api/track/[^/]+/insights { proxy_pass http://localhost:8765; ... }
     location /api/track/      { proxy_pass http://localhost:3333/api/track/; ... }
 
     # Map server — everything else (including /api/spectrum/, /api/markers/, etc.)


### PR DESCRIPTION
## Problem

`/api/track/` was routed to the MCP server (port 3333) by nginx. The track insights endpoint `/api/track/{id}/insights` lives on the map server (port 8765), so it returned **404 on production**.

This caused both reported issues:
- Track info not auto-opening when selecting a track (insights fetch returned 404 → `hasData=false` → panel never opened)
- Thumbs up/down counts not persisting (the `chat_id` values shown in the UI came from a 404 response, so feedback votes had no valid target)

## Fix

Added a regex location rule **before** the broad `/api/track/` rule in nginx:
```nginx
location ~ ^/api/track/[^/]+/insights { proxy_pass http://localhost:8765; ... }
location /api/track/ { proxy_pass http://localhost:3333/api/track/; ... }
```

Applied live to production nginx — verified working:
- `GET /api/track/8i4pbT/insights` → 200 with correct data ✅
- `POST /api/feedback` → feedback_score increments on refresh ✅

Also documented in `docs/cloudfront-mcp-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)