### PR TITLE
fix: add missing build tags to duckdb_analytics.go and stub var

### DIFF
--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -1,3 +1,5 @@
+//go:build duckdb
+
 // DuckDB Analytics Initialization for Unified Server
 // Uses DuckLake with PostgreSQL catalog for shared analytics across all services
 

--- a/cmd/unified-server/duckdb_stub.go
+++ b/cmd/unified-server/duckdb_stub.go
@@ -3,8 +3,12 @@
 package main
 
 import (
+	"database/sql"
 	"log"
 )
+
+// duckDB is nil when the duckdb build tag is not provided.
+var duckDB *sql.DB
 
 // Stub for DuckDB when not enabled in build tags
 func initDuckDBAnalytics() error {


### PR DESCRIPTION
## Summary
- Add `//go:build duckdb` to `duckdb_analytics.go` — it was missing after the rebase/merge, causing redeclaration errors against `duckdb_stub.go`
- Add `var duckDB *sql.DB` to the stub so non-duckdb builds compile cleanly (all call sites already guard with `duckDB == nil`)

## Root cause
The PR #91 merge brought `duckdb_stub.go` into main without the corresponding build tag on `duckdb_analytics.go`, breaking the default `go build` invocation.

## Test plan
- [ ] `go build -o safecast-new-map ./cmd/unified-server/` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)