### PR TITLE
fix(export): pass lat/lon/radius from AI response to /export endpoint

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -109,7 +109,11 @@ When returning data (sensor readings, radiation measurements, etc.), use this JS
   "export_available": true,
   "suggested_export": {
     "format": "csv",
-    "limit": "full"
+    "limit": "full",
+    "lat": <center latitude of the query>,
+    "lon": <center longitude of the query>,
+    "radius_m": <radius in meters used>,
+    "suggested_tool": "<MCP tool name used, e.g. query_radiation>"
   }
 }
 
@@ -521,6 +525,9 @@ func handleExport(mcpURL string) http.HandlerFunc {
 			Columns       []string  `json:"columns"`
 			Aggregation   string    `json:"aggregation"`
 			SuggestedTool string    `json:"suggested_tool"`
+			Lat           float64   `json:"lat"`
+			Lon           float64   `json:"lon"`
+			RadiusM       float64   `json:"radius_m"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&exportReq); err != nil {
 			http.Error(w, "Invalid request", http.StatusBadRequest)
@@ -566,6 +573,14 @@ func handleExport(mcpURL string) http.HandlerFunc {
 			args["lat"] = (exportReq.Bbox[0] + exportReq.Bbox[2]) / 2
 			args["lon"] = (exportReq.Bbox[1] + exportReq.Bbox[3]) / 2
 			args["radius_m"] = 50000
+		} else if exportReq.Lat != 0 || exportReq.Lon != 0 {
+			args["lat"] = exportReq.Lat
+			args["lon"] = exportReq.Lon
+			radius := exportReq.RadiusM
+			if radius == 0 {
+				radius = 50000
+			}
+			args["radius_m"] = radius
 		}
 
 		callReq := mcp.CallToolRequest{}

--- a/cmd/web-chat/main.go
+++ b/cmd/web-chat/main.go
@@ -553,14 +553,17 @@ func handleExport(mcpURL string) http.HandlerFunc {
 		}
 
 		var exportReq struct {
-			Format       string         `json:"format"`
-			Limit        string         `json:"limit"`
-			TimeRange    string         `json:"time_range"`
-			Bbox         []float64      `json:"bbox"`
-			Region       string         `json:"region"`
-			Columns      []string       `json:"columns"`
-			Aggregation  string         `json:"aggregation"`
-			SuggestedTool string         `json:"suggested_tool"`
+			Format        string    `json:"format"`
+			Limit         string    `json:"limit"`
+			TimeRange     string    `json:"time_range"`
+			Bbox          []float64 `json:"bbox"`
+			Region        string    `json:"region"`
+			Columns       []string  `json:"columns"`
+			Aggregation   string    `json:"aggregation"`
+			SuggestedTool string    `json:"suggested_tool"`
+			Lat           float64   `json:"lat"`
+			Lon           float64   `json:"lon"`
+			RadiusM       float64   `json:"radius_m"`
 		}
 
 		if err := json.NewDecoder(r.Body).Decode(&exportReq); err != nil {
@@ -613,20 +616,23 @@ func handleExport(mcpURL string) http.HandlerFunc {
 				limit = 100000
 			}
 
-			args := map[string]any{
-				"limit": limit,
-			}
+			args := map[string]any{"limit": limit}
 			if len(exportReq.Bbox) == 4 {
 				args["min_lat"] = exportReq.Bbox[0]
 				args["min_lon"] = exportReq.Bbox[1]
 				args["max_lat"] = exportReq.Bbox[2]
 				args["max_lon"] = exportReq.Bbox[3]
-				
-				centerLat := (exportReq.Bbox[0] + exportReq.Bbox[2]) / 2
-				centerLon := (exportReq.Bbox[1] + exportReq.Bbox[3]) / 2
-				args["lat"] = centerLat
-				args["lon"] = centerLon
-				args["radius_m"] = 50000 
+				args["lat"] = (exportReq.Bbox[0] + exportReq.Bbox[2]) / 2
+				args["lon"] = (exportReq.Bbox[1] + exportReq.Bbox[3]) / 2
+				args["radius_m"] = 50000
+			} else if exportReq.Lat != 0 || exportReq.Lon != 0 {
+				args["lat"] = exportReq.Lat
+				args["lon"] = exportReq.Lon
+				radius := exportReq.RadiusM
+				if radius == 0 {
+					radius = 50000
+				}
+				args["radius_m"] = radius
 			}
 
 			callReq := mcp.CallToolRequest{}


### PR DESCRIPTION
## Root cause

\`/export\` calls \`query_radiation\` which requires \`lat\` and \`lon\`, but the frontend only passed \`{format, limit}\` in the export config — no coordinates. The tool returned an error, causing the download to silently fail.

## Fix

- Add \`lat\`, \`lon\`, \`radius_m\` fields to the export request struct in both \`mcp_register.go\` and \`cmd/web-chat/main.go\`
- Use them in the MCP tool args when no bbox is provided
- Update system prompt to instruct the AI to include \`lat\`, \`lon\`, \`radius_m\`, and \`suggested_tool\` in \`suggested_export\` — the frontend already passes the full \`suggested_export\` object through, so the coordinates flow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)