### PR TITLE
fix(chat): fix extractJSON regex breaking on nested JSON braces

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10844,21 +10844,14 @@ function selectHomeSearchResult(result, query) {
       }
 
       function extractJSON(text) {
-        // 1. Pure JSON
-        const trimmed = text.trim();
-        if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-          try { return JSON.parse(trimmed); } catch (e) {}
-        }
-        // 2. Markdown code fence: ```json ... ``` or ``` ... ```
-        const fenceMatch = trimmed.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
-        if (fenceMatch) {
-          try { return JSON.parse(fenceMatch[1]); } catch (e) {}
-        }
-        // 3. JSON embedded anywhere in the text (greedy last { to last })
-        const start = text.indexOf('{');
-        const end = text.lastIndexOf('}');
+        // Strip markdown code fence prefix/suffix first, then find first { to last }
+        const stripped = text.trim()
+          .replace(/^```(?:json)?\s*/i, '')
+          .replace(/\s*```\s*$/, '');
+        const start = stripped.indexOf('{');
+        const end = stripped.lastIndexOf('}');
         if (start !== -1 && end > start) {
-          try { return JSON.parse(text.slice(start, end + 1)); } catch (e) {}
+          try { return JSON.parse(stripped.slice(start, end + 1)); } catch (e) {}
         }
         return null;
       }

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -660,9 +660,10 @@
       // Try to parse as data-aware JSON first
       let isDataAware = false;
       try {
-          const trimmed = text.trim();
-          if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-              const data = JSON.parse(trimmed);
+          const stripped = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '');
+          const s = stripped.indexOf('{'), e = stripped.lastIndexOf('}');
+          if (s !== -1 && e > s) {
+              const data = JSON.parse(stripped.slice(s, e + 1));
               if (data.type === 'data_preview') {
                   renderDataPreview(data, bubble);
                   isDataAware = true;


### PR DESCRIPTION
## Problem

After #72, the data table still rendered as raw JSON text. The \`extractJSON\` regex used \`[\s\S]*?\` (non-greedy) which stops at the **first** \`}\` found in the nested JSON object, causing \`JSON.parse\` to fail on the truncated string.

## Fix

Replace the regex approach with string slicing:
1. Strip markdown code fence prefix/suffix (\`\`\`\`json\`...\`\`\`\`\`)
2. \`indexOf('{')\` for start, \`lastIndexOf('}')\` for end
3. \`JSON.parse\` the slice

Applied to both \`map.html\` (\`extractJSON\`) and \`cmd/web-chat/index.html\` (\`addMessage\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)