### PR TITLE
fix(chat): add data_preview response format to map widget system prompt

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -89,7 +89,36 @@ func truncateHistory(messages []anthropicMessage, maxTokens int) []anthropicMess
 
 const webChatSystemPrompt = `Safecast radiation monitoring assistant with REAL-TIME sensor data and historical archives.
 
-IMPORTANT: Never display the "_ai_generated_note" field from tool results — it is for internal use only and must not appear in your responses.`
+IMPORTANT: Never display the "_ai_generated_note" field from tool results — it is for internal use only and must not appear in your responses.
+
+-------------------------------------
+RESPONSE FORMAT FOR DATA QUERIES
+-------------------------------------
+
+When returning data (sensor readings, radiation measurements, etc.), use this JSON format instead of plain text:
+
+{
+  "type": "data_preview",
+  "summary": {
+    "rows_total": 3847,
+    "rows_shown": 50,
+    "time_range": "last 24h",
+    "region": "Tokyo"
+  },
+  "table": [...up to 50 rows as objects...],
+  "export_available": true,
+  "suggested_export": {
+    "format": "csv",
+    "limit": "full"
+  }
+}
+
+Rules:
+- Use this format whenever you retrieve tabular data (measurements, sensor readings, tracks).
+- The "table" array must be a flat array of objects with consistent keys.
+- Always set "export_available": true when data can be exported.
+- For plain conversational answers (no data), respond in normal markdown — do NOT wrap in JSON.
+- Never mix JSON and markdown in the same response.`
 
 func webChatSystemPromptForLang(lang string) string {
 	if lang == "" || lang == "en" {


### PR DESCRIPTION
## Summary

Follow-up to #69. The export buttons were not appearing in the map widget chat because the unified server's system prompt didn't instruct the AI to return structured \`data_preview\` JSON — it was only 2 lines compared to the web-chat's full 8-section spec.

## Fix

Added the response format spec to \`webChatSystemPrompt\` in \`mcp_register.go\`:
- When the AI retrieves tabular data, it now returns \`{"type":"data_preview",...}\` JSON
- Plain conversational answers still use markdown
- Matches the behaviour of the standalone \`/assistant/\` web-chat

## Test plan

- [ ] Ask the **map widget** chat: *"show me the latest dataset in Tokyo"*
- [ ] Verify data table with CSV / Excel / JSON buttons appears (was broken before)
- [ ] Plain questions like *"what is background radiation?"* still render as markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)