### PR TITLE
fix: disable Codeberg auto-deploy that overwrote duckdb binary

### DIFF
--- a/.forgejo/workflows/deploy.yml
+++ b/.forgejo/workflows/deploy.yml
@@ -1,12 +1,18 @@
 name: Deploy to Production
 
+# NOTE: Production deployment is handled exclusively by GitHub Actions (.github/workflows/release.yml)
+# which builds the binary with DuckDB analytics support (-tags duckdb).
+# This Forgejo/Codeberg workflow is disabled to prevent overwriting the correct binary.
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'yes' to confirm manual deploy from Codeberg (normally use GitHub Actions)"
+        required: true
 
 jobs:
   deploy:
+    if: ${{ github.event.inputs.confirm == 'yes' }}
     runs-on: codeberg-medium
 
     steps:
@@ -20,7 +26,7 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Build unified server
+      - name: Build unified server (without DuckDB - limited analytics)
         run: |
           go build -o safecast-new-map ./cmd/unified-server
 


### PR DESCRIPTION
## Summary
- The `.forgejo/workflows/deploy.yml` was triggering on every push to Codeberg, building **without** `-tags duckdb` (~87MB) and overwriting the correct GitHub Actions deployment (~132MB with DuckDB analytics)
- This caused the `/admin/mcp` analytics to show "Analytics not available" after every Codeberg push
- Changed the Forgejo workflow trigger from `push` to `workflow_dispatch` only, with a confirmation input

## Root cause
When `git push origin main` is run, it pushes to both GitHub and Codeberg (dual push config). GitHub Actions correctly deploys the duckdb binary. But Codeberg's Forgejo runner also triggered `.forgejo/workflows/deploy.yml`, which built without duckdb tags and overwrote the binary ~90 seconds later.

## Fix
- Forgejo `deploy.yml` now only runs on manual `workflow_dispatch` with explicit confirmation
- GitHub Actions remains the sole automated deploy pipeline

## Test plan
- [x] Manually redeployed the correct duckdb binary — DuckDB/DuckLake confirmed working
- [x] `/admin/mcp` analytics page functional again

🤖 Generated with [Claude Code](https://claude.com/claude-code)