### PR TITLE
fix(chat): show 'Loading data...' placeholder during JSON streaming

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -11054,7 +11054,14 @@ function selectHomeSearchResult(result, query) {
                       accumulated = '';
                     }
                     accumulated += ev.text;
-                    renderBotBubble(botBubble, accumulated);
+                    // During streaming: show markdown. If it looks like JSON,
+                    // show a neutral placeholder to avoid raw JSON flicker.
+                    const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                    if (looksLikeJSON) {
+                      botBubble.innerHTML = '<em style="color:var(--text-muted,#888);font-size:13px">Loading data...</em>';
+                    } else {
+                      botBubble.innerHTML = markdownToHTML(accumulated);
+                    }
                     messagesEl.scrollTop = messagesEl.scrollHeight;
                   } else if (ev.type === 'action' || ev.action) {
                     executeMapAction(ev);

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -858,7 +858,12 @@
                   accumulated = '';
                 }
                 accumulated += ev.text;
-                renderBotBubble(botBubble, accumulated);
+                const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                if (looksLikeJSON) {
+                  botBubble.innerHTML = '<em style="color:var(--muted,#888);font-size:13px">Loading data...</em>';
+                } else {
+                  botBubble.innerHTML = markdownToHTML(accumulated);
+                }
                 messagesEl.scrollTop = messagesEl.scrollHeight;
               } else if (ev.type === 'done') {
                 if (ev.chat_id) { chatID = ev.chat_id; isCached = !!ev.cached; }

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -828,7 +828,12 @@
                   accumulated = '';
                 }
                 accumulated += ev.text;
-                botBubble.innerHTML = markdownToHTML(accumulated);
+                const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                if (looksLikeJSON) {
+                  botBubble.innerHTML = '<em style="color:var(--muted,#888);font-size:13px">Loading data...</em>';
+                } else {
+                  botBubble.innerHTML = markdownToHTML(accumulated);
+                }
                 messagesEl.scrollTop = messagesEl.scrollHeight;
               } else if (ev.type === 'done') {
                 finish();


### PR DESCRIPTION
## Problem

During streaming, partial JSON can't be parsed so it displayed as raw ugly JSON text to the user while the response was loading.

## Fix

Detect early in the streaming handler if the accumulating response looks like JSON (starts with \`{\` after stripping code fence prefix). If so, show \`Loading data...\` placeholder instead of the raw partial text. Once streaming completes, \`finish()\` calls \`renderBotBubble()\` with the full response and renders the proper data table.

Applied to all three HTML files: map widget, \`/assistant/\` page, and standalone web-chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)