### PR TITLE
fix(chat): always show export buttons when table data is present

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10744,7 +10744,7 @@ function selectHomeSearchResult(result, query) {
         if (data.summary.region) metaText += ` in ${data.summary.region}`;
         header.innerHTML = `<div class="ai-data-meta">${metaText}</div>`;
 
-        if (data.export_available) {
+        if (data.table && data.table.length > 0) {
           const btnGroup = document.createElement('div');
           btnGroup.className = 'ai-export-group';
           ['CSV', 'Excel', 'JSON'].forEach(f => {

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -501,12 +501,12 @@
     
     header.innerHTML = `<div class="meta">${metaText}</div>`;
     
-    if (data.export_available) {
+    if (data.table && data.table.length > 0) {
       const btnGroup = document.createElement('div');
       btnGroup.className = 'export-group';
       btnGroup.style.display = 'flex';
       btnGroup.style.gap = '8px';
-      
+
       const formats = ['CSV', 'Excel', 'JSON'];
       formats.forEach(f => {
         const btn = document.createElement('button');


### PR DESCRIPTION
## Problem

After #71 the data table rendered correctly but export buttons were missing. The AI omitted \`export_available: true\` from its JSON response, so the condition gating the buttons was never true.

## Fix

Remove the \`export_available\` gate — show CSV / Excel / JSON buttons whenever \`data.table\` is non-empty. Applied to both the map widget (\`map.html\`) and the standalone web-chat (\`index.html\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)