### PR TITLE
feat: combined API docs page, unified nav, dark mode fixes

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -9944,6 +9944,22 @@ func main() {
 				};
 				document.body.appendChild(btn);
 
+				// ── Dark-mode styles for preamble ──
+				const dmStyle = document.createElement('style');
+				dmStyle.textContent = [
+					'body.dark-mode #safecast-preamble { background: #1a2535 !important; border-bottom-color: #0d9488 !important; }',
+					'body.dark-mode #safecast-preamble h2 { color: #93c5fd !important; }',
+					'body.dark-mode #safecast-preamble > div > p { color: #b0b8c8 !important; }',
+					'body.dark-mode #safecast-preamble a[href*="creativecommons"] { color: #5eead4 !important; }',
+					'body.dark-mode #safecast-preamble summary { color: #93c5fd !important; }',
+					'body.dark-mode #safecast-preamble details > div > div { background: #0f1c2e !important; border-color: #2a3f5f !important; }',
+					'body.dark-mode #safecast-preamble details > div > div strong { color: #93c5fd !important; }',
+					'body.dark-mode #safecast-preamble details > div > div p { color: #8899aa !important; }',
+					'body.dark-mode #safecast-preamble details > div > p { color: #6b7a8d !important; }',
+					'body.dark-mode #safecast-preamble code { background: #0f1c2e !important; color: #5eead4 !important; }',
+				].join('\n');
+				document.head.appendChild(dmStyle);
+
 				// ── Preamble section (inserted before #swagger-ui) ──
 				const existing = document.getElementById('safecast-preamble');
 				if (existing) existing.remove();

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -9874,6 +9874,12 @@ func main() {
 	}
 	mcpDocsURL := strings.TrimRight(mcpBaseForDocs, "/") + "/mcp-api/"
 
+	// Combined API docs page (Map API + MCP API tabs)
+	http.HandleFunc("/docs/", serveAPIDocsPage)
+	http.HandleFunc("/docs", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/docs/", http.StatusMovedPermanently)
+	})
+
 	// Register Map API favicon and theme CSS endpoints
 	http.HandleFunc("/map-api/favicon.ico", serveFavicon)
 	http.HandleFunc("/map-api/favicon-16x16.png", serveFavicon16)

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -10084,6 +10084,17 @@ func main() {
 		}),
 	))
 
+	// Register MCP API swagger on port 8765 as well so the combined /docs/ page
+	// can fetch /mcp-api/doc.json without going to port 3333.
+	http.HandleFunc("/mcp-api/favicon.ico", serveFavicon)
+	http.HandleFunc("/mcp-api/favicon-16x16.png", serveFavicon16)
+	http.HandleFunc("/mcp-api/favicon-32x32.png", serveFavicon32)
+	http.HandleFunc("/mcp-api/swagger-theme.css", serveSwaggerTheme)
+	http.Handle("/mcp-api/", httpSwagger.Handler(
+		httpSwagger.URL("/mcp-api/doc.json"),
+		// default instance name "swagger" = MCP API spec from docs/docs.go
+	))
+
 	http.HandleFunc("/home", homeHandler)
 	http.HandleFunc("/", mapHandler)
 

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -5225,6 +5225,13 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 <html>
 <head>
 	<title>Admin - File Uploads</title>
+	<script>
+	(function() {
+		var saved = localStorage.getItem('safecastDocTheme');
+		var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+		document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+	})();
+	</script>
 
 	<!-- favicon -->
 	<link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
@@ -5261,41 +5268,34 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		:root[data-theme='light'] {
-			--bg-primary: #f5f5f5;
-			--bg-card: white;
-			--text-primary: #333;
-			--text-secondary: #666;
-			--text-muted: #999;
-			--border-color: #ddd;
-			--link-color: #0066cc;
-			--shadow: 0 1px 3px rgba(0,0,0,0.1);
-			--th-bg: #424242;
-			--hover-bg: #f9f9f9;
-			color-scheme: light;
+			--bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+			--text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+			--link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+			--hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
 		}
 		:root[data-theme='dark'] {
-			--bg-primary: #1a1a1a;
-			--bg-card: #2b2b2b;
-			--text-primary: #eee;
-			--text-secondary: #aaa;
-			--text-muted: #777;
-			--border-color: #444;
-			--link-color: #90caf9;
-			--shadow: 0 1px 3px rgba(255,255,255,0.1);
-			--th-bg: #616161;
-			--hover-bg: #333;
-			color-scheme: dark;
+			--bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+			--text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+			--link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+			--hover-bg: #333; --th-bg: #616161; color-scheme: dark;
 		}
-		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 20px; background: var(--bg-primary); color: var(--text-primary); }
+		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 0; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
 		h1 { color: var(--text-primary); }
+		.top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+		.nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+		.nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+		.nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+		.nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+		.nav-spacer { flex: 1; }
+		.back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+		.back-link:hover { color: #fff; }
+		#theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+		#theme-toggle:hover { background: rgba(255,255,255,0.22); }
+		.page-content { padding: 20px 24px; }
 		.nav { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); display: flex; align-items: center; justify-content: space-between; }
 		.nav-left { display: flex; align-items: center; gap: 15px; }
 		.nav a { color: var(--link-color); text-decoration: none; }
 		.nav a:hover { text-decoration: underline; }
-		.back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: 4px; text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-		.back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
-		.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-		.page-header h1 { margin: 0; }
 		.summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); }
 		table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); table-layout: auto; }
 		th { background: var(--th-bg); color: white; padding: 12px; text-align: left; font-weight: 600; white-space: nowrap; position: relative; overflow: hidden; }
@@ -5361,10 +5361,18 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 	</style>
 </head>
 <body>
-	<div class="page-header">
-		<h1>File Uploads Administration</h1>
-		<a href="/" class="back-to-map-btn">Back to Map</a>
-	</div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">File Uploads Administration</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">&#8592; Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">&#127769; Dark Mode</button>
+</nav>
+<div class="page-content">
 	<div class="admin-tabs">
 		<a href="/admin/users` + func() string {
 		if password != "" {
@@ -6107,6 +6115,22 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 			</div>
 		</div>
 	</div>
+</div><!-- .page-content -->
+<script>
+(function() {
+	function applyLabel() {
+		var btn = document.getElementById('theme-toggle');
+		if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+	}
+	applyLabel();
+	window.toggleTheme = function() {
+		var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+		document.documentElement.setAttribute('data-theme', next);
+		localStorage.setItem('safecastDocTheme', next);
+		applyLabel();
+	};
+})();
+</script>
 </body>
 </html>`
 
@@ -7160,6 +7184,13 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 <html>
 <head>
 	<title>Admin - All Tracks</title>
+	<script>
+	(function() {
+		var saved = localStorage.getItem('safecastDocTheme');
+		var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+		document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+	})();
+	</script>
 
 	<!-- favicon -->
 	<link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
@@ -7237,16 +7268,23 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 			--badge-spectrum-text: #81c784;
 			color-scheme: dark;
 		}
-		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 20px; background: var(--bg-primary); color: var(--text-primary); }
+		body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 0; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
 		h1 { color: var(--text-primary); }
+		.top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+		.nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+		.nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+		.nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+		.nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+		.nav-spacer { flex: 1; }
+		.back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+		.back-link:hover { color: #fff; }
+		#theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+		#theme-toggle:hover { background: rgba(255,255,255,0.22); }
+		.page-content { padding: 20px 24px; }
 		.nav { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); display: flex; align-items: center; justify-content: space-between; }
 		.nav-left { display: flex; align-items: center; gap: 15px; }
 		.nav a { color: var(--link-color); text-decoration: none; }
 		.nav a:hover { text-decoration: underline; }
-		.back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: 4px; text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-		.back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
-		.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-		.page-header h1 { margin: 0; }
 		.summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: 5px; box-shadow: var(--shadow); }
 		table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); }
 		th { background: var(--th-bg); color: white; padding: 12px; text-align: left; font-weight: 600; }
@@ -7304,10 +7342,18 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 	</style>
 </head>
 <body>
-	<div class="page-header">
-		<h1>All Tracks Administration</h1>
-		<a href="/" class="back-to-map-btn">Back to Map</a>
-	</div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">All Tracks Administration</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">&#8592; Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">&#127769; Dark Mode</button>
+</nav>
+<div class="page-content">
 	<div class="admin-tabs">
 		<a href="/admin/users` + func() string {
 		if password != "" {
@@ -7872,6 +7918,22 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 			updateDeleteButton();
 		}
 	</script>
+</div><!-- .page-content -->
+<script>
+(function() {
+	function applyLabel() {
+		var btn = document.getElementById('theme-toggle');
+		if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+	}
+	applyLabel();
+	window.toggleTheme = function() {
+		var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+		document.documentElement.setAttribute('data-theme', next);
+		localStorage.setItem('safecastDocTheme', next);
+		applyLabel();
+	};
+})();
+</script>
 </body>
 </html>`
 

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -2,6 +2,13 @@
 <html>
 <head>
   <title>MCP Analytics - Safecast Admin</title>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
@@ -40,8 +47,31 @@
         color-scheme: dark;
       }
     }
+    :root[data-theme='light'] {
+      --bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
+    }
+    :root[data-theme='dark'] {
+      --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+      --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+      --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+      --hover-bg: #333; --th-bg: #616161; color-scheme: dark;
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); padding: 20px; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+    .page-content { padding: 20px 24px; }
     h1 { margin-bottom: 15px; font-size: 1.6em; }
 
     /* Admin tab bar */
@@ -129,18 +159,21 @@
     td.actions-col { white-space: nowrap; }
     .btn-row-edit { padding: 3px 10px; font-size: 0.8em; border: 1px solid #e65100; border-radius: 4px; background: #ff6d00; color: white; cursor: pointer; }
     .btn-row-edit:hover { background: #e65100; }
-    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-    .page-header h1 { margin: 0; }
-    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-    .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
   </style>
 </head>
 <body>
-
-<div class="page-header">
-  <h1>MCP Analytics</h1>
-  <a href="/" class="back-to-map-btn">Back to Map</a>
-</div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">MCP Analytics</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
 
 <div class="admin-tabs" id="adminTabs"></div>
 
@@ -702,6 +735,22 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') { closeModal(); closeEditModal(); }
 });
+</script>
+</div><!-- .page-content -->
+<script>
+(function() {
+  function applyLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+  }
+  applyLabel();
+  window.toggleTheme = function() {
+    var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('safecastDocTheme', next);
+    applyLabel();
+  };
+})();
 </script>
 </body>
 </html>

--- a/cmd/unified-server/public_html/admin-realtime.html
+++ b/cmd/unified-server/public_html/admin-realtime.html
@@ -2,6 +2,13 @@
 <html>
 <head>
   <title>Realtime Devices - Safecast Admin</title>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
@@ -40,8 +47,31 @@
         color-scheme: dark;
       }
     }
+    :root[data-theme='light'] {
+      --bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
+    }
+    :root[data-theme='dark'] {
+      --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+      --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+      --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+      --hover-bg: #333; --th-bg: #616161; color-scheme: dark;
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); padding: 20px; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+    .page-content { padding: 20px 24px; }
     h1 { margin-bottom: 15px; font-size: 1.6em; }
 
     /* Admin tab bar */
@@ -107,18 +137,21 @@
     .modal h3 { margin-bottom: 10px; }
     .modal pre { white-space: pre-wrap; word-break: break-word; font-size: 0.9em; line-height: 1.5; background: var(--bg-primary); padding: 15px; border-radius: 8px; max-height: 60vh; overflow-y: auto; }
     .modal button { margin-top: 15px; padding: 8px 20px; background: var(--tab-active-bg); color: white; border: none; border-radius: var(--btn-border-radius); cursor: pointer; }
-    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-    .page-header h1 { margin: 0; }
-    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-    .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
   </style>
 </head>
 <body>
-
-<div class="page-header">
-  <h1>Realtime Devices</h1>
-  <a href="/" class="back-to-map-btn">Back to Map</a>
-</div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">Realtime Devices</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
 
 <div class="admin-tabs" id="adminTabs"></div>
 
@@ -525,6 +558,22 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') closeModal();
 });
+</script>
+</div><!-- .page-content -->
+<script>
+(function() {
+  function applyLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+  }
+  applyLabel();
+  window.toggleTheme = function() {
+    var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('safecastDocTheme', next);
+    applyLabel();
+  };
+})();
 </script>
 </body>
 </html>

--- a/cmd/unified-server/public_html/admin-translations.html
+++ b/cmd/unified-server/public_html/admin-translations.html
@@ -2,6 +2,13 @@
 <html>
 <head>
   <title>Translations - Safecast Admin</title>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
@@ -40,8 +47,31 @@
         color-scheme: dark;
       }
     }
+    :root[data-theme='light'] {
+      --bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
+    }
+    :root[data-theme='dark'] {
+      --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+      --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+      --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+      --hover-bg: #333; --th-bg: #616161; color-scheme: dark;
+    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); padding: 20px; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+    .page-content { padding: 20px 24px; }
     h1 { margin-bottom: 15px; font-size: 1.6em; }
 
     .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
@@ -109,20 +139,22 @@
     .modal .btn-cancel { background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border-color); padding: 10px 24px; border-radius: var(--btn-border-radius); cursor: pointer; font-size: 0.95em; }
     .modal .btn-cancel:hover { background: var(--hover-bg); }
 
-    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-    .page-header h1 { margin: 0; }
-    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-    .back-to-map-btn:hover { background: #1976D2 !important; }
-
     .lang-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; background: var(--tab-active-bg); color: white; font-size: 0.8em; font-weight: 600; }
   </style>
 </head>
 <body>
-
-<div class="page-header">
-  <h1>Translations</h1>
-  <a href="/" class="back-to-map-btn">Back to Map</a>
-</div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">Translations</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
 
 <div class="admin-tabs" id="adminTabs"></div>
 
@@ -507,6 +539,22 @@ document.addEventListener('keydown', function(e) {
 
 buildAdminTabs();
 fetchData();
+</script>
+</div><!-- .page-content -->
+<script>
+(function() {
+  function applyLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+  }
+  applyLabel();
+  window.toggleTheme = function() {
+    var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('safecastDocTheme', next);
+    applyLabel();
+  };
+})();
 </script>
 </body>
 </html>

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -2,6 +2,13 @@
 <html>
 <head>
   <title>User Administration - Safecast</title>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -66,16 +73,23 @@
       --hover-bg: #333;
       color-scheme: dark;
     }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 20px; background: var(--bg-primary); color: var(--text-primary); }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; margin: 0; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
     h1 { color: var(--text-primary); }
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+    .page-content { padding: 20px 24px; }
     .nav { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: var(--btn-border-radius); box-shadow: var(--shadow); display: flex; align-items: center; justify-content: space-between; }
     .nav-left { display: flex; align-items: center; gap: 15px; }
     .nav a { color: var(--link-color); text-decoration: none; }
     .nav a:hover { text-decoration: underline; }
-    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
-    .page-header h1 { margin: 0; }
-    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
-    .back-to-map-btn:hover { background: #1976D2 !important; text-decoration: none !important; }
     .summary { background: var(--bg-card); padding: 15px; margin-bottom: 20px; border-radius: var(--btn-border-radius); box-shadow: var(--shadow); }
     .table-wrapper { overflow-x: auto; }
     table { border-collapse: collapse; width: 100%; background: var(--bg-card); box-shadow: var(--shadow); }
@@ -163,10 +177,18 @@
   </style>
 </head>
 <body>
-  <div class="page-header">
-    <h1>User Administration</h1>
-    <a href="/" class="back-to-map-btn">Back to Map</a>
-  </div>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">User Administration</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
 
   <div class="admin-tabs" id="adminTabs"></div>
 
@@ -929,5 +951,21 @@
       }
     }
   </script>
+</div><!-- .page-content -->
+<script>
+(function() {
+  function applyLabel() {
+    var btn = document.getElementById('theme-toggle');
+    if (btn) btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+  }
+  applyLabel();
+  window.toggleTheme = function() {
+    var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('safecastDocTheme', next);
+    applyLabel();
+  };
+})();
+</script>
 </body>
 </html>

--- a/cmd/unified-server/rest.go
+++ b/cmd/unified-server/rest.go
@@ -314,15 +314,17 @@ body {
   top: 0;
   z-index: 100;
 }
-.top-nav .logo {
+.top-nav .nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-weight: 700;
   font-size: 17px;
-  letter-spacing: 0.02em;
   color: #fff;
   text-decoration: none;
   white-space: nowrap;
 }
-.top-nav .logo span { color: #7ecbff; }
+.top-nav .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
 .top-nav .back-link {
   color: #afd4f5;
   text-decoration: none;
@@ -488,7 +490,10 @@ body {
 <body>
 
 <nav class="top-nav">
-  <a href="/" class="logo">Safe<span>cast</span></a>
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
   <span style="color:rgba(255,255,255,0.3);font-size:18px;">|</span>
   <a href="/" class="back-link">← Back to Map</a>
   <span class="nav-title">API Documentation</span>

--- a/cmd/unified-server/rest.go
+++ b/cmd/unified-server/rest.go
@@ -234,6 +234,359 @@ func serveSwaggerTheme(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(mcpSwaggerThemeCSS))
 }
 
+// serveAPIDocsPage serves the combined Map API + MCP API documentation page with tabs.
+func serveAPIDocsPage(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(apiDocsPageHTML))
+}
+
+const apiDocsPageHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Safecast API Documentation</title>
+<link rel="stylesheet" href="/map-api/swagger-ui.css">
+<style>
+/* ── Admin-style CSS variables (matches admin pages exactly) ── */
+:root {
+  --bg-primary:   #f5f5f5;
+  --bg-card:      #fff;
+  --text-primary: #333;
+  --text-secondary:#666;
+  --text-muted:   #999;
+  --border-color: #ddd;
+  --link-color:   #0066cc;
+  --shadow:       0 1px 3px rgba(0,0,0,0.1);
+  --hover-bg:     #f9f9f9;
+  --th-bg:        #424242;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-primary:   #1a1a1a;
+    --bg-card:      #2b2b2b;
+    --text-primary: #eee;
+    --text-secondary:#aaa;
+    --text-muted:   #777;
+    --border-color: #444;
+    --link-color:   #90caf9;
+    --shadow:       0 1px 3px rgba(255,255,255,0.07);
+    --hover-bg:     #333;
+    --th-bg:        #616161;
+    color-scheme: dark;
+  }
+}
+:root[data-theme='light'] {
+  --bg-primary:   #f5f5f5; --bg-card: #fff; --text-primary: #333;
+  --text-secondary:#666; --text-muted: #999; --border-color: #ddd;
+  --link-color:   #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+  --hover-bg:     #f9f9f9; --th-bg: #424242; color-scheme: light;
+}
+:root[data-theme='dark'] {
+  --bg-primary:   #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+  --text-secondary:#aaa; --text-muted: #777; --border-color: #444;
+  --link-color:   #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+  --hover-bg:     #333; --th-bg: #616161; color-scheme: dark;
+}
+
+/* ── Layout ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Arial, sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  transition: background 0.2s, color 0.2s;
+}
+
+/* ── Top nav bar (matches admin pages) ── */
+.top-nav {
+  background: #1a3a5c;
+  color: #fff;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 52px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.top-nav .logo {
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: 0.02em;
+  color: #fff;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.top-nav .logo span { color: #7ecbff; }
+.top-nav .back-link {
+  color: #afd4f5;
+  text-decoration: none;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.top-nav .back-link:hover { color: #fff; }
+.top-nav .nav-title {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  color: #d0e8ff;
+  text-align: center;
+}
+#theme-toggle {
+  background: rgba(255,255,255,0.12);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.25);
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+#theme-toggle:hover { background: rgba(255,255,255,0.22); }
+
+/* ── Page content ── */
+.page-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+}
+
+/* ── Description card ── */
+.desc-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 20px 24px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow);
+}
+.desc-card h1 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+.desc-card p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+.desc-card a { color: var(--link-color); }
+
+/* ── API tabs (matches admin-tabs exactly) ── */
+.api-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 16px;
+  background: var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  width: fit-content;
+}
+.api-tab {
+  padding: 10px 28px;
+  border: none;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.95em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.api-tab:hover { background: var(--hover-bg); color: var(--text-primary); }
+.api-tab.active { background: #2196F3; color: #fff; }
+
+/* ── Swagger containers ── */
+.swagger-panel { display: none; }
+.swagger-panel.active { display: block; }
+.swagger-wrap {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+/* ── Swagger UI overrides — shared for both panels ── */
+.swagger-wrap .swagger-ui { background: var(--bg-card) !important; }
+.swagger-wrap .swagger-ui .info .title,
+.swagger-wrap .swagger-ui .info h1,
+.swagger-wrap .swagger-ui .info h2 { color: var(--text-primary) !important; }
+.swagger-wrap .swagger-ui .info .base-url,
+.swagger-wrap .swagger-ui .info p { color: var(--text-secondary) !important; }
+.swagger-wrap .swagger-ui .opblock-tag { color: var(--text-primary) !important; border-bottom: 1px solid var(--border-color) !important; }
+.swagger-wrap .swagger-ui .opblock { border-radius: 6px !important; margin-bottom: 6px !important; border: 1px solid var(--border-color) !important; background: var(--bg-card) !important; box-shadow: var(--shadow) !important; }
+.swagger-wrap .swagger-ui .opblock.opblock-get { border-color: #0066cc !important; background: #f0f6ff !important; }
+.swagger-wrap .swagger-ui .opblock.opblock-get .opblock-summary-method { background: #0066cc !important; border-radius: 4px !important; }
+.swagger-wrap .swagger-ui .opblock.opblock-post { border-color: #4caf50 !important; background: #f0fff4 !important; }
+.swagger-wrap .swagger-ui .opblock.opblock-post .opblock-summary-method { background: #4caf50 !important; border-radius: 4px !important; }
+.swagger-wrap .swagger-ui table thead tr th { background: var(--th-bg) !important; color: #fff !important; font-weight: 600 !important; }
+.swagger-wrap .swagger-ui table tbody tr:hover { background: var(--hover-bg) !important; }
+.swagger-wrap .swagger-ui .responses-inner { background: var(--bg-card) !important; border-radius: 6px !important; }
+.swagger-wrap .swagger-ui input[type=text],
+.swagger-wrap .swagger-ui textarea,
+.swagger-wrap .swagger-ui select { border-radius: 6px !important; border: 1px solid var(--border-color) !important; background: var(--bg-card) !important; color: var(--text-primary) !important; }
+.swagger-wrap .swagger-ui .btn.execute { background: #0066cc !important; border-color: #0066cc !important; border-radius: 6px !important; color: #fff !important; }
+.swagger-wrap .swagger-ui .btn.authorize { border-radius: 6px !important; color: #0066cc !important; border-color: #0066cc !important; }
+/* Code blocks — ensure readable text in light mode */
+.swagger-wrap .swagger-ui .microlight,
+.swagger-wrap .swagger-ui pre.microlight { background: #f6f8fa !important; color: #24292e !important; border-radius: 6px !important; border: 1px solid var(--border-color) !important; font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !important; font-size: 0.88rem !important; }
+.swagger-wrap .swagger-ui .microlight span { color: inherit !important; }
+/* Hide swagger topbar (we have our own nav) */
+.swagger-wrap .swagger-ui .topbar { display: none !important; }
+/* Hide doc.json info link */
+.swagger-wrap .swagger-ui .info .link,
+.swagger-wrap .swagger-ui .info a[href*="doc.json"] { display: none !important; }
+/* Scheme selector */
+.swagger-wrap .swagger-ui .scheme-container { background: var(--bg-card) !important; box-shadow: none !important; border-bottom: 1px solid var(--border-color) !important; padding: 10px 20px !important; }
+.swagger-wrap .swagger-ui .wrapper { padding: 16px 20px !important; }
+
+/* ── Dark mode overrides for swagger ── */
+[data-theme='dark'] .swagger-wrap .swagger-ui,
+[data-theme='dark'] .swagger-wrap .swagger-ui .wrapper { background: #1e1e1e !important; color: #eee !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock { background: #2b2b2b !important; border-color: #444 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock.opblock-get { background: #1a2940 !important; border-color: #90caf9 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock.opblock-get .opblock-summary-method { background: #1565c0 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock.opblock-post { background: #1a2e1a !important; border-color: #81c784 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock.opblock-post .opblock-summary-method { background: #388e3c !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock-summary-description,
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock-summary-path,
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock-tag,
+[data-theme='dark'] .swagger-wrap .swagger-ui p,
+[data-theme='dark'] .swagger-wrap .swagger-ui td,
+[data-theme='dark'] .swagger-wrap .swagger-ui label { color: #ddd !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui a { color: #90caf9 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .scheme-container { background: #1e1e1e !important; border-bottom-color: #444 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui select { background: #2b2b2b !important; color: #eee !important; border-color: #555 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui input[type=text],
+[data-theme='dark'] .swagger-wrap .swagger-ui textarea { background: #2b2b2b !important; color: #eee !important; border-color: #555 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .microlight,
+[data-theme='dark'] .swagger-wrap .swagger-ui pre.microlight { background: #0d1117 !important; color: #c9d1d9 !important; border-color: #444 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .responses-inner { background: #1e1e1e !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .model-box,
+[data-theme='dark'] .swagger-wrap .swagger-ui section.models { background: #2b2b2b !important; border-color: #444 !important; }
+[data-theme='dark'] .swagger-wrap { border-color: #444 !important; }
+[data-theme='dark'] .desc-card { border-color: #444 !important; }
+[data-theme='dark'] .swagger-wrap .swagger-ui .opblock-body { background: #222 !important; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .swagger-wrap .swagger-ui { background: #1e1e1e !important; color: #eee !important; }
+  :root:not([data-theme='light']) .swagger-wrap .swagger-ui .opblock { background: #2b2b2b !important; border-color: #444 !important; }
+  :root:not([data-theme='light']) .swagger-wrap .swagger-ui .opblock.opblock-get { background: #1a2940 !important; border-color: #90caf9 !important; }
+  :root:not([data-theme='light']) .swagger-wrap .swagger-ui .microlight,
+  :root:not([data-theme='light']) .swagger-wrap .swagger-ui pre.microlight { background: #0d1117 !important; color: #c9d1d9 !important; border-color: #444 !important; }
+}
+</style>
+</head>
+<body>
+
+<nav class="top-nav">
+  <a href="/" class="logo">Safe<span>cast</span></a>
+  <span style="color:rgba(255,255,255,0.3);font-size:18px;">|</span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <span class="nav-title">API Documentation</span>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+
+<div class="page-content">
+  <div class="desc-card">
+    <h1>Safecast API Documentation</h1>
+    <p>Safecast has collected over 200 million radiation measurements from citizen scientists worldwide.
+       All data is <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank">CC0 licensed</a>
+       and freely accessible — no account or API key required.</p>
+  </div>
+
+  <div class="api-tabs">
+    <button class="api-tab active" id="tab-btn-map" onclick="switchTab('map')">Map API</button>
+    <button class="api-tab" id="tab-btn-mcp" onclick="switchTab('mcp')">MCP API</button>
+  </div>
+
+  <div id="panel-map" class="swagger-panel active">
+    <div class="swagger-wrap"><div id="swagger-map"></div></div>
+  </div>
+  <div id="panel-mcp" class="swagger-panel">
+    <div class="swagger-wrap"><div id="swagger-mcp"></div></div>
+  </div>
+</div>
+
+<script src="/map-api/swagger-ui-bundle.js"></script>
+<script src="/map-api/swagger-ui-standalone-preset.js"></script>
+<script>
+(function() {
+  // ── Theme ──
+  var saved = localStorage.getItem('safecastDocTheme');
+  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var theme = saved || (prefersDark ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', theme);
+
+  function applyThemeLabel() {
+    var btn = document.getElementById('theme-toggle');
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    btn.textContent = isDark ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode';
+  }
+  applyThemeLabel();
+
+  window.toggleTheme = function() {
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    var next = isDark ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('safecastDocTheme', next);
+    applyThemeLabel();
+  };
+
+  // ── Tab switching ──
+  var mcpInitialized = false;
+  window.switchTab = function(tab) {
+    document.getElementById('panel-map').classList.toggle('active', tab === 'map');
+    document.getElementById('panel-mcp').classList.toggle('active', tab === 'mcp');
+    document.getElementById('tab-btn-map').classList.toggle('active', tab === 'map');
+    document.getElementById('tab-btn-mcp').classList.toggle('active', tab === 'mcp');
+    localStorage.setItem('safecastDocTab', tab);
+    if (tab === 'mcp' && !mcpInitialized) {
+      mcpInitialized = true;
+      initMCP();
+    }
+  };
+
+  // ── Initialize Map API swagger ──
+  SwaggerUIBundle({
+    url: '/map-api/doc.json',
+    domNode: document.getElementById('swagger-map'),
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    layout: 'BaseLayout',
+    deepLinking: false,
+    displayRequestDuration: true,
+    defaultModelsExpandDepth: -1,
+  });
+
+  // ── Initialize MCP API swagger (lazy — on first tab click) ──
+  function initMCP() {
+    SwaggerUIBundle({
+      url: '/mcp-api/doc.json',
+      domNode: document.getElementById('swagger-mcp'),
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+      layout: 'BaseLayout',
+      deepLinking: false,
+      displayRequestDuration: true,
+      defaultModelsExpandDepth: -1,
+    });
+  }
+
+  // ── Restore last active tab ──
+  var lastTab = localStorage.getItem('safecastDocTab');
+  if (lastTab === 'mcp') switchTab('mcp');
+})();
+</script>
+</body>
+</html>`
+
 // serveMapSwaggerTheme serves the Map API Swagger theme CSS (blue/navy accent).
 func serveMapSwaggerTheme(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/css")
@@ -414,10 +767,14 @@ body,
 .swagger-ui .microlight,
 .swagger-ui pre.microlight {
   background: #f6f8fa !important;
+  color: #24292e !important;
   border-radius: 8px !important;
   border: 1px solid #ddd !important;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !important;
   font-size: 0.9rem !important;
+}
+.swagger-ui .microlight span {
+  color: inherit !important;
 }
 
 /* Input fields */
@@ -714,10 +1071,14 @@ body,
 .swagger-ui .microlight,
 .swagger-ui pre.microlight {
   background: #f6f8fa !important;
+  color: #24292e !important;
   border-radius: 8px !important;
   border: 1px solid #ddd !important;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace !important;
   font-size: 0.9rem !important;
+}
+.swagger-ui .microlight span {
+  color: inherit !important;
 }
 
 /* Input fields */

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -427,6 +427,59 @@ ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 "systemctl cat safecast-new-map
 
 **Note:** Many tracks have no comment in the old API (the uploader never wrote one) — this is normal. Only tracks where the uploader provided a description will have a non-empty `comment`.
 
+## API Documentation Pages
+
+### Overview
+
+Three Swagger UI pages are served by the unified server (`safecast-new-map`, port 8765):
+
+| URL | Description |
+|-----|-------------|
+| `/docs/` | **Combined page** — Map API and MCP API in a tabbed interface |
+| `/map-api/` | Map API only (standalone Swagger UI) |
+| `/mcp-api/` | MCP API only (standalone Swagger UI) |
+
+All three support dark mode. `/docs/` is the canonical entry point.
+
+### Nginx routing
+
+All three paths are proxied from both nginx configs to port 8765:
+
+```nginx
+location /docs/     { proxy_pass http://localhost:8765/docs/; ... }
+location /mcp-api/  { proxy_pass http://localhost:8765/mcp-api/; ... }
+location /map-api/  { ... }  # falls through to the default location / block → 8765
+```
+
+**Note:** `/mcp-api/` requires an explicit nginx `location` block — it does NOT fall through to the default `location /` block because that block also goes to 8765 but earlier nginx configs had it pointing to port 3333 by mistake.
+
+### Combined docs page (`/docs/`)
+
+Implemented in `cmd/unified-server/rest.go` — `serveAPIDocsPage()` handler.
+
+- Admin-style CSS variables (`--bg-primary`, `--bg-card`, `--text-primary`, etc.) matching all admin pages
+- Tab bar uses the same `.api-tabs` pattern as admin `.admin-tabs`
+- Dark mode stored in `localStorage` key `safecastDocTheme`, applied via `data-theme` on `<html>`
+- MCP API swagger initialized **lazily** — only on first tab click (avoids loading both at page load)
+- Active tab persisted in `localStorage` key `safecastDocTab`
+- Both swagger instances use `BaseLayout` (no duplicate swagger topbars)
+- Swagger UI assets reused from `/map-api/swagger-ui-bundle.js`
+
+### Code block visibility fix (light mode)
+
+Swagger's microlight syntax highlighter was rendering code examples with near-invisible light text on a light background in light mode. Fixed in both theme CSS constants (`mapSwaggerThemeCSS`, `mcpSwaggerThemeCSS`) in `cmd/unified-server/rest.go`:
+
+```css
+.swagger-ui .microlight, .swagger-ui pre.microlight {
+  color: #24292e !important;  /* dark charcoal — was unset, defaulting to near-white */
+}
+.swagger-ui .microlight span { color: inherit !important; }
+```
+
+### Preamble dark mode fix (`/map-api/`)
+
+The white preamble header box (title, description, nav buttons) on `/map-api/` was not responding to dark mode. Fixed by injecting a `<style>` element via the `onComplete` JS callback with `body.dark-mode #safecast-preamble` rules.
+
 ## Related Documentation
 
 - [CloudFront Setup Guide](cloudfront-setup.md) - Initial CloudFront configuration
@@ -444,8 +497,9 @@ ssh -i ~/.ssh/safecast-deploy root@65.108.24.131 "systemctl cat safecast-new-map
 **Binary Path:** `/usr/local/bin/safecast-new-map`
 
 **API Documentation URLs:**
-- Map API Docs: `https://simplemap.safecast.org/map-api/`
-- MCP API Docs: `https://simplemap.safecast.org/mcp-api/`
+- **Combined docs (tabs):** `https://simplemap.safecast.org/docs/`
+- Map API only: `https://simplemap.safecast.org/map-api/`
+- MCP API only: `https://simplemap.safecast.org/mcp-api/`
 
 **One-Line Deploy:**
 ```bash


### PR DESCRIPTION
## Summary

- Combined Map API and MCP API Swagger docs into a single tabbed `/docs/` page styled like admin pages
- Unified sticky top-nav (logo, page title, Back to Map, light/dark toggle) across all admin pages and `/docs/`
- Fixed dark mode: preamble header on `/map-api/` now respects theme; code blocks readable in light mode
- Fixed `MAP_BASE_URL`/`MCP_BASE_URL` env vars so "Switch to API" cross-links point to production URL, not localhost
- Registered `/mcp-api/` swagger on port 8765 (default mux) so the combined `/docs/` page can load both API specs
- Added nginx `location /mcp-api/` and `location /docs/` blocks (both origin and CloudFront configs) pointing to port 8765
- CloudFront invalidation: `/mcp-api/*` and `/docs/*`

## Nginx changes (applied directly on server)
Both `/etc/nginx/sites-available/origin-simplemap.safecast.org` and `simplemap.safecast.org` updated.

## Test plan
- [ ] https://simplemap.safecast.org/docs/ loads with Map API and MCP API tabs
- [ ] Dark mode toggle works on all admin pages and `/docs/`
- [ ] "Switch to MCP API" / "Switch to Map API" links use production URL (not localhost)
- [ ] MCP API tab in `/docs/` loads Swagger spec without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)