### PR TITLE
fix(web-chat): preserve data_preview table in finish() + fix .xlsx extension

### DIFF
--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -780,9 +780,26 @@
 
       // Add AI disclaimer to successful bot messages
       if (success && accumulated) {
-        // Re-render with disclaimer
-        const disclaimerText = '\n\n---\n\n_Note: AI-generated response using data from the Safecast radiation monitoring network. For critical safety decisions, please consult official sources._';
-        botBubble.innerHTML = markdownToHTML(accumulated + disclaimerText);
+        // Check if accumulated content is a data_preview — if so, re-render as table
+        let isDataPreview = false;
+        try {
+          const stripped = accumulated.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '');
+          const s = stripped.indexOf('{'), e = stripped.lastIndexOf('}');
+          if (s !== -1 && e > s) {
+            const data = JSON.parse(stripped.slice(s, e + 1));
+            if (data.type === 'data_preview') {
+              botBubble.innerHTML = '';
+              renderDataPreview(data, botBubble);
+              isDataPreview = true;
+            }
+          }
+        } catch (_) {}
+
+        if (!isDataPreview) {
+          // Re-render with disclaimer
+          const disclaimerText = '\n\n---\n\n_Note: AI-generated response using data from the Safecast radiation monitoring network. For critical safety decisions, please consult official sources._';
+          botBubble.innerHTML = markdownToHTML(accumulated + disclaimerText);
+        }
 
         // Re-add copy button (since we replaced innerHTML)
         const copyBtn = document.createElement('button');


### PR DESCRIPTION
## Summary

- **fix(web-chat):** The `finish()` handler in `cmd/web-chat/index.html` was always calling `markdownToHTML(accumulated + disclaimerText)`, overwriting the rendered data table. Now detects `data_preview` JSON in `accumulated` and re-renders via `renderDataPreview()` instead — matching the pattern already used in `map.html`'s `renderBotBubble()`.
- **fix(export):** Excel downloads now use `.xlsx` extension (from previous commit on this branch).

## Root cause

The SSE pump correctly called `renderDataPreview()` when it received a `data_preview` event, but `finish()` then unconditionally replaced `innerHTML` with the markdown+disclaimer path, nuking the table.

## Test plan

- [ ] Ask "What's the radiation level near Tokyo?" in `/assistant/` — should show a data table, not raw JSON
- [ ] Same query in the map chat widget locally — should show table (was showing JSON due to stale binary, now rebuilt)
- [ ] Excel download button produces a `.xlsx` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)