### PR TITLE
fix(chat): robust bracket-counting extractJSON for data_preview rendering

### DIFF
--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -512,13 +512,33 @@
   const dlSVG = '<svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>';
 
   function extractJSON(text) {
-    const stripped = text.trim()
-      .replace(/^```(?:json)?\s*/i, '')
-      .replace(/\s*```\s*$/, '');
-    const start = stripped.indexOf('{');
-    const end = stripped.lastIndexOf('}');
-    if (start !== -1 && end > start) {
-      try { return JSON.parse(stripped.slice(start, end + 1)); } catch (e) {}
+    // Find the data_preview marker first (both compact and spaced key formats)
+    let m = text.indexOf('"type":"data_preview"');
+    if (m === -1) m = text.indexOf('"type": "data_preview"');
+    if (m === -1) return null;
+
+    // Bracket-counting helper: returns index of matching } for the { at start
+    const matchingBrace = (t, s) => {
+      let depth = 0, inStr = false, esc = false;
+      for (let i = s; i < t.length; i++) {
+        const c = t[i];
+        if (esc) { esc = false; continue; }
+        if (c === '\\' && inStr) { esc = true; continue; }
+        if (c === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (c === '{') depth++;
+        else if (c === '}') { depth--; if (depth === 0) return i; }
+      }
+      return -1;
+    };
+
+    // Scan forward to find the first { whose matching } spans the marker
+    for (let i = 0; i < m; i++) {
+      if (text[i] !== '{') continue;
+      const end = matchingBrace(text, i);
+      if (end !== -1 && end >= m) {
+        try { return JSON.parse(text.slice(i, end + 1)); } catch (_) { continue; }
+      }
     }
     return null;
   }

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -421,6 +421,38 @@
     msgEl.style.height = 'auto';
   }
 
+  // Robust JSON extractor: finds the first { whose matching } spans the
+  // "type":"data_preview" marker. Uses bracket counting so it works even
+  // when the AI puts summary fields before "type" or adds preamble text.
+  function extractJSON(text) {
+    let m = text.indexOf('"type":"data_preview"');
+    if (m === -1) m = text.indexOf('"type": "data_preview"');
+    if (m === -1) return null;
+
+    const matchingBrace = (t, s) => {
+      let depth = 0, inStr = false, esc = false;
+      for (let i = s; i < t.length; i++) {
+        const c = t[i];
+        if (esc) { esc = false; continue; }
+        if (c === '\\' && inStr) { esc = true; continue; }
+        if (c === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (c === '{') depth++;
+        else if (c === '}') { depth--; if (depth === 0) return i; }
+      }
+      return -1;
+    };
+
+    for (let i = 0; i < m; i++) {
+      if (text[i] !== '{') continue;
+      const end = matchingBrace(text, i);
+      if (end !== -1 && end >= m) {
+        try { return JSON.parse(text.slice(i, end + 1)); } catch (_) { continue; }
+      }
+    }
+    return null;
+  }
+
   // Convert markdown to HTML
   function markdownToHTML(text) {
     let html = text;
@@ -664,24 +696,13 @@
     // User messages are plain text, bot messages support markdown
     if (role === 'bot') {
       // Try to parse as data-aware JSON first
-      let isDataAware = false;
-      try {
-          const stripped = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '');
-          const s = stripped.indexOf('{'), e = stripped.lastIndexOf('}');
-          if (s !== -1 && e > s) {
-              const data = JSON.parse(stripped.slice(s, e + 1));
-              if (data.type === 'data_preview') {
-                  renderDataPreview(data, bubble);
-                  isDataAware = true;
-              } else if (data.type === 'export_request') {
-                  handleExportRequest(data, bubble);
-                  isDataAware = true;
-              }
-          }
-      } catch (e) { /* fallback to markdown */ }
-
-      if (!isDataAware) {
-          bubble.innerHTML = markdownToHTML(text);
+      const jsonData = extractJSON(text);
+      if (jsonData && jsonData.type === 'data_preview') {
+        renderDataPreview(jsonData, bubble);
+      } else if (jsonData && jsonData.type === 'export_request') {
+        handleExportRequest(jsonData, bubble);
+      } else {
+        bubble.innerHTML = markdownToHTML(text);
       }
 
       // Add copy button for bot messages
@@ -780,23 +801,12 @@
 
       // Add AI disclaimer to successful bot messages
       if (success && accumulated) {
-        // Check if accumulated content is a data_preview — if so, re-render as table
-        let isDataPreview = false;
-        try {
-          const stripped = accumulated.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '');
-          const s = stripped.indexOf('{'), e = stripped.lastIndexOf('}');
-          if (s !== -1 && e > s) {
-            const data = JSON.parse(stripped.slice(s, e + 1));
-            if (data.type === 'data_preview') {
-              botBubble.innerHTML = '';
-              renderDataPreview(data, botBubble);
-              isDataPreview = true;
-            }
-          }
-        } catch (_) {}
-
-        if (!isDataPreview) {
-          // Re-render with disclaimer
+        // Re-render final state: table if data_preview detected, markdown otherwise
+        const jsonData = extractJSON(accumulated);
+        if (jsonData && jsonData.type === 'data_preview') {
+          botBubble.innerHTML = '';
+          renderDataPreview(jsonData, botBubble);
+        } else {
           const disclaimerText = '\n\n---\n\n_Note: AI-generated response using data from the Safecast radiation monitoring network. For critical safety decisions, please consult official sources._';
           botBubble.innerHTML = markdownToHTML(accumulated + disclaimerText);
         }


### PR DESCRIPTION
## Summary

The root cause of JSON showing instead of tables: `extractJSON` used `indexOf('{') + lastIndexOf('}')` which breaks when the AI generates JSON with summary/table fields before the `"type"` key:

```json
{"summary": {"rows_total": 84, ...}, "type": "data_preview", "table": [...]}
```

`lastIndexOf('}')` lands on the closing `}` of the inner `summary` object, not the outer one, so `JSON.parse` fails on a partial/wrong slice.

## Fix

Replace with the same bracket-counting algorithm the Go server already uses in `extractDataPreview()`:
- Find the `"type":"data_preview"` marker position
- Scan forward from the beginning for `{` characters
- Use bracket counting (with string/escape awareness) to find the matching `}`
- The first `{...}` whose span contains the marker is the data_preview object
- Applied to **all three** copies of the fragile logic: `static/index.html` and both spots in `web-chat/index.html`

## Test plan

- [ ] "What's the radiation level near Tokyo?" on `/assistant/` → table, not JSON
- [ ] Works even when AI puts `summary` or `table` keys before `type` in JSON
- [ ] Works when AI adds preamble prose before the JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)