### PR TITLE
fix: MCP analytics search error and local data persistence

### DIFF
--- a/cmd/unified-server/admin_mcp.go
+++ b/cmd/unified-server/admin_mcp.go
@@ -71,10 +71,17 @@ func adminMCPDataHandler(w http.ResponseWriter, r *http.Request) {
 
 	search := r.URL.Query().Get("search")
 
-	// Build WHERE clause for search
+	// virtualCols are computed via JOIN, not real columns in the table — must be
+	// excluded from WHERE clauses and direct SELECTs.
+	virtualCols := map[string]bool{"thumbs_up": true, "thumbs_down": true}
+
+	// Build WHERE clause for search — skip virtual (computed) columns
 	var whereClauses []string
 	if search != "" {
 		for _, col := range columns {
+			if virtualCols[col] {
+				continue
+			}
 			whereClauses = append(whereClauses, fmt.Sprintf("CAST(%s AS VARCHAR) ILIKE '%%%s%%'", col, escapeLike(search)))
 		}
 	}
@@ -101,7 +108,6 @@ func adminMCPDataHandler(w http.ResponseWriter, r *http.Request) {
 	// inlined VARCHAR values are truncated to a single byte on read.
 	// LEFT(col, 100000) forces DuckDB to materialize a new string that the driver reads correctly.
 	longTextCols := map[string]bool{"question": true, "answer": true, "generated_query": true, "user_agent": true, "params": true, "note": true}
-	virtualCols := map[string]bool{"thumbs_up": true, "thumbs_down": true}
 
 	var dataQuery string
 	if tableName == "chat_questions" {
@@ -222,9 +228,15 @@ func adminMCPExportHandler(w http.ResponseWriter, r *http.Request) {
 
 	search := r.URL.Query().Get("search")
 
+	// virtualCols are computed via JOIN, not real columns — skip in WHERE and SELECT.
+	exportVirtualCols := map[string]bool{"thumbs_up": true, "thumbs_down": true}
+
 	var whereClauses []string
 	if search != "" {
 		for _, col := range columns {
+			if exportVirtualCols[col] {
+				continue
+			}
 			whereClauses = append(whereClauses, fmt.Sprintf("CAST(%s AS VARCHAR) ILIKE '%%%s%%'", col, escapeLike(search)))
 		}
 	}
@@ -234,14 +246,20 @@ func adminMCPExportHandler(w http.ResponseWriter, r *http.Request) {
 		whereSQL = "WHERE " + strings.Join(whereClauses, " OR ")
 	}
 
-	// Use LEFT() workaround for long text columns (same DuckLake driver bug as data handler)
+	// Use LEFT() workaround for long text columns (same DuckLake driver bug as data handler).
+	// Skip virtual columns — they are not real columns in the table.
 	exportLongTextCols := map[string]bool{"question": true, "answer": true, "generated_query": true, "user_agent": true, "params": true}
-	exportCastCols := make([]string, len(columns))
-	for i, col := range columns {
+	var exportCastCols []string
+	var exportColumns []string
+	for _, col := range columns {
+		if exportVirtualCols[col] {
+			continue
+		}
+		exportColumns = append(exportColumns, col)
 		if exportLongTextCols[col] {
-			exportCastCols[i] = fmt.Sprintf("LEFT(%s, 100000) AS %s", col, col)
+			exportCastCols = append(exportCastCols, fmt.Sprintf("LEFT(%s, 100000) AS %s", col, col))
 		} else {
-			exportCastCols[i] = col
+			exportCastCols = append(exportCastCols, col)
 		}
 	}
 	colList := strings.Join(exportCastCols, ", ")
@@ -266,18 +284,18 @@ func adminMCPExportHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.csv", tableName))
 
 	writer := csv.NewWriter(w)
-	writer.Write(columns) // header row
+	writer.Write(exportColumns) // header row (virtual cols excluded)
 
 	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		ptrs := make([]interface{}, len(columns))
+		values := make([]interface{}, len(exportColumns))
+		ptrs := make([]interface{}, len(exportColumns))
 		for i := range values {
 			ptrs[i] = &values[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
 			continue
 		}
-		record := make([]string, len(columns))
+		record := make([]string, len(exportColumns))
 		for i, v := range values {
 			if v == nil {
 				record[i] = ""

--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -19,10 +19,29 @@ var duckDB *sql.DB
 
 // initDuckDBAnalytics initializes DuckDB with DuckLake catalog backed by PostgreSQL.
 // This allows multiple services to share the same analytics tables concurrently.
+// When DuckLake is not configured (local dev), falls back to a local DuckDB file for persistence.
 func initDuckDBAnalytics() error {
-	// Open in-memory DuckDB — all persistent data lives in DuckLake (PostgreSQL + Parquet)
+	ducklakePGURL := os.Getenv("DUCKLAKE_PG_URL")
+	dataPath := os.Getenv("DUCKLAKE_DATA_PATH")
+	if dataPath == "" {
+		dataPath = "/var/lib/safecast/ducklake/"
+	}
+
+	useDucklake := ducklakePGURL != ""
+
+	// Open DuckDB — in-memory when using DuckLake (data lives in PG+Parquet),
+	// or a local file for persistence when running without DuckLake (local dev).
+	dbPath := ""
+	if !useDucklake {
+		localPath := os.Getenv("DUCKDB_LOCAL_PATH")
+		if localPath == "" {
+			localPath = "./analytics_local.duckdb"
+		}
+		dbPath = localPath
+	}
+
 	var err error
-	duckDB, err = sql.Open("duckdb", "")
+	duckDB, err = sql.Open("duckdb", dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to open duckdb: %w", err)
 	}
@@ -35,45 +54,39 @@ func initDuckDBAnalytics() error {
 		return fmt.Errorf("failed to ping duckdb: %w", err)
 	}
 
-	log.Println("DuckDB initialized (in-memory)")
+	if useDucklake {
+		log.Println("DuckDB initialized (in-memory, DuckLake mode)")
 
-	// Install and load required extensions
-	for _, ext := range []string{"ducklake", "postgres"} {
-		if _, err := duckDB.Exec(fmt.Sprintf("INSTALL %s;", ext)); err != nil {
-			log.Printf("Warning: INSTALL %s failed: %v", ext, err)
+		// Install and load required extensions
+		for _, ext := range []string{"ducklake", "postgres"} {
+			if _, err := duckDB.Exec(fmt.Sprintf("INSTALL %s;", ext)); err != nil {
+				log.Printf("Warning: INSTALL %s failed: %v", ext, err)
+			}
+			if _, err := duckDB.Exec(fmt.Sprintf("LOAD %s;", ext)); err != nil {
+				return fmt.Errorf("LOAD %s: %w", ext, err)
+			}
 		}
-		if _, err := duckDB.Exec(fmt.Sprintf("LOAD %s;", ext)); err != nil {
-			return fmt.Errorf("LOAD %s: %w", ext, err)
-		}
-	}
 
-	// Attach DuckLake catalog via PostgreSQL (optional — falls back to in-memory for local dev)
-	ducklakePGURL := os.Getenv("DUCKLAKE_PG_URL")
-	if ducklakePGURL == "" {
-		ducklakePGURL = "dbname=ducklake_catalog host=localhost user=ducklake_rw"
-	}
-	dataPath := os.Getenv("DUCKLAKE_DATA_PATH")
-	if dataPath == "" {
-		dataPath = "/var/lib/safecast/ducklake/"
-	}
-
-	attachQuery := fmt.Sprintf(
-		"ATTACH 'ducklake:postgres:%s' AS analytics (DATA_PATH '%s');",
-		ducklakePGURL, dataPath,
-	)
-	ducklakeOK := false
-	if _, err := duckDB.Exec(attachQuery); err != nil {
-		log.Printf("Warning: DuckLake attach failed (%v) — falling back to in-memory tables (local dev mode)", err)
-	} else {
-		log.Printf("DuckLake attached (catalog=PostgreSQL, data=%s)", dataPath)
-		if _, err := duckDB.Exec("USE analytics;"); err != nil {
-			log.Printf("Warning: USE analytics failed: %v — using in-memory tables", err)
+		attachQuery := fmt.Sprintf(
+			"ATTACH 'ducklake:postgres:%s' AS analytics (DATA_PATH '%s');",
+			ducklakePGURL, dataPath,
+		)
+		ducklakeOK := false
+		if _, err := duckDB.Exec(attachQuery); err != nil {
+			log.Printf("Warning: DuckLake attach failed (%v) — falling back to in-memory tables", err)
 		} else {
-			ducklakeOK = true
+			log.Printf("DuckLake attached (catalog=PostgreSQL, data=%s)", dataPath)
+			if _, err := duckDB.Exec("USE analytics;"); err != nil {
+				log.Printf("Warning: USE analytics failed: %v — using in-memory tables", err)
+			} else {
+				ducklakeOK = true
+			}
 		}
-	}
-	if !ducklakeOK {
-		log.Println("DuckDB running in-memory only (analytics will not persist across restarts)")
+		if !ducklakeOK {
+			log.Println("DuckDB running in-memory only (analytics will not persist across restarts)")
+		}
+	} else {
+		log.Printf("DuckDB initialized (local file: %s)", dbPath)
 	}
 
 	// Also attach main Safecast PostgreSQL for cross-database queries (read-only)

--- a/docs/cloudfront-setup.md
+++ b/docs/cloudfront-setup.md
@@ -186,3 +186,58 @@ Developer → 65.108.24.131 (Direct IP) → Server
   - Bytes downloaded
   - Error rates
   - Popular objects
+
+---
+
+## Nginx Routing Rules — Port 3333 vs 8765
+
+The unified server runs two listeners:
+- **Port 8765** — main map server (`cmd/unified-server`). Handles all web pages, uploads, auth, and track downloads (CSV/XLSX/JSON) via `pkg/httpapi/handlers_core.go`.
+- **Port 3333** — MCP server (same binary, separate goroutine). Handles MCP protocol (`/mcp`, `/mcp-http`) and exposes a JSON-only REST mirror of `/api/*`.
+
+### Critical routing rule: never use a broad `location /api/`
+
+The MCP server's REST mirror (`rest_tracks.go`) only returns **JSON**. It does not detect `.csv` or `.xlsx` extensions. Only port 8765's `handleTrackData` in `handlers_core.go` performs format detection and serves CSV/XLSX downloads.
+
+A broad `location /api/` block pointing to port 3333 **breaks all file-format downloads** — requests like `/api/track/8hp0s9.csv` reach the MCP server, which strips no extension and returns JSON.
+
+**Correct approach (origin-simplemap.safecast.org):** Use specific `location =` rules for each MCP-only endpoint, and route `/api/track/` to port 8765:
+
+```nginx
+# MCP-only endpoints → port 3333
+location = /api/radiation  { proxy_pass http://localhost:3333/api/radiation; ... }
+location = /api/area       { proxy_pass http://localhost:3333/api/area; ... }
+location = /api/stats      { proxy_pass http://localhost:3333/api/stats; ... }
+location = /api/extreme    { proxy_pass http://localhost:3333/api/extreme; ... }
+location = /api/spectra    { proxy_pass http://localhost:3333/api/spectra; ... }
+location /api/sensor/      { proxy_pass http://localhost:3333/api/sensor/; ... }
+location /api/device/      { proxy_pass http://localhost:3333/api/device/; ... }
+location /api/info/        { proxy_pass http://localhost:3333/api/info/; ... }
+
+# Track downloads (CSV/XLSX/JSON) MUST go to port 8765
+location ~ ^/api/track/[^/]+/insights { proxy_pass http://localhost:8765; ... }
+location /api/track/       { proxy_pass http://localhost:8765; ... }
+
+# Everything else → port 8765
+location / { proxy_pass http://localhost:8765; ... }
+```
+
+**Wrong (breaks CSV/XLSX downloads):**
+```nginx
+location /api/ {
+    proxy_pass http://localhost:3333/api/;  # ← sends /api/track/x.csv to MCP → JSON returned
+}
+```
+
+### How track format detection works (port 8765 only)
+
+`pkg/httpapi/handlers_core.go` `handleTrackData()` strips the extension from the URL path before querying the database:
+
+| URL | Format served |
+|-----|--------------|
+| `/api/track/8hp0s9` | JSON |
+| `/api/track/8hp0s9.json` | JSON |
+| `/api/track/8hp0s9.csv` | CSV (`text/csv`, `Content-Disposition: attachment`) |
+| `/api/track/8hp0s9.xlsx` | XLSX (`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`) |
+
+The MCP server's `rest_tracks.go` `handleTrack()` does none of this — it passes the full path segment (including `.csv`) as the track ID and always returns JSON.


### PR DESCRIPTION
## Summary
- Fix DuckDB binder error when searching MCP analytics — virtual columns `thumbs_up`/`thumbs_down` (computed via JOIN) were incorrectly included in `WHERE` clauses against the base table
- Fix export handler to exclude virtual columns from both `SELECT` and CSV header
- Fix local dev data loss on restart: use a local file-based DuckDB (`analytics_local.duckdb`) when `DUCKLAKE_PG_URL` is not set, instead of in-memory only

## Test plan
- [ ] Search "Mitsue" (or any term) in MCP Analytics → Chat Questions — should return results without error
- [ ] Restart local server — analytics entries should still be visible
- [ ] Export CSV from Chat Questions — should not error and should omit thumbs_up/thumbs_down columns (they're not in the base table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)