### PR TITLE
fix(chat): sanitize embedded newlines in JSON + parse string location for map links

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -180,6 +180,72 @@ type chunk struct {
 	DataPreview json.RawMessage `json:"data_preview,omitempty"`
 }
 
+// sanitizeJSON replaces non-standard JSON values the AI sometimes emits so that
+// json.Unmarshal succeeds: NaN/Infinity → null, trailing commas removed,
+// literal control characters inside strings escaped properly.
+func sanitizeJSON(s string) string {
+	s = strings.NewReplacer(
+		": NaN", ": null",
+		":NaN", ":null",
+		": Infinity", ": null",
+		":Infinity", ":null",
+		": -Infinity", ": null",
+		":-Infinity", ":null",
+	).Replace(s)
+	var out []byte
+	inStr := false
+	esc := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if esc {
+			esc = false
+			out = append(out, c)
+			continue
+		}
+		if c == '\\' && inStr {
+			esc = true
+			out = append(out, c)
+			continue
+		}
+		if c == '"' {
+			inStr = !inStr
+			out = append(out, c)
+			continue
+		}
+		if inStr {
+			// Escape literal control characters that are invalid in JSON strings
+			switch c {
+			case '\n':
+				out = append(out, '\\', 'n')
+				continue
+			case '\r':
+				out = append(out, '\\', 'r')
+				continue
+			case '\t':
+				out = append(out, '\\', 't')
+				continue
+			default:
+				if c < 0x20 {
+					continue // drop other control chars
+				}
+			}
+		} else {
+			// Outside strings: strip trailing commas before } or ]
+			if c == ',' {
+				j := i + 1
+				for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+					j++
+				}
+				if j < len(s) && (s[j] == '}' || s[j] == ']') {
+					continue
+				}
+			}
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
 // extractDataPreview looks for a data_preview JSON object in the AI response text.
 // Returns the raw JSON bytes if found, nil otherwise.
 func extractDataPreview(text string) json.RawMessage {
@@ -244,16 +310,18 @@ func extractDataPreview(text string) json.RawMessage {
 		}
 		// This object's span [i, objEnd] contains the marker — try to parse it
 		candidate := text[i : objEnd+1]
+		// Sanitize non-standard JSON values the AI sometimes emits (NaN, Infinity, trailing commas)
+		sanitized := sanitizeJSON(candidate)
 		var obj map[string]json.RawMessage
-		if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
-			log.Printf("[extractDataPreview] JSON parse failed: %v (len=%d)", err, len(candidate))
+		if err := json.Unmarshal([]byte(sanitized), &obj); err != nil {
+			log.Printf("[extractDataPreview] JSON parse failed: %v (len=%d)", err, len(sanitized))
 			continue
 		}
 		var typeVal string
 		if err := json.Unmarshal(obj["type"], &typeVal); err != nil || typeVal != "data_preview" {
 			continue
 		}
-		return json.RawMessage(candidate)
+		return json.RawMessage(sanitized)
 	}
 	log.Printf("[extractDataPreview] no containing object found for marker at %d, text len=%d", marker, len(text))
 	return nil

--- a/cmd/unified-server/static/index.html
+++ b/cmd/unified-server/static/index.html
@@ -511,6 +511,30 @@
 
   const dlSVG = '<svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>';
 
+  function sanitizeForParse(s) {
+    // Fix NaN/Infinity, trailing commas, and literal control chars inside strings
+    let out = '', inStr = false, esc = false;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i];
+      if (esc) { esc = false; out += c; continue; }
+      if (c === '\\' && inStr) { esc = true; out += c; continue; }
+      if (c === '"') { inStr = !inStr; out += c; continue; }
+      if (inStr) {
+        if (c === '\n') { out += '\\n'; continue; }
+        if (c === '\r') { out += '\\r'; continue; }
+        if (c === '\t') { out += '\\t'; continue; }
+        if (c.charCodeAt(0) < 0x20) continue;
+      } else {
+        if (c === ',' && /^[ \t\r\n]*[}\]]/.test(s.slice(i + 1))) continue;
+      }
+      out += c;
+    }
+    return out
+      .replace(/:[ \t]*NaN\b/g, ': null')
+      .replace(/:[ \t]*Infinity\b/g, ': null')
+      .replace(/:[ \t]*-Infinity\b/g, ': null');
+  }
+
   function extractJSON(text) {
     // Find the data_preview marker first (both compact and spaced key formats)
     let m = text.indexOf('"type":"data_preview"');
@@ -537,7 +561,10 @@
       if (text[i] !== '{') continue;
       const end = matchingBrace(text, i);
       if (end !== -1 && end >= m) {
-        try { return JSON.parse(text.slice(i, end + 1)); } catch (_) { continue; }
+        const slice = text.slice(i, end + 1);
+        try { return JSON.parse(slice); } catch (_) {
+          try { return JSON.parse(sanitizeForParse(slice)); } catch (_) { continue; }
+        }
       }
     }
     return null;
@@ -583,9 +610,13 @@
       data.table.forEach(row => {
         const tr = document.createElement('tr');
         // Build map URL from map_link field or lat/lon
-        const mapUrl = row.map_link || (row.latitude && row.longitude
-          ? `https://simplemap.safecast.org/?lat=${row.latitude}&lon=${row.longitude}&zoom=15`
-          : (row.lat && row.lon ? `https://simplemap.safecast.org/?lat=${row.lat}&lon=${row.lon}&zoom=15` : null));
+        let mapUrl = row.map_link ||
+          (row.latitude && row.longitude ? `https://simplemap.safecast.org/?lat=${row.latitude}&lon=${row.longitude}&zoom=15` :
+          (row.lat && row.lon ? `https://simplemap.safecast.org/?lat=${row.lat}&lon=${row.lon}&zoom=15` : null));
+        if (!mapUrl && row.location) {
+          const m = String(row.location).match(/([-\d.]+)[°\s]*[Nn][,\s]+([-\d.]+)[°\s]*[Ee]/);
+          if (m) mapUrl = `https://simplemap.safecast.org/?lat=${m[1]}&lon=${m[2]}&zoom=15`;
+        }
         keys.forEach(k => {
           const td = document.createElement('td');
           let v = row[k];

--- a/cmd/web-chat/index.html
+++ b/cmd/web-chat/index.html
@@ -421,6 +421,29 @@
     msgEl.style.height = 'auto';
   }
 
+  function sanitizeForParse(s) {
+    let out = '', inStr = false, esc = false;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i];
+      if (esc) { esc = false; out += c; continue; }
+      if (c === '\\' && inStr) { esc = true; out += c; continue; }
+      if (c === '"') { inStr = !inStr; out += c; continue; }
+      if (inStr) {
+        if (c === '\n') { out += '\\n'; continue; }
+        if (c === '\r') { out += '\\r'; continue; }
+        if (c === '\t') { out += '\\t'; continue; }
+        if (c.charCodeAt(0) < 0x20) continue;
+      } else {
+        if (c === ',' && /^[ \t\r\n]*[}\]]/.test(s.slice(i + 1))) continue;
+      }
+      out += c;
+    }
+    return out
+      .replace(/:[ \t]*NaN\b/g, ': null')
+      .replace(/:[ \t]*Infinity\b/g, ': null')
+      .replace(/:[ \t]*-Infinity\b/g, ': null');
+  }
+
   // Robust JSON extractor: finds the first { whose matching } spans the
   // "type":"data_preview" marker. Uses bracket counting so it works even
   // when the AI puts summary fields before "type" or adds preamble text.
@@ -447,7 +470,10 @@
       if (text[i] !== '{') continue;
       const end = matchingBrace(text, i);
       if (end !== -1 && end >= m) {
-        try { return JSON.parse(text.slice(i, end + 1)); } catch (_) { continue; }
+        const slice = text.slice(i, end + 1);
+        try { return JSON.parse(slice); } catch (_) {
+          try { return JSON.parse(sanitizeForParse(slice)); } catch (_) { continue; }
+        }
       }
     }
     return null;
@@ -579,9 +605,13 @@
       const tbody = document.createElement('tbody');
       data.table.forEach(row => {
         const tr = document.createElement('tr');
-        const mapUrl = row.map_link || (row.latitude && row.longitude
-          ? `https://simplemap.safecast.org/?lat=${row.latitude}&lon=${row.longitude}&zoom=15`
-          : (row.lat && row.lon ? `https://simplemap.safecast.org/?lat=${row.lat}&lon=${row.lon}&zoom=15` : null));
+        let mapUrl = row.map_link ||
+          (row.latitude && row.longitude ? `https://simplemap.safecast.org/?lat=${row.latitude}&lon=${row.longitude}&zoom=15` :
+          (row.lat && row.lon ? `https://simplemap.safecast.org/?lat=${row.lat}&lon=${row.lon}&zoom=15` : null));
+        if (!mapUrl && row.location) {
+          const m = String(row.location).match(/([-\d.]+)[°\s]*[Nn][,\s]+([-\d.]+)[°\s]*[Ee]/);
+          if (m) mapUrl = `https://simplemap.safecast.org/?lat=${m[1]}&lon=${m[2]}&zoom=15`;
+        }
         keys.forEach(k => {
           const td = document.createElement('td');
           let val = row[k];

--- a/cmd/web-chat/main.go
+++ b/cmd/web-chat/main.go
@@ -290,6 +290,68 @@ type chunk struct {
 	DataPreview json.RawMessage `json:"data_preview,omitempty"`
 }
 
+// sanitizeJSON replaces non-standard JSON values the AI sometimes emits.
+func sanitizeJSON(s string) string {
+	s = strings.NewReplacer(
+		": NaN", ": null",
+		":NaN", ":null",
+		": Infinity", ": null",
+		":Infinity", ":null",
+		": -Infinity", ": null",
+		":-Infinity", ":null",
+	).Replace(s)
+	var out []byte
+	inStr := false
+	esc := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if esc {
+			esc = false
+			out = append(out, c)
+			continue
+		}
+		if c == '\\' && inStr {
+			esc = true
+			out = append(out, c)
+			continue
+		}
+		if c == '"' {
+			inStr = !inStr
+			out = append(out, c)
+			continue
+		}
+		if inStr {
+			switch c {
+			case '\n':
+				out = append(out, '\\', 'n')
+				continue
+			case '\r':
+				out = append(out, '\\', 'r')
+				continue
+			case '\t':
+				out = append(out, '\\', 't')
+				continue
+			default:
+				if c < 0x20 {
+					continue
+				}
+			}
+		} else {
+			if c == ',' {
+				j := i + 1
+				for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+					j++
+				}
+				if j < len(s) && (s[j] == '}' || s[j] == ']') {
+					continue
+				}
+			}
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
 // extractDataPreview looks for a data_preview JSON object in the AI response text.
 // Returns the raw JSON bytes if found, nil otherwise.
 func extractDataPreview(text string) json.RawMessage {
@@ -345,7 +407,7 @@ func extractDataPreview(text string) json.RawMessage {
 		if objEnd == -1 || objEnd < marker {
 			continue
 		}
-		candidate := text[i : objEnd+1]
+		candidate := sanitizeJSON(text[i : objEnd+1])
 		var obj map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
 			continue


### PR DESCRIPTION
## Summary

Two bugs fixed:

**1. Embedded literal newlines in JSON strings break parsing**
The AI sometimes returns `"location": "34.483°N,\n136.163°E"` with an actual newline byte inside the string — invalid JSON. `JSON.parse` / `json.Unmarshal` fails, table never renders.

Fix: `sanitizeForParse` (JS) and `sanitizeJSON` (Go) now do a string-aware pass that escapes `\n`, `\r`, `\t` and drops other control chars that appear inside JSON string values.

**2. Device ID map links missing when location is a string**
When the AI returns `"location": "35.476°N, 139.572°E"` instead of separate `latitude`/`longitude` fields, `mapUrl` was null and device IDs showed as plain text.

Fix: `renderDataPreview` now falls back to parsing the `location` string with a regex (`/([-\d.]+)°N, ([-\d.]+)°E/`) to construct map links.

## Test plan

- [ ] "Can you give me a dataset of real-time radiation readings for Sugano, Mitsue, Nara?" → table with download buttons, not raw JSON
- [ ] "What's the radiation level near Tokyo?" → device IDs are clickable map links
- [ ] Map chat widget unchanged and still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)