### PR TITLE
fix: CI duckdb build uses committed go.mod instead of mutating deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,6 @@ jobs:
             VERSION=${{ github.run_number }}
             mkdir -p dist
             apt-get update && apt-get install -y gcc libc6-dev
-            go get github.com/marcboeker/go-duckdb/v2@latest
-            go mod tidy
             GOFLAGS="-trimpath -buildvcs=false" \
             go build -tags "netgo,osusergo,duckdb" \
                      -ldflags "-s -w -X main.CompileVersion=$VERSION" \


### PR DESCRIPTION
## Summary
- Remove `go get github.com/marcboeker/go-duckdb/v2@latest` and `go mod tidy` from the `build_linux_duckdb` CI job
- These commands mutated the dependency graph at build time, producing an 87MB non-duckdb binary instead of the expected 154MB binary with DuckDB embedded
- `go.mod` already correctly pins `github.com/duckdb/duckdb-go/v2 v2.10500.0` — CI should trust it

## Root cause
Every push to main: CI ran `go get` on the deprecated `marcboeker/go-duckdb/v2` module, which pulled in conflicting dependency versions via `go mod tidy`, silently producing a binary that included `duckdb_stub.go` (the `!duckdb` build tag file) instead of the real DuckDB library.

## Test plan
- [ ] Verify next CI run produces a ~154MB `bin-linux_amd64_duckdb` artifact (previously was ~46MB zipped / 87MB binary)
- [ ] Verify production deployment after merge shows `DuckLake attached` in logs (not `DuckDB analytics disabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)