### PR TITLE
fix: AI chat hang, table rendering, and admin delete bugs

### DIFF
--- a/cmd/unified-server/admin_mcp.go
+++ b/cmd/unified-server/admin_mcp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // adminMCPDataHandler returns JSON data for MCP analytics tables.
@@ -380,7 +382,9 @@ func adminMCPDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		query := fmt.Sprintf("DELETE FROM %s %s", tableName, whereSQL)
-		result, err := duckDB.Exec(query)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		result, err := duckDB.ExecContext(ctx, query)
 		if err != nil {
 			log.Printf("admin mcp delete all error: %v", err)
 			http.Error(w, "Delete failed", http.StatusInternalServerError)
@@ -399,21 +403,48 @@ func adminMCPDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Integer key columns: use numeric IN list (avoids CAST issues in DuckLake
+	// and keeps IDs within JS MAX_SAFE_INTEGER range).
+	// Timestamp key columns: fall back to string CAST comparison.
+	integerKeyCols := map[string]bool{"id": true}
+
 	idList := strings.Split(ids, ",")
-	placeholders := make([]string, len(idList))
-	for i := range idList {
-		placeholders[i] = "'" + escapeLike(strings.TrimSpace(idList[i])) + "'"
+	var query string
+	if integerKeyCols[keyCol] {
+		nums := make([]string, 0, len(idList))
+		for _, raw := range idList {
+			raw = strings.TrimSpace(raw)
+			if _, err := strconv.ParseInt(raw, 10, 64); err == nil {
+				nums = append(nums, raw)
+			}
+		}
+		if len(nums) == 0 {
+			http.Error(w, "No valid integer IDs provided", http.StatusBadRequest)
+			return
+		}
+		query = fmt.Sprintf("DELETE FROM %s WHERE %s IN (%s)",
+			tableName, keyCol, strings.Join(nums, ","))
+	} else {
+		placeholders := make([]string, len(idList))
+		for i, raw := range idList {
+			placeholders[i] = "'" + escapeLike(strings.TrimSpace(raw)) + "'"
+		}
+		query = fmt.Sprintf("DELETE FROM %s WHERE CAST(%s AS VARCHAR) IN (%s)",
+			tableName, keyCol, strings.Join(placeholders, ","))
 	}
 
-	query := fmt.Sprintf("DELETE FROM %s WHERE CAST(%s AS VARCHAR) IN (%s)",
-		tableName, keyCol, strings.Join(placeholders, ","))
-	result, err := duckDB.Exec(query)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	result, err := duckDB.ExecContext(ctx, query)
 	if err != nil {
 		log.Printf("admin mcp delete error: %v", err)
 		http.Error(w, "Delete failed", http.StatusInternalServerError)
 		return
 	}
 	affected, _ := result.RowsAffected()
+	if affected < 0 {
+		affected = int64(len(idList)) // DuckDB doesn't always report rows affected
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"deleted": affected})
 }

--- a/cmd/unified-server/mcp_db_helpers.go
+++ b/cmd/unified-server/mcp_db_helpers.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"log"
 	"time"
 )
 
@@ -82,13 +83,14 @@ func LogQueryAsync(name string, args map[string]any, resultCount int, duration t
 		}
 	}
 
-	_, err := duckDB.Exec(`
-		INSERT INTO mcp_query_log (tool_name, duration_ms, result_count, client, user_id, user_email)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, name, duration.Milliseconds(), resultCount, client, userID, userEmail)
-
-	if err != nil {
-		// Silently ignore logging errors
-		return
-	}
+	// Run in background — DuckLake writes can be slow and must never block MCP tool responses.
+	go func() {
+		_, err := duckDB.Exec(`
+			INSERT INTO mcp_query_log (tool_name, duration_ms, result_count, client, user_id, user_email)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, name, duration.Milliseconds(), resultCount, client, userID, userEmail)
+		if err != nil {
+			log.Printf("LogQueryAsync: %v", err)
+		}
+	}()
 }

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -446,15 +446,10 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		}
 
 		finalAnswer := strings.TrimSpace(answerText.String())
-		logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, finalAnswer, embeddingChatID)
 
-		// 3. Async: store Q&A + embedding in semantic cache for future lookups.
-		if len(embedding) > 0 && finalAnswer != "" {
-			storeQAEmbeddingAsync(ctx, embeddingChatID, chatQuestion, finalAnswer, embedding)
-		}
-
-		// If list_sensors was called and returned an export URL, send it to the
-		// client so the download buttons can fetch the full dataset from the server.
+		// Send export URL (if list_sensors was used) and done chunk BEFORE any
+		// DuckDB logging so the client always receives finish signal promptly.
+		// DuckLake writes can be slow (Parquet flush) and must never block the response.
 		if pendingExportURL != "" {
 			writeChunkBuffered(w, chunk{
 				Type:        "export",
@@ -466,6 +461,14 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		writeChunkBuffered(w, chunk{Type: "done", ChatID: embeddingChatID}, &buffer, isCloudFront)
 		if isCloudFront {
 			flushBuffer(w, buffer)
+		}
+
+		// Log and store asynchronously — must not block after done is sent.
+		go logChatQuestionWithAnswer(chatReqRef, chatQuestion, chatSource, chatModel, "", chatHistory, chatClientTS, finalAnswer, embeddingChatID)
+
+		// 3. Async: store Q&A + embedding in semantic cache for future lookups.
+		if len(embedding) > 0 && finalAnswer != "" {
+			storeQAEmbeddingAsync(ctx, embeddingChatID, chatQuestion, finalAnswer, embedding)
 		}
 	}
 }

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -10866,11 +10866,27 @@ function selectHomeSearchResult(result, query) {
           .replace(/`([^`]+)`/g, '<code style="background: var(--control-bg); padding: 2px 5px; border-radius: 4px; font-size: 0.9em;">$1</code>')
           .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank">$1</a>');
 
-        // Robust Markdown Table parser
-        // We match from the first pipe to the last pipe in a greedy block
-        html = html.replace(/((^|\n)\|[\s\S]*?\|($|\n(?![| \t]*\|)))/g, function (match) {
-          let rows = match.trim().split('\n').map(r => r.trim()).filter(r => r.length > 0);
-          if (rows.length < 2) return match;
+        // Markdown Table parser — line-by-line to avoid regex stack overflow on large tables.
+        // Finds consecutive lines starting with | and renders them as HTML tables.
+        // Handles incomplete/truncated tables (e.g. cut off mid-row by token limit).
+        const lines = html.split('\n');
+        const tableBlocks = []; // [{start, end}] indices into lines[]
+        let tStart = -1;
+        for (let i = 0; i <= lines.length; i++) {
+          const isTableLine = i < lines.length && lines[i].trimStart().startsWith('|');
+          if (isTableLine && tStart === -1) { tStart = i; }
+          else if (!isTableLine && tStart !== -1) {
+            if (i - tStart >= 2) tableBlocks.push({start: tStart, end: i});
+            tStart = -1;
+          }
+        }
+        // Process blocks in reverse so indices stay valid as we splice
+        for (let b = tableBlocks.length - 1; b >= 0; b--) {
+          const {start, end} = tableBlocks[b];
+          const tableLines = lines.slice(start, end);
+          const rendered = (function(tableLines) {
+          let rows = tableLines.map(r => r.trim()).filter(r => r.length > 0);
+          if (rows.length < 2) return rows.join('\n');
 
           let bodyRows = [];
 
@@ -10889,6 +10905,7 @@ function selectHomeSearchResult(result, query) {
           const maxDisplay = 10;
           const visibleRows = dataRows.slice(0, maxDisplay);
           const truncated = dataRows.length > maxDisplay;
+          const isSensorTable = headers.some(h => /device.?id/i.test(h.trim()));
 
           let out = '<div class="ai-table-container">';
 
@@ -10900,7 +10917,6 @@ function selectHomeSearchResult(result, query) {
             // Detect sensor tables by header — render <a> links pointing directly
             // to /api/sensors/export (same pattern as track downloads).
             // For all other tables keep blob-based <button> downloads.
-            const isSensorTable = headers.some(h => /device.?id/i.test(h.trim()));
             const date = new Date().toISOString().slice(0, 10);
 
             out += '<div class="table-download-bar" data-table="' + tableJson + '">';
@@ -10944,7 +10960,10 @@ function selectHomeSearchResult(result, query) {
 
           out += '</table></div>';
           return out;
-        });
+          })(tableLines);
+          lines.splice(start, end - start, rendered);
+        }
+        html = lines.join('\n');
 
         // Handle line breaks ONLY if they are not inside a table-container
         let parts = html.split(/(<div class="ai-table-container">[\s\S]*?<\/div>)/g);

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -205,7 +205,7 @@ func storeQAEmbeddingAsync(ctx context.Context, embeddingChatID int64, question,
 		if err != nil {
 			return
 		}
-		id := time.Now().UnixNano()
+		id := time.Now().UnixMilli() // UnixNano exceeds JS MAX_SAFE_INTEGER
 		if _, err := duckDB.Exec(
 			`INSERT INTO qa_embeddings (id, chat_id, question, answer, embedding, feedback_score) VALUES (?, ?, ?, ?, ?, 0)`,
 			id, embeddingChatID, question, answer, string(embJSON),
@@ -273,7 +273,7 @@ func extractLocationKnowledge(chatID int64) {
 	if math.Abs(lat) > 90 || math.Abs(lon) > 180 {
 		return
 	}
-	id := time.Now().UnixNano()
+	id := time.Now().UnixMilli() // UnixNano exceeds JS MAX_SAFE_INTEGER
 	if _, err := duckDB.Exec(
 		`INSERT INTO location_knowledge (id, lat, lon, radius_m, note, source_chat_id) VALUES (?, ?, ?, 1000, ?, ?)`,
 		id, lat, lon, answer, chatID,

--- a/cmd/unified-server/tool_list_sensors.go
+++ b/cmd/unified-server/tool_list_sensors.go
@@ -57,13 +57,23 @@ func handleListSensors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 }
 
 // findRealtimeTable discovers the realtime sensor table in the database.
+// cachedRealtimeTable caches the discovered table name after the first lookup.
+var cachedRealtimeTable string
+
 // Returns (tableName, availableTables, error). tableName is "" if not found.
 func findRealtimeTable(ctx context.Context) (string, []string, error) {
+	// Return cached result — the table name never changes at runtime.
+	if cachedRealtimeTable != "" {
+		return cachedRealtimeTable, nil, nil
+	}
+
+	// Use pg_tables instead of information_schema.tables — the latter can take
+	// minutes on databases with many objects due to complex system-catalog joins.
 	tablesQuery := `
-		SELECT table_name
-		FROM information_schema.tables
-		WHERE table_schema = 'public'
-		ORDER BY table_name
+		SELECT tablename AS table_name
+		FROM pg_tables
+		WHERE schemaname = 'public'
+		ORDER BY tablename
 	`
 	tableRows, err := queryRows(ctx, tablesQuery)
 	if err != nil {
@@ -83,6 +93,7 @@ func findRealtimeTable(ctx context.Context) (string, []string, error) {
 			}
 		}
 	}
+	cachedRealtimeTable = realtimeTable
 	return realtimeTable, availableTables, nil
 }
 


### PR DESCRIPTION
## Summary
- **AI chat hang fixed**: `LogQueryAsync` was blocking synchronously on every MCP tool call — wrapped DuckDB exec in goroutine
- **Sensor query speed**: Replaced slow `information_schema.tables` (could take minutes) with `pg_tables` + in-memory cache in `findRealtimeTable`
- **Table rendering fixed**: Rewrote markdown table parser from regex (fails/overflows on 361-row tables) to line-by-line scanner — also gracefully handles truncated responses cut off mid-row by token limit
- **Delete Selected fixed**: MCP Analytics admin panel now uses numeric `IN` list for `id`-keyed tables instead of broken `CAST(id AS VARCHAR)` comparison
- **JS integer overflow**: Changed `UnixNano()` → `UnixMilli()` for DuckLake row IDs (18-digit nanosecond timestamps exceed JS `MAX_SAFE_INTEGER`)
- **DuckDB timeouts**: Added 30s `context.WithTimeout` to all admin delete operations

## Test plan
- [ ] Ask AI "give me a table with all real-time devices" — should respond in <30s with HTML table + CSV/Excel/JSON buttons
- [ ] Table shows "showing 10 of N rows — download for all" with correct total
- [ ] Download buttons return actual data (CSV/Excel/JSON), not HTML page
- [ ] MCP Analytics → select rows → Delete Selected removes them
- [ ] DuckDB analytics panel shows data (not "not available" error)
- [ ] Short track queries still respond quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)