### PR TITLE
fix: use explicit track_id for semantic cache to handle all-letter track IDs

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -287,7 +287,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 
 		if len(embedding) > 0 {
 			// 1. Check semantic cache: high-similarity + positive feedback → return instantly.
-			if cachedAnswer, _ := checkSemanticCache(embedding, chatReq.Message); cachedAnswer != "" {
+			if cachedAnswer, _ := checkSemanticCache(embedding, chatReq.Message, chatReq.TrackID); cachedAnswer != "" {
 				writeChunkBuffered(w, chunk{Type: "text", Text: cachedAnswer}, &buffer, isCloudFront)
 				writeChunkBuffered(w, chunk{Type: "done", ChatID: embeddingChatID, Cached: true}, &buffer, isCloudFront)
 				if isCloudFront {

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -71,9 +71,10 @@ func extractTrackID(s string) string {
 
 // checkSemanticCache looks for a positively-rated cached answer with high
 // cosine similarity to the given embedding.
-// question is used to detect a track ID so that cache hits from a different
-// track are never returned. Returns ("", 0) on miss.
-func checkSemanticCache(embedding []float32, question string) (answer string, chatID int64) {
+// trackID is the explicit track the user is viewing (may be ""); question is
+// used as a fallback to extract a track ID when trackID is empty. Cache hits
+// from a different track are never returned. Returns ("", 0) on miss.
+func checkSemanticCache(embedding []float32, question, trackID string) (answer string, chatID int64) {
 	if !duckDBAvailable() || len(embedding) == 0 {
 		return "", 0
 	}
@@ -83,9 +84,11 @@ func checkSemanticCache(embedding []float32, question string) (answer string, ch
 		return "", 0
 	}
 
-	// If the question references a specific track ID, only accept cache hits
-	// whose question/answer also mention that same track ID.
-	queryTrackID := extractTrackID(question)
+	// Prefer the explicit track ID; fall back to extracting from question text.
+	queryTrackID := trackID
+	if queryTrackID == "" {
+		queryTrackID = extractTrackID(question)
+	}
 
 	var bestScore float32
 	var best *qaEntry


### PR DESCRIPTION
## Summary
- `extractTrackID()` requires tokens with BOTH letters AND digits — track IDs like `FBjjkU` (all letters) were never matched, so the cache accepted answers about any other track as a valid hit
- `checkSemanticCache()` now takes an explicit `trackID` parameter; when the frontend sends `track_id` (set on single-track pages), that is used directly for filtering
- Regex extraction from question text is kept as fallback for general chat (no explicit track ID)

## Root cause
When user asks about track `FBjjkU`, `extractTrackID("Tell me about track FBjjkU")` returned `""` because `FBjjkU` has no digits. With no track guard, the cache returned the cached answer for `8i4pbT` (high semantic similarity between "tell me about track X" queries).

## Test plan
- [ ] Visit `/trackid/FBjjkU` on production — AI should answer about FBjjkU, not 8i4pbT
- [ ] Visit `/trackid/8i4pbT` — still returns cached answer for 8i4pbT correctly
- [ ] General chat (no track page) — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)