### PR TITLE
fix(table): render markdown links as clickable links in data table

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -172,11 +172,32 @@ type anthropicResponse struct {
 
 // Streaming helpers
 type chunk struct {
-	Type   string `json:"type"`
-	Text   string `json:"text,omitempty"`
-	Error  string `json:"error,omitempty"`
-	ChatID int64  `json:"chat_id,omitempty"` // set on "done" for feedback linkage
-	Cached bool   `json:"cached,omitempty"`  // true when answer came from semantic cache
+	Type        string          `json:"type"`
+	Text        string          `json:"text,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	ChatID      int64           `json:"chat_id,omitempty"`
+	Cached      bool            `json:"cached,omitempty"`
+	DataPreview json.RawMessage `json:"data_preview,omitempty"`
+}
+
+// extractDataPreview looks for a data_preview JSON object in the AI response text.
+// Returns the raw JSON bytes if found, nil otherwise.
+func extractDataPreview(text string) json.RawMessage {
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end <= start {
+		return nil
+	}
+	candidate := text[start : end+1]
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
+		return nil
+	}
+	var typeVal string
+	if err := json.Unmarshal(obj["type"], &typeVal); err != nil || typeVal != "data_preview" {
+		return nil
+	}
+	return json.RawMessage(candidate)
 }
 
 func writeChunk(w http.ResponseWriter, c chunk) {
@@ -405,7 +426,11 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 				switch block.Type {
 				case "text":
 					answerText.WriteString(block.Text)
-					writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
+					if dp := extractDataPreview(block.Text); dp != nil {
+						writeChunkBuffered(w, chunk{Type: "data_preview", DataPreview: dp}, &buffer, isCloudFront)
+					} else {
+						writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
+					}
 				case "tool_use":
 					toolUses = append(toolUses, block)
 				}

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -426,7 +426,9 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 				switch block.Type {
 				case "text":
 					answerText.WriteString(block.Text)
-					if dp := extractDataPreview(block.Text); dp != nil {
+					dp := extractDataPreview(block.Text)
+					log.Printf("[chat] text block len=%d, extractDataPreview=%v", len(block.Text), dp != nil)
+					if dp != nil {
 						writeChunkBuffered(w, chunk{Type: "data_preview", DataPreview: dp}, &buffer, isCloudFront)
 					} else {
 						writeChunkBuffered(w, chunk{Type: "text", Text: block.Text}, &buffer, isCloudFront)
@@ -542,107 +544,125 @@ func handleExport(mcpURL string) http.HandlerFunc {
 		}
 
 		var exportReq struct {
-			Format        string    `json:"format"`
-			Limit         string    `json:"limit"`
-			TimeRange     string    `json:"time_range"`
-			Bbox          []float64 `json:"bbox"`
-			Region        string    `json:"region"`
-			Columns       []string  `json:"columns"`
-			Aggregation   string    `json:"aggregation"`
-			SuggestedTool string    `json:"suggested_tool"`
-			Lat           float64   `json:"lat"`
-			Lon           float64   `json:"lon"`
-			RadiusM       float64   `json:"radius_m"`
+			Format        string           `json:"format"`
+			Limit         string           `json:"limit"`
+			TimeRange     string           `json:"time_range"`
+			Bbox          []float64        `json:"bbox"`
+			Region        string           `json:"region"`
+			Columns       []string         `json:"columns"`
+			Aggregation   string           `json:"aggregation"`
+			SuggestedTool string           `json:"suggested_tool"`
+			Lat           float64          `json:"lat"`
+			Lon           float64          `json:"lon"`
+			RadiusM       float64          `json:"radius_m"`
+			Rows          []map[string]any `json:"rows"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&exportReq); err != nil {
 			http.Error(w, "Invalid request", http.StatusBadRequest)
 			return
 		}
 
-		var data map[string]any
-
-		ctx := r.Context()
-		mc, err := mcpclient.NewStreamableHttpClient(mcpURL)
-		if err != nil {
-			http.Error(w, "MCP connection failed: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer mc.Close()
-
-		if _, err := mc.Initialize(ctx, mcp.InitializeRequest{
-			Params: mcp.InitializeParams{
-				ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
-				ClientInfo:      mcp.Implementation{Name: "safecast-export", Version: "1.0.0"},
-			},
-		}); err != nil {
-			http.Error(w, "MCP init error", http.StatusInternalServerError)
-			return
-		}
-
-		toolName := "query_radiation"
-		if exportReq.SuggestedTool != "" {
-			toolName = exportReq.SuggestedTool
-		}
-
-		limit := 10000
-		if exportReq.Limit == "full" {
-			limit = 100000
-		}
-
-		args := map[string]any{"limit": limit}
-		if len(exportReq.Bbox) == 4 {
-			args["min_lat"] = exportReq.Bbox[0]
-			args["min_lon"] = exportReq.Bbox[1]
-			args["max_lat"] = exportReq.Bbox[2]
-			args["max_lon"] = exportReq.Bbox[3]
-			args["lat"] = (exportReq.Bbox[0] + exportReq.Bbox[2]) / 2
-			args["lon"] = (exportReq.Bbox[1] + exportReq.Bbox[3]) / 2
-			args["radius_m"] = 50000
-		} else if exportReq.Lat != 0 || exportReq.Lon != 0 {
-			args["lat"] = exportReq.Lat
-			args["lon"] = exportReq.Lon
-			radius := exportReq.RadiusM
-			if radius == 0 {
-				radius = 50000
+		// rows may be provided inline from the client (from the already-fetched data_preview table).
+		// If not provided, fall back to re-calling the MCP tool.
+		var rows []any
+		if len(exportReq.Rows) > 0 {
+			for _, r2 := range exportReq.Rows {
+				rows = append(rows, r2)
 			}
-			args["radius_m"] = radius
-		}
-
-		callReq := mcp.CallToolRequest{}
-		callReq.Params.Name = toolName
-		callReq.Params.Arguments = args
-
-		toolResult, err := mc.CallTool(ctx, callReq)
-		if err != nil {
-			http.Error(w, "Tool call failed: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		var resultText string
-		for _, c := range toolResult.Content {
-			if tc, ok := c.(mcp.TextContent); ok {
-				resultText += tc.Text
+		} else {
+			ctx := r.Context()
+			mc, err := mcpclient.NewStreamableHttpClient(mcpURL)
+			if err != nil {
+				http.Error(w, "MCP connection failed: "+err.Error(), http.StatusInternalServerError)
+				return
 			}
-		}
-		if err := json.Unmarshal([]byte(resultText), &data); err != nil {
-			http.Error(w, "Parse tool result failed", http.StatusInternalServerError)
-			return
-		}
+			defer mc.Close()
 
-		switch exportReq.Format {
-		case "json":
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Content-Disposition", "attachment; filename=safecast_export.json")
-			json.NewEncoder(w).Encode(data)
-		case "excel", "xlsx":
-			w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-			w.Header().Set("Content-Disposition", "attachment; filename=safecast_export.xlsx")
-			var rows []any
+			if _, err := mc.Initialize(ctx, mcp.InitializeRequest{
+				Params: mcp.InitializeParams{
+					ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+					ClientInfo:      mcp.Implementation{Name: "safecast-export", Version: "1.0.0"},
+				},
+			}); err != nil {
+				http.Error(w, "MCP init error", http.StatusInternalServerError)
+				return
+			}
+
+			toolName := "query_radiation"
+			if exportReq.SuggestedTool != "" {
+				toolName = exportReq.SuggestedTool
+			}
+
+			limit := 10000
+			if exportReq.Limit == "full" {
+				limit = 100000
+			}
+
+			args := map[string]any{"limit": limit}
+			if len(exportReq.Bbox) == 4 {
+				args["min_lat"] = exportReq.Bbox[0]
+				args["min_lon"] = exportReq.Bbox[1]
+				args["max_lat"] = exportReq.Bbox[2]
+				args["max_lon"] = exportReq.Bbox[3]
+				args["lat"] = (exportReq.Bbox[0] + exportReq.Bbox[2]) / 2
+				args["lon"] = (exportReq.Bbox[1] + exportReq.Bbox[3]) / 2
+				args["radius_m"] = 50000
+			} else if exportReq.Lat != 0 || exportReq.Lon != 0 {
+				args["lat"] = exportReq.Lat
+				args["lon"] = exportReq.Lon
+				radius := exportReq.RadiusM
+				if radius == 0 {
+					radius = 50000
+				}
+				args["radius_m"] = radius
+			}
+
+			callReq := mcp.CallToolRequest{}
+			callReq.Params.Name = toolName
+			callReq.Params.Arguments = args
+
+			toolResult, err := mc.CallTool(ctx, callReq)
+			if err != nil {
+				log.Printf("[export] tool call failed: tool=%s args=%v err=%v", toolName, args, err)
+				http.Error(w, "Tool call failed: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			var resultText string
+			for _, c := range toolResult.Content {
+				if tc, ok := c.(mcp.TextContent); ok {
+					resultText += tc.Text
+				}
+			}
+			var data map[string]any
+			if err := json.Unmarshal([]byte(resultText), &data); err != nil {
+				log.Printf("[export] parse failed: %v — text=%q", err, resultText)
+				http.Error(w, "Parse tool result failed: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
 			if m, ok := data["measurements"].([]any); ok {
 				rows = m
 			} else if r2, ok := data["readings"].([]any); ok {
 				rows = r2
+			} else {
+				// try any first array value
+				for _, v := range data {
+					if arr, ok := v.([]any); ok {
+						rows = arr
+						break
+					}
+				}
 			}
+		}
+		// rows now holds the data to export — proceed to format
+		switch exportReq.Format {
+		case "json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Disposition", "attachment; filename=safecast_export.json")
+			json.NewEncoder(w).Encode(rows)
+		case "excel", "xlsx":
+			w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+			w.Header().Set("Content-Disposition", "attachment; filename=safecast_export.xlsx")
 			f := excelize.NewFile()
 			defer f.Close()
 			f.SetSheetName("Sheet1", "Data")
@@ -675,12 +695,6 @@ func handleExport(mcpURL string) http.HandlerFunc {
 		default: // csv
 			w.Header().Set("Content-Type", "text/csv")
 			w.Header().Set("Content-Disposition", "attachment; filename=safecast_export.csv")
-			var rows []any
-			if m, ok := data["measurements"].([]any); ok {
-				rows = m
-			} else if r2, ok := data["readings"].([]any); ok {
-				rows = r2
-			}
 			if len(rows) > 0 {
 				writer := csv.NewWriter(w)
 				firstRow, _ := rows[0].(map[string]any)

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10754,6 +10754,7 @@ function selectHomeSearchResult(result, query) {
             btn.onclick = () => {
               const cfg = Object.assign({}, data.suggested_export || { limit: 'full' });
               cfg.format = f.toLowerCase();
+              cfg.rows = data.table;
               triggerExport(cfg, btn);
             };
             btnGroup.appendChild(btn);

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -11049,7 +11049,13 @@ function selectHomeSearchResult(result, query) {
                 if (!line.trim()) continue;
                 try {
                   const ev = JSON.parse(line);
-                  if (ev.type === 'text') {
+                  if (ev.type === 'data_preview') {
+                    botBubble.classList.remove('ai-thinking');
+                    botBubble.innerHTML = '';
+                    renderDataPreview(ev.data_preview, botBubble);
+                    accumulated = JSON.stringify(ev.data_preview);
+                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                  } else if (ev.type === 'text') {
                     if (botBubble.classList.contains('ai-thinking')) {
                       botBubble.classList.remove('ai-thinking');
                       accumulated = '';

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10786,7 +10786,13 @@ function selectHomeSearchResult(result, query) {
               const td = document.createElement('td');
               let val = row[k];
               if (typeof val === 'object' && val !== null) val = JSON.stringify(val);
-              td.textContent = val;
+              val = String(val == null ? '' : val);
+              const mdLink = val.match(/^\[(.+?)\]\((https?:\/\/[^\s)]+)\)$/);
+              if (mdLink) {
+                const a = document.createElement('a');
+                a.href = mdLink[2]; a.textContent = mdLink[1]; a.target = '_blank'; a.rel = 'noopener';
+                td.appendChild(a);
+              } else { td.textContent = val; }
               tr.appendChild(td);
             });
             tbody.appendChild(tr);

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -853,7 +853,13 @@
             if (!line.trim()) continue;
             try {
               const ev = JSON.parse(line);
-              if (ev.type === 'text') {
+              if (ev.type === 'data_preview') {
+                botBubble.classList.remove('thinking');
+                botBubble.innerHTML = '';
+                renderDataPreview(ev.data_preview, botBubble);
+                accumulated = JSON.stringify(ev.data_preview);
+                messagesEl.scrollTop = messagesEl.scrollHeight;
+              } else if (ev.type === 'text') {
                 if (botBubble.classList.contains('thinking')) {
                   botBubble.classList.remove('thinking');
                   accumulated = '';

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -541,6 +541,7 @@
         btn.onclick = () => {
           const cfg = Object.assign({}, data.suggested_export || { limit: 'full' });
           cfg.format = f.toLowerCase();
+          cfg.rows = data.table;
           triggerExport(cfg, btn);
         };
         grp.appendChild(btn);
@@ -799,7 +800,8 @@
       msgEl.focus();
 
       if (success && accumulated) {
-        renderBotBubble(botBubble, accumulated);
+        console.log('[chat] finish() accumulated starts with:', accumulated.slice(0,80));
+        try { renderBotBubble(botBubble, accumulated); } catch(e) { console.error('[chat] renderBotBubble error', e); }
 
         // Re-add copy button
         const copyBtn = document.createElement('button');
@@ -854,9 +856,10 @@
             try {
               const ev = JSON.parse(line);
               if (ev.type === 'data_preview') {
+                console.log('[chat] data_preview event received', ev.data_preview);
                 botBubble.classList.remove('thinking');
                 botBubble.innerHTML = '';
-                renderDataPreview(ev.data_preview, botBubble);
+                try { renderDataPreview(ev.data_preview, botBubble); } catch(e) { console.error('[chat] renderDataPreview error', e); botBubble.textContent = JSON.stringify(ev.data_preview); }
                 accumulated = JSON.stringify(ev.data_preview);
                 messagesEl.scrollTop = messagesEl.scrollHeight;
               } else if (ev.type === 'text') {

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -565,7 +565,13 @@
           const td = document.createElement('td');
           let v = row[k];
           if (typeof v === 'object' && v !== null) v = JSON.stringify(v);
-          td.textContent = v;
+          v = String(v == null ? '' : v);
+          const mdLink = v.match(/^\[(.+?)\]\((https?:\/\/[^\s)]+)\)$/);
+          if (mdLink) {
+            const a = document.createElement('a');
+            a.href = mdLink[2]; a.textContent = mdLink[1]; a.target = '_blank'; a.rel = 'noopener';
+            td.appendChild(a);
+          } else { td.textContent = v; }
           tr.appendChild(td);
         });
         tbody.appendChild(tr);

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -555,13 +555,13 @@
               val = JSON.stringify(val);
           }
           // If it looks like a coordinate or map link, make it clickable
-          if (k === 'device_id' && row.lat && row.lon) {
-              td.innerHTML = `<a href="https://simplemap.safecast.org/?lat=${row.lat}&lon=${row.lon}&zoom=15" target="_blank">${val}</a>`;
-          } else if (typeof val === 'string' && val.includes('https://simplemap.safecast.org')) {
-              td.innerHTML = markdownToHTML(val);
-          } else {
-              td.textContent = val;
-          }
+          val = String(val == null ? '' : val);
+          const mdLink = val.match(/^\[(.+?)\]\((https?:\/\/[^\s)]+)\)$/);
+          if (mdLink) {
+            const a = document.createElement('a');
+            a.href = mdLink[2]; a.textContent = mdLink[1]; a.target = '_blank'; a.rel = 'noopener';
+            td.appendChild(a);
+          } else { td.textContent = val; }
           tr.appendChild(td);
         });
         tbody.appendChild(tr);

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -516,6 +516,7 @@
         btn.onclick = () => {
              const expConfig = Object.assign({}, data.suggested_export || { limit: 'full' });
              expConfig.format = formatId;
+             expConfig.rows = data.table;
              triggerExport(expConfig, btn);
         };
         btnGroup.appendChild(btn);

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -823,7 +823,13 @@
             if (!line.trim()) continue;
             try {
               const ev = JSON.parse(line);
-              if (ev.type === 'text') {
+              if (ev.type === 'data_preview') {
+                botBubble.classList.remove('thinking');
+                botBubble.innerHTML = '';
+                renderDataPreview(ev.data_preview, botBubble);
+                accumulated = JSON.stringify(ev.data_preview);
+                messagesEl.scrollTop = messagesEl.scrollHeight;
+              } else if (ev.type === 'text') {
                 if (botBubble.classList.contains('thinking')) {
                   botBubble.classList.remove('thinking');
                   accumulated = '';


### PR DESCRIPTION
## Summary
- Device/location columns contain `[text](url)` markdown — now rendered as clickable `<a>` links in all three interfaces
- Consistent implementation across map widget, /assistant/, and web-chat
- Removes the old ad-hoc `simplemap.safecast.org` special-casing in web-chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)