### PR TITLE
fix(chat): preserve original button label after export completes

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10817,6 +10817,7 @@ function selectHomeSearchResult(result, query) {
       }
 
       async function triggerExport(config, btn, statusEl) {
+        const origLabel = btn ? btn.innerHTML : null;
         if (btn) { btn.disabled = true; btn.innerHTML = 'Exporting...'; }
         if (statusEl) statusEl.innerHTML = '<em>Fetching dataset...</em>';
         try {
@@ -10839,7 +10840,7 @@ function selectHomeSearchResult(result, query) {
         } catch (err) {
           if (statusEl) statusEl.innerHTML = `<span style="color:#e53935">✗ Export failed: ${err.message}</span>`;
         } finally {
-          if (btn) { btn.disabled = false; btn.innerHTML = `${downloadSVG} Export CSV`; }
+          if (btn) { btn.disabled = false; btn.innerHTML = origLabel; }
         }
       }
 

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -592,6 +592,7 @@
   }
 
   async function triggerExport(config, btn, statusEl) {
+    const origLabel = btn ? btn.innerHTML : null;
     if (btn) { btn.disabled = true; btn.innerHTML = 'Exporting...'; }
     if (statusEl) statusEl.innerHTML = '<em>Fetching dataset...</em>';
     try {
@@ -612,7 +613,7 @@
     } catch (err) {
       if (statusEl) statusEl.innerHTML = `<span style="color:var(--err)">✗ Export failed: ${err.message}</span>`;
     } finally {
-      if (btn) { btn.disabled = false; btn.innerHTML = `${dlSVG} Export CSV`; }
+      if (btn) { btn.disabled = false; btn.innerHTML = origLabel; }
     }
   }
 

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -596,6 +596,7 @@
   }
 
   async function triggerExport(config, btn, statusEl) {
+    const origLabel = btn ? btn.innerHTML : null;
     if (btn) {
         btn.disabled = true;
         btn.classList.add('loading');
@@ -630,7 +631,7 @@
         if (btn) {
             btn.disabled = false;
             btn.classList.remove('loading');
-            btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg> Export CSV`;
+            btn.innerHTML = origLabel;
         }
     }
   }


### PR DESCRIPTION
The \`triggerExport\` finally block was resetting any clicked button back to the hardcoded text \"Export CSV\", so clicking the Excel or JSON button would rename it. Now stores the original label before disabling and restores it in the finally block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)