### PR TITLE
ci: always build and deploy DuckDB binary on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
 
 # ---------- DUCKDB: Unified server with DuckDB analytics (Linux/amd64 + macOS) ----------
   build_duckdb:
-    if: github.server_url == 'https://github.com' && (contains(toJson(github.event.head_commit.message), 'stable release') || github.event_name == 'workflow_dispatch')
+    if: github.server_url == 'https://github.com'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -179,6 +179,41 @@ jobs:
         with:
           name: bin-${{ matrix.target }}
           path: dist/
+
+# ---------- DEPLOY: Push linux/amd64 DuckDB binary to production on every main push ----------
+  deploy:
+    if: github.server_url == 'https://github.com' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build_duckdb]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download linux/amd64 DuckDB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bin-linux_amd64_duckdb
+          path: dist/
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H 65.108.24.131 >> ~/.ssh/known_hosts
+
+      - name: Stop service
+        run: ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl stop safecast-new-map"
+
+      - name: Upload binary
+        run: |
+          chmod +x dist/safecast-new-map_linux_amd64_duckdb
+          rsync -avP -e "ssh -i ~/.ssh/deploy_key" \
+            dist/safecast-new-map_linux_amd64_duckdb \
+            root@65.108.24.131:/usr/local/bin/safecast-new-map
+
+      - name: Start service and verify
+        run: |
+          ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl start safecast-new-map"
+          sleep 3
+          ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl is-active safecast-new-map"
 
   release:
     if: github.server_url == 'https://github.com'


### PR DESCRIPTION
## Problem
`build_duckdb` was gated on the commit message containing `'stable release'`, so every normal push to main deployed a portable (no-analytics) binary. This caused **Analytics not available** on production.

## Changes
- **`build_duckdb`**: removed the `'stable release'` condition — now runs on every push to main
- **`deploy` (new job)**: runs after `build_duckdb` succeeds, SSH-deploys `safecast-new-map_linux_amd64_duckdb` to `65.108.24.131:/usr/local/bin/safecast-new-map` on every main push
- **`release`** (portable multi-platform + GitHub Release): still gated on `'stable release'` commits — no change

## Test plan
- [ ] Merge → verify CI `build_duckdb` and `deploy` jobs both pass
- [ ] Check `https://simplemap.safecast.org/admin/mcp` — Analytics should no longer show "Analytics not available"
- [ ] Verify `systemctl is-active safecast-new-map` returns `active` in the deploy job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)