### PR TITLE
fix(export): server-side data_preview extraction

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -172,11 +172,32 @@ type anthropicResponse struct {
 
 // Streaming helpers
 type chunk struct {
-	Type   string `json:"type"`
-	Text   string `json:"text,omitempty"`
-	Error  string `json:"error,omitempty"`
-	ChatID int64  `json:"chat_id,omitempty"` // set on "done" for feedback linkage
-	Cached bool   `json:"cached,omitempty"`  // true when answer came from semantic cache
+	Type        string          `json:"type"`
+	Text        string          `json:"text,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	ChatID      int64           `json:"chat_id,omitempty"`
+	Cached      bool            `json:"cached,omitempty"`
+	DataPreview json.RawMessage `json:"data_preview,omitempty"`
+}
+
+// extractDataPreview looks for a data_preview JSON object in the AI response text.
+// Returns the raw JSON bytes if found, nil otherwise.
+func extractDataPreview(text string) json.RawMessage {
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end <= start {
+		return nil
+	}
+	candidate := text[start : end+1]
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
+		return nil
+	}
+	var typeVal string
+	if err := json.Unmarshal(obj["type"], &typeVal); err != nil || typeVal != "data_preview" {
+		return nil
+	}
+	return json.RawMessage(candidate)
 }
 
 func writeChunk(w http.ResponseWriter, c chunk) {
@@ -405,7 +426,11 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 				switch block.Type {
 				case "text":
 					answerText.WriteString(block.Text)
-					writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
+					if dp := extractDataPreview(block.Text); dp != nil {
+						writeChunkBuffered(w, chunk{Type: "data_preview", DataPreview: dp}, &buffer, isCloudFront)
+					} else {
+						writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
+					}
 				case "tool_use":
 					toolUses = append(toolUses, block)
 				}

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -11049,7 +11049,13 @@ function selectHomeSearchResult(result, query) {
                 if (!line.trim()) continue;
                 try {
                   const ev = JSON.parse(line);
-                  if (ev.type === 'text') {
+                  if (ev.type === 'data_preview') {
+                    botBubble.classList.remove('ai-thinking');
+                    botBubble.innerHTML = '';
+                    renderDataPreview(ev.data_preview, botBubble);
+                    accumulated = JSON.stringify(ev.data_preview);
+                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                  } else if (ev.type === 'text') {
                     if (botBubble.classList.contains('ai-thinking')) {
                       botBubble.classList.remove('ai-thinking');
                       accumulated = '';

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -853,7 +853,13 @@
             if (!line.trim()) continue;
             try {
               const ev = JSON.parse(line);
-              if (ev.type === 'text') {
+              if (ev.type === 'data_preview') {
+                botBubble.classList.remove('thinking');
+                botBubble.innerHTML = '';
+                renderDataPreview(ev.data_preview, botBubble);
+                accumulated = JSON.stringify(ev.data_preview);
+                messagesEl.scrollTop = messagesEl.scrollHeight;
+              } else if (ev.type === 'text') {
                 if (botBubble.classList.contains('thinking')) {
                   botBubble.classList.remove('thinking');
                   accumulated = '';

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -823,7 +823,13 @@
             if (!line.trim()) continue;
             try {
               const ev = JSON.parse(line);
-              if (ev.type === 'text') {
+              if (ev.type === 'data_preview') {
+                botBubble.classList.remove('thinking');
+                botBubble.innerHTML = '';
+                renderDataPreview(ev.data_preview, botBubble);
+                accumulated = JSON.stringify(ev.data_preview);
+                messagesEl.scrollTop = messagesEl.scrollHeight;
+              } else if (ev.type === 'text') {
                 if (botBubble.classList.contains('thinking')) {
                   botBubble.classList.remove('thinking');
                   accumulated = '';


### PR DESCRIPTION
## Summary
- Server now calls `extractDataPreview()` on every AI text block — strips preamble text and code fences, finds the `data_preview` JSON by bracket matching, validates `type == "data_preview"` via `json.Unmarshal`
- When found, sends a `{type: "data_preview", data_preview: {...}}` event to the client instead of raw text
- All three HTML clients (map widget, `/assistant/`, web-chat) now handle `ev.type === 'data_preview'` by calling `renderDataPreview()` directly — no client-side JSON parsing needed
- This definitively fixes the raw JSON display issue regardless of how much preamble the AI adds

## Test plan
- [ ] Ask radiation data question in map widget chat → data table with CSV/Excel/JSON buttons appears
- [ ] Same in `/assistant/` page
- [ ] Same in standalone web-chat (port 3334)
- [ ] Click export buttons → file downloads correctly
- [ ] Non-data answers still render as markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)