### PR TITLE
fix(assistant): register /assistant/ on port 8765 (main map server)

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -799,10 +799,14 @@ func RegisterMCP() {
 		mux.HandleFunc("/chat", chatHandler)
 		mux.HandleFunc("/export", handleExport(mcpURL))
 
-		// Also register /chat and /export on main map server (port 8765) so the
-		// embedded widget can use relative URLs without cross-origin issues.
+		// Also register on main map server (port 8765) so relative URLs work
+		// and /assistant/ is reachable without going through port 3333.
 		http.HandleFunc("/chat", chatHandler)
 		http.HandleFunc("/export", handleExport(mcpURL))
+		http.HandleFunc("/assistant/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(webChatIndexHTML)
+		})
 
 		log.Printf("Web chat enabled at http://localhost:%s/assistant/ (model=%s)", mcpPort, model)
 	} else {


### PR DESCRIPTION
## Problem

Visiting \`http://localhost:8765/assistant/\` showed the map instead of the chat page. The \`/assistant/\` route was only registered on the MCP mux (port 3333), so requests on port 8765 fell through to the catch-all map handler.

## Fix

Register \`/assistant/\` on the main \`http\` mux (port 8765) alongside the existing \`/chat\` and \`/export\` registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)