### PR TITLE
fix(chat): robustly extract data_preview JSON from mixed AI responses

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -118,7 +118,7 @@ Rules:
 - The "table" array must be a flat array of objects with consistent keys.
 - Always set "export_available": true when data can be exported.
 - For plain conversational answers (no data), respond in normal markdown — do NOT wrap in JSON.
-- Never mix JSON and markdown in the same response.`
+- CRITICAL: When returning data_preview JSON, output ONLY the raw JSON object — no introductory text, no trailing text, no markdown code fences. The response must start with { and end with }.`
 
 func webChatSystemPromptForLang(lang string) string {
 	if lang == "" || lang == "en" {

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10843,21 +10843,38 @@ function selectHomeSearchResult(result, query) {
         }
       }
 
-      function renderBotBubble(bubble, text) {
+      function extractJSON(text) {
+        // 1. Pure JSON
         const trimmed = text.trim();
         if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-          try {
-            const data = JSON.parse(trimmed);
-            if (data.type === 'data_preview') {
-              bubble.innerHTML = '';
-              renderDataPreview(data, bubble);
-              return;
-            } else if (data.type === 'export_request') {
-              bubble.innerHTML = '';
-              handleExportRequest(data, bubble);
-              return;
-            }
-          } catch (e) { /* fall through to markdown */ }
+          try { return JSON.parse(trimmed); } catch (e) {}
+        }
+        // 2. Markdown code fence: ```json ... ``` or ``` ... ```
+        const fenceMatch = trimmed.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+        if (fenceMatch) {
+          try { return JSON.parse(fenceMatch[1]); } catch (e) {}
+        }
+        // 3. JSON embedded anywhere in the text (greedy last { to last })
+        const start = text.indexOf('{');
+        const end = text.lastIndexOf('}');
+        if (start !== -1 && end > start) {
+          try { return JSON.parse(text.slice(start, end + 1)); } catch (e) {}
+        }
+        return null;
+      }
+
+      function renderBotBubble(bubble, text) {
+        const data = extractJSON(text);
+        if (data) {
+          if (data.type === 'data_preview') {
+            bubble.innerHTML = '';
+            renderDataPreview(data, bubble);
+            return;
+          } else if (data.type === 'export_request') {
+            bubble.innerHTML = '';
+            handleExportRequest(data, bubble);
+            return;
+          }
         }
         bubble.innerHTML = markdownToHTML(text);
       }


### PR DESCRIPTION
## Problem

After #70, the map widget was returning the JSON but wrapped in a code fence with introductory text:

> "I'll retrieve the latest radiation measurements from Tokyo for you.\`\`\`json { ... } \`\`\`"

\`renderBotBubble\` only checked for a pure \`{...\}` string, so it fell through to markdown rendering and displayed raw JSON text.

## Fix

- Add \`extractJSON()\` helper that handles three cases:
  1. Pure JSON (starts with \`{\`, ends with \`}\`)
  2. JSON inside markdown code fences (\`\`\`json ... \`\`\`)
  3. JSON embedded anywhere within surrounding text
- Tighten system prompt with a CRITICAL rule: output only raw JSON, no preamble, no code fences

## Test plan

- [ ] Map widget: *"show me the latest dataset in Tokyo"* → data table with export buttons
- [ ] Plain question → normal markdown response (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)