### PR TITLE
feat: remove /assistant/ page + truncate AI chat tables to 10 rows

### DIFF
--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,11 +29,6 @@ var (
 	mcpHintsLoader  *modeladapter.HintsLoader
 )
 
-//go:embed static/index.html
-var webChatIndexHTML []byte
-
-//go:embed static/safecast-square-ct.png
-var webChatLogoPNG []byte
 
 // Maximum tokens for the prompt sent to Claude. Leave headroom for tool results.
 const maxPromptTokens = 150000
@@ -579,26 +573,15 @@ func RegisterMCP() {
 	if apiKey != "" {
 		chatHandler := handleWebChat(mcpURL, apiKey, model)
 
-		// Register on MCP mux (port 3333)
-		mux.HandleFunc("/assistant/", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Write(webChatIndexHTML)
-		})
-		mux.HandleFunc("/safecast-square-ct.png", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "image/png")
-			w.Header().Set("Cache-Control", "public, max-age=86400")
-			w.Write(webChatLogoPNG)
-		})
+		// Register /chat on MCP mux (port 3333)
 		mux.HandleFunc("/chat", chatHandler)
 
 		// Also register /chat on main map server (port 8765) so the
 		// embedded widget can use a relative "/chat" URL without
 		// cross-origin or CloudFront routing issues.
 		http.HandleFunc("/chat", chatHandler)
-
-		log.Printf("Web chat enabled at http://localhost:%s/assistant/ (model=%s)", mcpPort, model)
 	} else {
-		log.Println("Web chat disabled: ANTHROPIC_API_KEY not set")
+		log.Println("AI chat disabled: ANTHROPIC_API_KEY not set")
 	}
 
 	log.Printf("MCP Server starting on port %s", mcpPort)
@@ -607,9 +590,6 @@ func RegisterMCP() {
 	log.Printf("  Hints directory: %s", hintsDir)
 	log.Println("  REST API: /api/...")
 	log.Println("  Swagger UI: /mcp-api/")
-	if apiKey != "" {
-		log.Printf("  Web Chat: http://localhost:%s/assistant/", mcpPort)
-	}
 
 	// Start MCP server on separate port
 	go func() {
@@ -763,8 +743,7 @@ func registerSwaggerDocs(mux *http.ServeMux) {
 					'<p style="margin:0 0 16px;font-size:15px;color:#555;">' +
 						'This API is designed for AI assistants and automated tools. It exposes the Safecast radiation dataset ' +
 						'as a set of callable functions (MCP tools) and standard REST endpoints, so that language models and ' +
-						'applications can query radiation data programmatically. If you want to ask questions about the data ' +
-						'in plain English instead, try the <a href="/assistant/" style="color:#0d9488;">AI web chat</a>.' +
+						'applications can query radiation data programmatically. Use the map AI chat panel to query data in plain English.' +
 					'</p>' +
 					'<details style="margin-bottom:16px;">' +
 						'<summary style="cursor:pointer;font-weight:600;font-size:14px;color:#0f3d38;user-select:none;">For developers &mdash; transports &amp; tools overview</summary>' +
@@ -782,14 +761,13 @@ func registerSwaggerDocs(mux *http.ServeMux) {
 								'<p style="margin:4px 0 0;font-size:13px;color:#555;">All MCP tools are also accessible as plain HTTP GET/POST calls under <code>/api/</code>.</p>' +
 							'</div>' +
 							'<div style="background:#f0fdfa;border:1px solid #99f6e4;border-radius:8px;padding:12px;">' +
-								'<strong style="color:#0f3d38;">AI Web Chat</strong>' +
-								'<p style="margin:4px 0 0;font-size:13px;color:#555;">Human-friendly interface at <code>/assistant/</code> for querying data with natural language.</p>' +
+								'<strong style="color:#0f3d38;">AI Map Chat</strong>' +
+								'<p style="margin:4px 0 0;font-size:13px;color:#555;">Open the map and use the AI chat panel to query data with natural language.</p>' +
 							'</div>' +
 						'</div>' +
 						'<p style="margin:12px 0 0;font-size:13px;color:#777;">No authentication required. All data is CC0 licensed.</p>' +
 					'</details>' +
 					'<div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;">' +
-						'<a href="/assistant/" style="display:inline-block;padding:7px 16px;background:#0f3d38;color:#fff;border-radius:6px;font:600 13px/1.4 sans-serif;text-decoration:none;">Open AI Chat</a>' +
 						'<a href="' + mapDocsURL + '" style="display:inline-block;padding:7px 16px;background:#1a3a5c;color:#fff;border-radius:6px;font:600 13px/1.4 sans-serif;text-decoration:none;">\u2190 Switch to Map API</a>' +
 					'</div>' +
 				'</div>';

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10755,11 +10755,14 @@ function selectHomeSearchResult(result, query) {
 
           const headers = bodyRows[0] || [];
           const dataRows = bodyRows.slice(1);
+          const maxDisplay = 10;
+          const visibleRows = dataRows.slice(0, maxDisplay);
+          const truncated = dataRows.length > maxDisplay;
 
           let out = '<div class="ai-table-container">';
 
           if (enableTableDownload && dataRows.length > 0) {
-            // Encode table data into a data attribute for CSV export
+            // Store ALL rows in data attribute so downloads get the full table
             const tableJson = JSON.stringify({ headers: headers, rows: dataRows })
               .replace(/&/g, '&amp;').replace(/"/g, '&quot;');
             const dlSvg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
@@ -10767,23 +10770,31 @@ function selectHomeSearchResult(result, query) {
             out += '<button class="table-download-btn" data-fmt="csv" title="Download as CSV">' + dlSvg + ' CSV</button>';
             out += '<button class="table-download-btn excel" data-fmt="excel" title="Download as Excel">' + dlSvg + ' Excel</button>';
             out += '<button class="table-download-btn json" data-fmt="json" title="Download as JSON">' + dlSvg + ' JSON</button>';
-            out += '<span class="table-rows-info">' + dataRows.length + ' rows</span>';
+            if (truncated) {
+              out += '<span class="table-rows-info">showing ' + maxDisplay + ' of ' + dataRows.length + ' rows — download for all</span>';
+            } else {
+              out += '<span class="table-rows-info">' + dataRows.length + ' rows</span>';
+            }
             out += '</div>';
           }
 
           out += '<table class="ai-table">';
 
-          bodyRows.forEach((cols, rowIndex) => {
+          // Header row
+          out += '<tr>';
+          headers.forEach(col => { out += `<th>${col}</th>`; });
+          out += '</tr>';
+
+          // Data rows — only show up to maxDisplay
+          visibleRows.forEach(cols => {
             out += '<tr>';
-            cols.forEach(col => {
-              if (rowIndex === 0) {
-                out += `<th>${col}</th>`;
-              } else {
-                out += `<td>${col}</td>`;
-              }
-            });
+            cols.forEach(col => { out += `<td>${col}</td>`; });
             out += '</tr>';
           });
+
+          if (truncated) {
+            out += `<tr><td colspan="${headers.length}" style="text-align:center;opacity:0.5;font-style:italic;padding:8px;">… ${dataRows.length - maxDisplay} more rows — download to see all</td></tr>`;
+          }
 
           out += '</table></div>';
           return out;


### PR DESCRIPTION
## Summary
- **Remove `/assistant/` standalone web-chat page** — functionality covered by map AI chat panel
- **Truncate large tables to 10 rows** — downloads always deliver the full dataset

## Details
- Dropped embed directives and route handlers for `/assistant/` and `/safecast-square-ct.png`
- Updated Swagger docs to reference map AI chat instead
- `/chat` endpoint unchanged — still powers the map widget on both ports
- Tables with >10 rows show first 10 + greyed footer "… N more rows — download to see all"
- `data-table` attribute always holds all rows so exports are complete

## Test plan
- [ ] Tables with >10 rows show truncation footer
- [ ] CSV/Excel/JSON downloads contain all rows
- [ ] `/assistant/` returns 404
- [ ] Map AI chat works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)