### PR TITLE
fix(chat): detect data_preview anywhere in stream, not just at start

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -11057,7 +11057,7 @@ function selectHomeSearchResult(result, query) {
                     accumulated += ev.text;
                     // During streaming: show markdown. If it looks like JSON,
                     // show a neutral placeholder to avoid raw JSON flicker.
-                    const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                    const looksLikeJSON = accumulated.includes('"type": "data_preview"') || accumulated.includes('"type":"data_preview"');
                     if (looksLikeJSON) {
                       botBubble.innerHTML = '<em style="color:var(--text-muted,#888);font-size:13px">Loading data...</em>';
                     } else {

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -859,7 +859,7 @@
                   accumulated = '';
                 }
                 accumulated += ev.text;
-                const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                const looksLikeJSON = accumulated.includes('"type": "data_preview"') || accumulated.includes('"type":"data_preview"');
                 if (looksLikeJSON) {
                   botBubble.innerHTML = '<em style="color:var(--muted,#888);font-size:13px">Loading data...</em>';
                 } else {

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -829,7 +829,7 @@
                   accumulated = '';
                 }
                 accumulated += ev.text;
-                const looksLikeJSON = accumulated.trim().replace(/^```(?:json)?\s*/i,'').trimStart().startsWith('{');
+                const looksLikeJSON = accumulated.includes('"type": "data_preview"') || accumulated.includes('"type":"data_preview"');
                 if (looksLikeJSON) {
                   botBubble.innerHTML = '<em style="color:var(--muted,#888);font-size:13px">Loading data...</em>';
                 } else {


### PR DESCRIPTION
The AI frequently adds preamble text (\"I'll retrieve...\") before the JSON, so the previous \`startsWith('{')\` check never matched and the raw JSON text was shown during streaming instead of \"Loading data...\".

Now checks for \`\"type\": \"data_preview\"\` anywhere in the accumulated stream — works regardless of preamble text or code fences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)