### PR TITLE
fix: use systemctl restart to prevent race with Restart=always

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,8 +217,8 @@ jobs:
 
       - name: Start service and verify
         run: |
-          ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl start safecast-new-map"
-          sleep 3
+          ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl restart safecast-new-map"
+          sleep 5
           ssh -i ~/.ssh/deploy_key root@65.108.24.131 "systemctl is-active safecast-new-map"
 
   release:


### PR DESCRIPTION
## Summary
- Replace `systemctl start` with `systemctl restart` in the deploy workflow
- Increase post-start verification sleep from 3s to 5s

## Root cause
With `Restart=always` + `RestartSec=5` in the systemd unit, after `systemctl stop` the service auto-restarts with the **old binary** before rsync completes (~9s window). `systemctl start` is a no-op if the service is already running, so the deploy appeared successful but the old binary was still serving. `systemctl restart` forces a reload regardless of current state.

## Test plan
- [ ] Next CI deploy shows `DuckLake attached` in production logs (not `DuckDB analytics disabled`)
- [ ] Binary size on server matches ~132MB (duckdb build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)