### PR TITLE
fix: point map logo link to Codeberg repo

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -1985,7 +1985,7 @@ body, html {
     </div>
 
     <!-- GitHub link and program info -->
-    <a href="https://github.com/Safecast/safecast-new-map" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="{{translate "github_link_tooltip_desc"}}">
+    <a href="https://codeberg.org/Safecast/safecast-new-map" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="{{translate "github_link_tooltip_desc"}}">
       <img src="/static/images/safecast-logo-squared.png" alt="{{translate "description"}} (version: {{ .Version }})" class="github-icon">
     </a>
 


### PR DESCRIPTION
## Summary
- Changes the Safecast logo link on the map from the GitHub repo to the Codeberg repo (`https://codeberg.org/Safecast/safecast-new-map`)

## Test plan
- [ ] Verify logo link on map opens the Codeberg repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)