### PR TITLE
fix: proxy Nominatim geocoding through server to fix place search

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -1041,6 +1041,10 @@ func main() {
 		APITrackInsightsHandler:          trackInsightsHandler,
 	})
 
+	// Geocoding proxy — lets the browser search for places without hitting
+	// Nominatim directly (browsers cannot set User-Agent in fetch()).
+	http.DefaultServeMux.HandleFunc("/api/geocode", handleGeocode)
+
 	// Register MCP Server (AI assistant, REST API, Swagger) on port 3333
 	// Uses existing PostgreSQL (db) and DuckDB (duckDB) connections
 	RegisterMCP()

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -8824,15 +8824,11 @@ async function performSearch(query, selectFirst = false) {
   if (!searchResults) return;
 
   try {
-    // Use Nominatim API for geocoding
-    const url = `https://nominatim.openstreetmap.org/search?` +
-      `format=json&q=${encodeURIComponent(query)}&limit=5&addressdetails=1`;
+    // Proxy through our own server so we can set a proper User-Agent for Nominatim
+    // (browsers block setting User-Agent in fetch() as a forbidden header).
+    const url = `/api/geocode?q=${encodeURIComponent(query)}`;
 
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'Safecast Map (https://map.safecast.org)'
-      }
-    });
+    const response = await fetch(url);
 
     if (!response.ok) {
       throw new Error('Search failed');
@@ -9110,14 +9106,9 @@ async function performHomeSearch(query, selectFirst = false) {
   if (!homeSearchResults) return;
 
   try {
-    const url = `https://nominatim.openstreetmap.org/search?` +
-      `format=json&q=${encodeURIComponent(query)}&limit=5&addressdetails=1`;
+    const url = `/api/geocode?q=${encodeURIComponent(query)}`;
 
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'Safecast Map (https://map.safecast.org)'
-      }
-    });
+    const response = await fetch(url);
 
     if (!response.ok) {
       throw new Error('Search failed');

--- a/cmd/unified-server/rest.go
+++ b/cmd/unified-server/rest.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -97,6 +98,43 @@ func (h *RESTHandler) registerAPIRoutes(mux *http.ServeMux) {
 func (h *RESTHandler) Register(mux *http.ServeMux) {
 	h.registerAPIRoutes(mux)
 	registerMainAPIDocsRoutes(mux, "")
+}
+
+// handleGeocode proxies geocoding requests to Nominatim server-side so that
+// the browser does not need to set a User-Agent header (a forbidden header in
+// browser fetch() calls that causes Nominatim to reject the request).
+func handleGeocode(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "missing q parameter")
+		return
+	}
+
+	nominatimURL := "https://nominatim.openstreetmap.org/search?" +
+		url.Values{
+			"format":         {"json"},
+			"q":              {q},
+			"limit":          {"5"},
+			"addressdetails": {"1"},
+		}.Encode()
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, nominatimURL, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to build geocode request")
+		return
+	}
+	req.Header.Set("User-Agent", "Safecast Map (https://map.safecast.org)")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "geocode request failed")
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body) //nolint:errcheck
 }
 
 // writeJSON writes v as a JSON response with the given HTTP status code.


### PR DESCRIPTION
## Summary
- Place search was showing "Search error. Please try again." for all queries
- Root cause: browsers block setting `User-Agent` in `fetch()` (forbidden header), so Nominatim rejected every request
- Added `/api/geocode?q=...` server-side proxy that forwards to Nominatim with the required `User-Agent` header
- Updated both map search and home search to use the proxy instead of calling Nominatim directly

## Test plan
- [ ] Search for a city (e.g. "amsterdam") on the map — results should appear in the dropdown
- [ ] Press Enter on a search result — map should navigate to that location
- [ ] Search from the home page — should also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)