### PR TITLE
fix(export): use .xlsx extension for Excel downloads

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10846,7 +10846,8 @@ function selectHomeSearchResult(result, query) {
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
           a.href = url;
-          a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${config.format || 'csv'}`;
+          const ext = config.format === 'excel' ? 'xlsx' : (config.format || 'csv');
+          a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${ext}`;
           document.body.appendChild(a);
           a.click();
           document.body.removeChild(a);

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -622,7 +622,8 @@
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${config.format || 'csv'}`;
+      const ext = config.format === 'excel' ? 'xlsx' : (config.format || 'csv');
+      a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${ext}`;
       document.body.appendChild(a); a.click(); document.body.removeChild(a);
       URL.revokeObjectURL(url);
       if (statusEl) statusEl.innerHTML = '<span style="color:var(--green)">✓ Download started.</span>';

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -621,7 +621,8 @@
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${config.format || 'csv'}`;
+        const ext = config.format === 'excel' ? 'xlsx' : (config.format || 'csv');
+        a.download = `safecast_export_${new Date().toISOString().slice(0,10)}.${ext}`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- Excel download files were being saved with `.excel` extension instead of `.xlsx`
- Fixed in all three interfaces: map widget, assistant page, web-chat
- Maps `config.format === 'excel'` → `'xlsx'` when constructing the download filename

## Test plan
- [ ] Click Excel download button in map widget chat
- [ ] Verify downloaded file has `.xlsx` extension and opens in Excel/LibreOffice

🤖 Generated with [Claude Code](https://claude.com/claude-code)