### PR TITLE
feat: Add table download button and clickable device links in AI assistant

### DIFF
--- a/cmd/mcp-server/hints/claude.json
+++ b/cmd/mcp-server/hints/claude.json
@@ -41,7 +41,7 @@
           }
         }
       ],
-      "output_hints": "Present results in a markdown table with columns: Location, Dose Rate (µSv/h), Date, Detector. Every coordinate must be a clickable map link: [lat°N, lon°E](https://simplemap.safecast.org/?lat=LAT&lon=LON&zoom=15). Include context about whether readings are elevated compared to typical background (0.05-0.20 µSv/h).",
+      "output_hints": "Present results in a markdown table with columns: Location, Dose Rate (µSv/h), Date, Detector. Every coordinate must be a clickable map link: [lat°N, lon°E](https://simplemap.safecast.org/?lat=LAT&lon=LON&zoom=15). Every device_id MUST also be a clickable map link: [device_id](https://simplemap.safecast.org/?lat=LAT&lon=LON&zoom=15). Include context about whether readings are elevated compared to typical background (0.05-0.20 µSv/h). Always inform users that tables can be downloaded using the download button above each table.",
       "warnings": [
         "Never report 'no real-time data' without first calling sensor_current",
         "Distinguish between CPM (counts per minute) and µSv/h (dose rate)",

--- a/cmd/mcp-server/tool_list_sensors.go
+++ b/cmd/mcp-server/tool_list_sensors.go
@@ -51,7 +51,7 @@ func handleListSensors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 	if dbAvailable() {
 		return listSensorsDB(ctx, sensorType, minLat, maxLat, minLon, maxLon, limit)
 	}
-	
+
 	// Fallback to API if database not available
 	return mcp.NewToolResultError("Database connection required for list_sensors tool. Please ensure DATABASE_URL is set to access real-time sensor data."), nil
 }
@@ -64,12 +64,12 @@ func listSensorsDB(ctx context.Context, sensorType string, minLat, maxLat, minLo
 		WHERE table_schema = 'public'
 		ORDER BY table_name
 	`
-	
+
 	tableRows, err := queryRows(ctx, tablesQuery)
 	if err != nil {
 		return mcp.NewToolResultError("Could not query database schema: " + err.Error()), nil
 	}
-	
+
 	// Look for tables that might contain real-time sensor data
 	availableTables := make([]string, len(tableRows))
 	realtimeTable := ""
@@ -77,25 +77,25 @@ func listSensorsDB(ctx context.Context, sensorType string, minLat, maxLat, minLo
 		if tableName, ok := row["table_name"].(string); ok {
 			availableTables[i] = tableName
 			// Check for possible real-time sensor data tables
-			if tableName == "realtime_measurements" || 
-			   tableName == "measurements_realtime" || 
-			   tableName == "sensors" ||
-			   tableName == "devices" {
+			if tableName == "realtime_measurements" ||
+				tableName == "measurements_realtime" ||
+				tableName == "sensors" ||
+				tableName == "devices" {
 				realtimeTable = tableName
 			}
 		}
 	}
-	
+
 	if realtimeTable == "" {
 		// If no real-time table found, return available tables for debugging
 		result := map[string]any{
-			"message": "No known real-time sensor data tables found in database.",
+			"message":          "No known real-time sensor data tables found in database.",
 			"available_tables": availableTables,
-			"suggestion": "Real-time sensor data may not be available through this database connection.",
+			"suggestion":       "Real-time sensor data may not be available through this database connection.",
 		}
 		return jsonResult(result)
 	}
-	
+
 	// Query the appropriate real-time table to find unique devices/sensors
 	var query string
 	var args []interface{}
@@ -158,9 +158,9 @@ func listSensorsDB(ctx context.Context, sensorType string, minLat, maxLat, minLo
 	sensors := make([]map[string]any, len(rows))
 	for i, r := range rows {
 		sensors[i] = map[string]any{
-			"device_id":       r["device_id"],
-			"device_name":     r["device_name"],
-			"type":            r["transport"],
+			"device_id":   r["device_id"],
+			"device_name": r["device_name"],
+			"type":        r["transport"],
 			"location": map[string]any{
 				"latitude":  r["latitude"],
 				"longitude": r["longitude"],
@@ -170,12 +170,12 @@ func listSensorsDB(ctx context.Context, sensorType string, minLat, maxLat, minLo
 	}
 
 	result := map[string]any{
-		"count":   len(sensors),
-		"source":  "database",
-		"sensors": sensors,
-		"table_used": realtimeTable,
-		"available_tables": availableTables,
-		"_ai_hint": "CRITICAL INSTRUCTIONS: (1) The 'unit' field indicates measurement units - CPM means 'counts per minute' NOT 'counts per second'. Always interpret and report CPM values as counts per minute. (2) Present all data in a purely scientific, factual manner. NEVER use personal pronouns (I, we, I'll, I'm, you, your), exclamations (!, Perfect, Great, Excellent), or conversational phrases. Format responses as objective statements: 'Latest reading: X CPM at location Y' NOT 'I found a reading of X CPM' or 'Perfect! The sensor shows...'. State only objective facts and measurements. (3) **FORMATTING — REQUIRED**: Always present results in a markdown table. Every device_id MUST be a clickable map link: [device_id](https://simplemap.safecast.org/?lat=LATITUDE&lon=LONGITUDE&zoom=15) using the actual lat/lon from the location field. Never show plain device IDs without a link.",
+		"count":              len(sensors),
+		"source":             "database",
+		"sensors":            sensors,
+		"table_used":         realtimeTable,
+		"available_tables":   availableTables,
+		"_ai_hint":           "CRITICAL INSTRUCTIONS: (1) The 'unit' field indicates measurement units - CPM means 'counts per minute' NOT 'counts per second'. Always interpret and report CPM values as counts per minute. (2) Present all data in a purely scientific, factual manner. NEVER use personal pronouns (I, we, I'll, I'm, you, your), exclamations (!, Perfect, Great, Excellent), or conversational phrases. Format responses as objective statements: 'Latest reading: X CPM at location Y' NOT 'I found a reading of X CPM' or 'Perfect! The sensor shows...'. State only objective facts and measurements. (3) **FORMATTING — REQUIRED**: Always present results in a markdown table. Every device_id MUST be a clickable map link: [device_id](https://simplemap.safecast.org/?lat=LATITUDE&lon=LONGITUDE&zoom=15) using the actual lat/lon from the location field. Never show plain device IDs without a link. (4) **MANDATORY DOWNLOAD**: When presenting tables, always include a note at the end: 'This table can be downloaded using the download button above the table.'",
 		"_ai_generated_note": aiGeneratedNote,
 	}
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1764,6 +1764,102 @@
       font-family: inherit;
       color: var(--modal-text);
     }
+
+    /* ── Data Table & Export ── */
+    .data-card {
+      background: var(--surface, #242930);
+      border: 1px solid var(--border, #2e3540);
+      border-radius: 8px;
+      margin: 12px 0;
+      overflow: hidden;
+      color: #e4e8ef;
+    }
+    .data-header {
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border, #2e3540);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(255, 255, 255, 0.03);
+    }
+    .data-header .meta { font-size: 12px; color: var(--muted, #7a8494); }
+    .data-table-container {
+      overflow-x: auto;
+      max-height: 400px;
+    }
+    .data-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    .data-table th {
+      text-align: left;
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.05);
+      border-bottom: 1px solid var(--border, #2e3540);
+      color: var(--muted, #7a8494);
+      font-weight: 600;
+      position: sticky;
+      top: 0;
+    }
+    .data-table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border, #2e3540);
+    }
+    .data-table tr:hover { background: rgba(255, 255, 255, 0.02); }
+
+    .export-btn {
+      background: var(--green, #1e88e5);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      transition: background .15s;
+    }
+    .export-btn:hover { background: var(--green-dk, #1565c0); }
+    .export-btn svg { width: 12px; height: 12px; fill: #fff; }
+    .export-btn.loading { opacity: 0.7; cursor: wait; }
+
+    /* Table download button in chat responses */
+    .table-download-bar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: 1px solid var(--border, #2e3540);
+    }
+    .table-download-btn {
+      background: transparent;
+      color: var(--text, #e4e8ef);
+      border: 1px solid var(--border, #2e3540);
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      transition: all .15s;
+    }
+    .table-download-btn:hover {
+      background: var(--green, #1e88e5);
+      border-color: var(--green, #1e88e5);
+      color: #fff;
+    }
+    .table-download-btn svg {
+      width: 14px;
+      height: 14px;
+    }
+    .table-rows-info {
+      color: var(--muted, #7a8494);
+      font-size: 11px;
+    }
   </style>
 
   <!-- Translation script -->
@@ -10354,6 +10450,52 @@
         }
       });
 
+      // Handle table download button clicks (delegated event)
+      messagesEl.addEventListener('click', function(e) {
+        const downloadBtn = e.target.closest('.table-download-btn');
+        if (!downloadBtn) return;
+
+        e.preventDefault();
+        
+        // Find the table data in the same table container
+        const tableContainer = downloadBtn.closest('.ai-table-container');
+        const dataScript = tableContainer.querySelector('script.table-data');
+        
+        if (!dataScript) {
+          console.error('Table data not found');
+          return;
+        }
+
+        try {
+          const tableData = JSON.parse(dataScript.textContent);
+          const { headers, rows } = tableData;
+          
+          // Convert to CSV
+          const csvContent = [
+            headers.join(','),
+            ...rows.map(row => row.map(cell => {
+              // Escape quotes and wrap in quotes if contains comma
+              const escaped = String(cell).replace(/"/g, '""');
+              return escaped.includes(',') ? `"${escaped}"` : escaped;
+            }).join(','))
+          ].join('\n');
+          
+          // Create download link
+          const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = `table_${new Date().toISOString().slice(0,10)}_${new Date().toISOString().slice(11,19).replace(/:/g,'-')}.csv`;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+        } catch (err) {
+          console.error('Error downloading table:', err);
+          alert('Failed to download table: ' + err.message);
+        }
+      });
+
       const expandBtn = document.getElementById('safecast-ai-expand');
 
       closeBtn.addEventListener('click', () => {
@@ -10457,7 +10599,7 @@
         }
       }
 
-      function markdownToHTML(text) {
+      function markdownToHTML(text, enableTableDownload = false) {
         if (!text) return '';
 
         let html = text
@@ -10478,7 +10620,7 @@
           let rows = match.trim().split('\n').map(r => r.trim()).filter(r => r.length > 0);
           if (rows.length < 2) return match;
 
-          let out = '<div class="ai-table-container"><table class="ai-table">';
+          let tableData = [];
           let bodyRows = [];
 
           rows.forEach((row) => {
@@ -10490,6 +10632,30 @@
             if (row.endsWith('|')) cols.pop();
             bodyRows.push(cols.map(c => c.trim()));
           });
+
+          // Store table data for export
+          const headers = bodyRows[0] || [];
+          const dataRows = bodyRows.slice(1) || [];
+          
+          let out = '<div class="ai-table-container">';
+          
+          // Add download button if enabled
+          if (enableTableDownload && dataRows.length > 0) {
+            out += '<div class="table-download-bar">';
+            out += '<button class="table-download-btn" data-table-index="' + (tableData.length) + '" title="Download table as CSV">';
+            out += '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
+            out += ' Download Table';
+            out += '</button>';
+            out += '<span class="table-rows-info">' + dataRows.length + ' rows</span>';
+            out += '</div>';
+            
+            // Store table data in a script tag for later retrieval
+            out += '<script type="application/json" class="table-data">';
+            out += JSON.stringify({ headers: headers, rows: dataRows });
+            out += '</script>';
+          }
+          
+          out += '<table class="ai-table">';
 
           bodyRows.forEach((cols, rowIndex) => {
             out += '<tr>';
@@ -10533,7 +10699,8 @@
         bubble.className = 'ai-bubble';
 
         if (role === 'bot') {
-          bubble.innerHTML = markdownToHTML(text);
+          // Enable table downloads for bot messages
+          bubble.innerHTML = markdownToHTML(text, true);
         } else {
           bubble.textContent = text;
         }

--- a/test_table_download.html
+++ b/test_table_download.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Test Table Download</title>
+  <style>
+    body {
+      background: #1a1e24;
+      color: #e4e8ef;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 40px;
+    }
+    
+    .ai-table-container {
+      background: #242930;
+      border: 1px solid #2e3540;
+      border-radius: 8px;
+      margin: 20px 0;
+      overflow: hidden;
+    }
+    
+    .table-download-bar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: 1px solid #2e3540;
+    }
+    
+    .table-download-btn {
+      background: transparent;
+      color: #e4e8ef;
+      border: 1px solid #2e3540;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      transition: all .15s;
+    }
+    
+    .table-download-btn:hover {
+      background: #1e88e5;
+      border-color: #1e88e5;
+      color: #fff;
+    }
+    
+    .table-rows-info {
+      color: #7a8494;
+      font-size: 11px;
+    }
+    
+    .ai-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    
+    .ai-table th {
+      background: rgba(255, 255, 255, 0.05);
+      color: #7a8494;
+      font-weight: 600;
+      padding: 8px 12px;
+      text-align: left;
+    }
+    
+    .ai-table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid #2e3540;
+    }
+    
+    .ai-table tr:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
+  </style>
+</head>
+<body>
+  <h1>Test Table Download Functionality</h1>
+  
+  <div class="ai-table-container">
+    <div class="table-download-bar">
+      <button class="table-download-btn" title="Download table as CSV">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+        Download Table
+      </button>
+      <span class="table-rows-info">5 rows</span>
+    </div>
+    <script type="application/json" class="table-data">
+    {"headers":["Device id","Timestamp","Lat","Lon","Cpm","Usvh","Sensor type"],"rows":[["SC-JP-0847","2026-03-03 22:14 UTC","35.6895","139.6917","28","0.193","LND 7318"],["SC-JP-0912","2026-03-03 22:10 UTC","35.6762","139.758","31","0.214","LND 7318"],["SC-JP-0445","2026-03-03 22:08 UTC","35.7189","139.7297","26","0.179","LND 7318"],["SC-JP-0623","2026-03-03 22:05 UTC","35.6549","139.7454","29","0.2","LND 7318"],["SC-JP-0778","2026-03-03 22:02 UTC","35.6814","139.7673","27","0.186","LND 7318"]]}
+    </script>
+    <table class="ai-table">
+      <thead>
+        <tr>
+          <th>Device id</th>
+          <th>Timestamp</th>
+          <th>Lat</th>
+          <th>Lon</th>
+          <th>Cpm</th>
+          <th>Usvh</th>
+          <th>Sensor type</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>SC-JP-0847</td>
+          <td>2026-03-03 22:14 UTC</td>
+          <td>35.6895</td>
+          <td>139.6917</td>
+          <td>28</td>
+          <td>0.193</td>
+          <td>LND 7318</td>
+        </tr>
+        <tr>
+          <td>SC-JP-0912</td>
+          <td>2026-03-03 22:10 UTC</td>
+          <td>35.6762</td>
+          <td>139.758</td>
+          <td>31</td>
+          <td>0.214</td>
+          <td>LND 7318</td>
+        </tr>
+        <tr>
+          <td>SC-JP-0445</td>
+          <td>2026-03-03 22:08 UTC</td>
+          <td>35.7189</td>
+          <td>139.7297</td>
+          <td>26</td>
+          <td>0.179</td>
+          <td>LND 7318</td>
+        </tr>
+        <tr>
+          <td>SC-JP-0623</td>
+          <td>2026-03-03 22:05 UTC</td>
+          <td>35.6549</td>
+          <td>139.7454</td>
+          <td>29</td>
+          <td>0.2</td>
+          <td>LND 7318</td>
+        </tr>
+        <tr>
+          <td>SC-JP-0778</td>
+          <td>2026-03-03 22:02 UTC</td>
+          <td>35.6814</td>
+          <td>139.7673</td>
+          <td>27</td>
+          <td>0.186</td>
+          <td>LND 7318</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <script>
+    document.addEventListener('click', function(e) {
+      const downloadBtn = e.target.closest('.table-download-btn');
+      if (!downloadBtn) return;
+
+      e.preventDefault();
+      
+      const tableContainer = downloadBtn.closest('.ai-table-container');
+      const dataScript = tableContainer.querySelector('script.table-data');
+      
+      if (!dataScript) {
+        console.error('Table data not found');
+        return;
+      }
+
+      try {
+        const tableData = JSON.parse(dataScript.textContent);
+        const { headers, rows } = tableData;
+        
+        const csvContent = [
+          headers.join(','),
+          ...rows.map(row => row.map(cell => {
+            const escaped = String(cell).replace(/"/g, '""');
+            return escaped.includes(',') ? `"${escaped}"` : escaped;
+          }).join(','))
+        ].join('\n');
+        
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `table_${new Date().toISOString().slice(0,10)}_${new Date().toISOString().slice(11,19).replace(/:/g,'-')}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        console.error('Error downloading table:', err);
+        alert('Failed to download table: ' + err.message);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds table download functionality and clickable device links to the AI assistant.

## Changes
- **Download Button**: All markdown tables in AI chat responses now have a download button
- **Clickable Device Links**: Device IDs in tables are now clickable links to the map
- **AI Hints Updated**: Strengthened formatting rules in MCP tool hints
- **Test Page**: Included test page for verification

## Features
- Tables store data for CSV export with proper escaping
- Download button shows row count
- Device IDs link to https://simplemap.safecast.org with lat/lon coordinates
- Works for both data_preview tables and markdown tables

## Testing
Tested locally with the AI assistant - both features work as expected.