### PR TITLE
feat: DB-backed tour steps admin with multilingual text and element picker

### DIFF
--- a/cmd/unified-server/admin_tour_steps.go
+++ b/cmd/unified-server/admin_tour_steps.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// tourStepsPublicHandler returns enabled tour steps with text resolved for
+// the requested language. Used by map.html.
+//
+// @Summary     Public tour steps
+// @Description Returns enabled, ordered tour steps with text resolved for the requested language.
+// @Tags        tour
+// @Produce     json
+// @Param       lang query string false "Language code (defaults to 'en')"
+// @Success     200 {array}  map[string]interface{} "Tour steps"
+// @Failure     503 {string} string "Database unavailable"
+// @Router      /api/tour/steps [get]
+func tourStepsPublicHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	lang := r.URL.Query().Get("lang")
+	if lang == "" {
+		lang = getPreferredLanguage(r)
+	}
+	steps, err := newTourService().ListPublic(lang)
+	if err != nil {
+		log.Printf("tour public list error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"steps": steps})
+}
+
+// adminTourStepsListHandler returns every row (enabled + disabled) for the
+// admin UI.
+//
+// @Summary     Admin tour steps list
+// @Description Returns all tour step rows for admin editing.
+// @Tags        admin
+// @Produce     json
+// @Param       sort  query string false "Sort column"
+// @Param       order query string false "Sort order"
+// @Success     200 {object} map[string]interface{} "Tour step rows"
+// @Failure     503 {string} string "Database unavailable"
+// @Router      /api/admin/tour/steps [get]
+func adminTourStepsListHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	sortCol := r.URL.Query().Get("sort")
+	order := r.URL.Query().Get("order")
+	rows, err := newTourService().List(sortCol, order)
+	if err != nil {
+		log.Printf("admin tour list error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"data":  rows,
+		"total": len(rows),
+	})
+}
+
+// adminTourStepsCreateHandler inserts a new step at the end of the order.
+//
+// @Summary     Admin tour step create
+// @Description Creates a new tour step row.
+// @Tags        admin
+// @Accept      json
+// @Produce     json
+// @Success     201 {object} map[string]interface{} "Create result"
+// @Failure     400 {string} string "Invalid request"
+// @Failure     503 {string} string "Database unavailable"
+// @Router      /api/admin/tour/steps [post]
+func adminTourStepsCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	var in tourStepInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	id, err := newTourService().Create(in)
+	if err != nil {
+		log.Printf("admin tour create error: %v", err)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]interface{}{"status": "ok", "id": id})
+}
+
+// adminTourStepsReorderHandler rewrites sort_order to match a given slice of
+// row IDs in a single transaction.
+//
+// @Summary     Admin tour steps reorder
+// @Description Rewrites sort_order to match a supplied ID order.
+// @Tags        admin
+// @Accept      json
+// @Produce     json
+// @Success     200 {object} map[string]string "Reorder result"
+// @Failure     400 {string} string "Invalid request"
+// @Failure     503 {string} string "Database unavailable"
+// @Router      /api/admin/tour/steps/reorder [post]
+func adminTourStepsReorderHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	var payload struct {
+		IDs []int64 `json:"ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	if err := newTourService().Reorder(payload.IDs); err != nil {
+		log.Printf("admin tour reorder error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Reorder failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminTourStepsByIDHandler routes PUT/DELETE on /api/admin/tour/steps/{id}.
+//
+// @Summary     Admin tour step update/delete
+// @Description Update (PUT) or delete (DELETE) a tour step row by ID.
+// @Tags        admin
+// @Accept      json
+// @Produce     json
+// @Param       id path int true "Tour step ID"
+// @Success     200 {object} map[string]string "Result"
+// @Failure     400 {string} string "Invalid request"
+// @Failure     503 {string} string "Database unavailable"
+// @Router      /api/admin/tour/steps/{id} [put]
+func adminTourStepsByIDHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	parts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
+	idStr := parts[len(parts)-1]
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid step ID")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		var in tourStepInput
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid JSON")
+			return
+		}
+		if err := newTourService().Update(id, in); err != nil {
+			log.Printf("admin tour update error: %v", err)
+			writeError(w, http.StatusInternalServerError, "Update failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case http.MethodDelete:
+		if err := newTourService().Delete(id); err != nil {
+			log.Printf("admin tour delete error: %v", err)
+			writeError(w, http.StatusInternalServerError, "Delete failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/cmd/unified-server/docs/api/unifiedapi_docs.go
+++ b/cmd/unified-server/docs/api/unifiedapi_docs.go
@@ -907,6 +907,166 @@ const docTemplateunifiedapi = `{
                 }
             }
         },
+        "/api/admin/tour/steps": {
+            "get": {
+                "description": "Returns all tour step rows for admin editing.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour steps list",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tour step rows",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new tour step row.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour step create",
+                "responses": {
+                    "201": {
+                        "description": "Create result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/tour/steps/reorder": {
+            "post": {
+                "description": "Rewrites sort_order to match a supplied ID order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour steps reorder",
+                "responses": {
+                    "200": {
+                        "description": "Reorder result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/tour/steps/{id}": {
+            "put": {
+                "description": "Update (PUT) or delete (DELETE) a tour step row by ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour step update/delete",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Tour step ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/admin/tracks": {
             "get": {
                 "description": "Returns paginated track statistics for admin users.",
@@ -2298,6 +2458,44 @@ const docTemplateunifiedapi = `{
                         "description": "Spectrum or format data unavailable",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tour/steps": {
+            "get": {
+                "description": "Returns enabled, ordered tour steps with text resolved for the requested language.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tour"
+                ],
+                "summary": "Public tour steps",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Language code (defaults to 'en')",
+                        "name": "lang",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tour steps",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
                         }
                     },
                     "503": {

--- a/cmd/unified-server/docs/api/unifiedapi_swagger.json
+++ b/cmd/unified-server/docs/api/unifiedapi_swagger.json
@@ -905,6 +905,166 @@
                 }
             }
         },
+        "/api/admin/tour/steps": {
+            "get": {
+                "description": "Returns all tour step rows for admin editing.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour steps list",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tour step rows",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new tour step row.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour step create",
+                "responses": {
+                    "201": {
+                        "description": "Create result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/tour/steps/reorder": {
+            "post": {
+                "description": "Rewrites sort_order to match a supplied ID order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour steps reorder",
+                "responses": {
+                    "200": {
+                        "description": "Reorder result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/tour/steps/{id}": {
+            "put": {
+                "description": "Update (PUT) or delete (DELETE) a tour step row by ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin tour step update/delete",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Tour step ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/admin/tracks": {
             "get": {
                 "description": "Returns paginated track statistics for admin users.",
@@ -2296,6 +2456,44 @@
                         "description": "Spectrum or format data unavailable",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Database unavailable",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tour/steps": {
+            "get": {
+                "description": "Returns enabled, ordered tour steps with text resolved for the requested language.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tour"
+                ],
+                "summary": "Public tour steps",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Language code (defaults to 'en')",
+                        "name": "lang",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tour steps",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
                         }
                     },
                     "503": {

--- a/cmd/unified-server/docs/api/unifiedapi_swagger.yaml
+++ b/cmd/unified-server/docs/api/unifiedapi_swagger.yaml
@@ -730,6 +730,112 @@ paths:
       summary: Admin realtime export
       tags:
       - admin
+  /api/admin/tour/steps:
+    get:
+      description: Returns all tour step rows for admin editing.
+      parameters:
+      - description: Sort column
+        in: query
+        name: sort
+        type: string
+      - description: Sort order
+        in: query
+        name: order
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Tour step rows
+          schema:
+            additionalProperties: true
+            type: object
+        "503":
+          description: Database unavailable
+          schema:
+            type: string
+      summary: Admin tour steps list
+      tags:
+      - admin
+    post:
+      consumes:
+      - application/json
+      description: Creates a new tour step row.
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Create result
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid request
+          schema:
+            type: string
+        "503":
+          description: Database unavailable
+          schema:
+            type: string
+      summary: Admin tour step create
+      tags:
+      - admin
+  /api/admin/tour/steps/{id}:
+    put:
+      consumes:
+      - application/json
+      description: Update (PUT) or delete (DELETE) a tour step row by ID.
+      parameters:
+      - description: Tour step ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Invalid request
+          schema:
+            type: string
+        "503":
+          description: Database unavailable
+          schema:
+            type: string
+      summary: Admin tour step update/delete
+      tags:
+      - admin
+  /api/admin/tour/steps/reorder:
+    post:
+      consumes:
+      - application/json
+      description: Rewrites sort_order to match a supplied ID order.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Reorder result
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Invalid request
+          schema:
+            type: string
+        "503":
+          description: Database unavailable
+          schema:
+            type: string
+      summary: Admin tour steps reorder
+      tags:
+      - admin
   /api/admin/tracks:
     get:
       description: Returns paginated track statistics for admin users.
@@ -1673,6 +1779,32 @@ paths:
       summary: Download spectrum file
       tags:
       - web
+  /api/tour/steps:
+    get:
+      description: Returns enabled, ordered tour steps with text resolved for the
+        requested language.
+      parameters:
+      - description: Language code (defaults to 'en')
+        in: query
+        name: lang
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Tour steps
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+        "503":
+          description: Database unavailable
+          schema:
+            type: string
+      summary: Public tour steps
+      tags:
+      - tour
   /api/track-info/{id}:
     get:
       description: Returns username, detector, and recording date metadata for a track

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -554,8 +554,11 @@ func main() {
 	}
 	queueDuckDBMaintenanceAfterImport(driverName, db, log.Printf, "startup")
 
-	// Seed translations into DB if empty, then reload from DB
+	// Seed translations into DB if empty. Tour step seeding also inserts
+	// tour.<step_key>.text rows, so run it before loading translations so the
+	// in-memory map picks up the new keys on first boot.
 	seedTranslationsDB(content, "public_html/translations.json")
+	seedTourStepsDB()
 	loadTranslationsFromDB()
 
 	// Initialize authentication system if configured
@@ -827,6 +830,7 @@ func main() {
 	var adminMCPPageHandler http.HandlerFunc
 	var adminRealtimePageHandler http.HandlerFunc
 	var adminTranslationsPageHandler http.HandlerFunc
+	var adminTourPageHandler http.HandlerFunc
 
 	// Register authentication and admin page handlers only when auth is enabled.
 	if authManager != nil {
@@ -924,6 +928,16 @@ func main() {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Write(data)
 		}
+
+		adminTourPageHandler = func(w http.ResponseWriter, r *http.Request) {
+			data, err := content.ReadFile("public_html/admin-tour.html")
+			if err != nil {
+				http.Error(w, "Page not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(data)
+		}
 	}
 
 	httpapi.RegisterPageRoutes(http.DefaultServeMux, httpapi.PageRoutesConfig{
@@ -940,6 +954,7 @@ func main() {
 		AdminMCPPageHandler:          adminMCPPageHandler,
 		AdminRealtimePageHandler:     adminRealtimePageHandler,
 		AdminTranslationsPageHandler: adminTranslationsPageHandler,
+		AdminTourPageHandler:         adminTourPageHandler,
 	})
 
 	// Legacy public endpoints (non-/api) live in one registrar to keep route
@@ -974,6 +989,9 @@ func main() {
 	var adminTranslationsReloadAPIHandler http.HandlerFunc
 	var adminTranslationByIDAPIHandler http.HandlerFunc
 	var adminTranslationsAPIHandler http.HandlerFunc
+	var adminTourStepsReorderAPIHandler http.HandlerFunc
+	var adminTourStepsByIDAPIHandler http.HandlerFunc
+	var adminTourStepsAPIHandler http.HandlerFunc
 	if authManager != nil {
 		adminMCPDataAPIHandler = adminMCPDataHandler
 		adminMCPExportAPIHandler = adminMCPExportHandler
@@ -999,6 +1017,24 @@ func main() {
 				adminTranslationsDataHandler(w, r)
 			case http.MethodPost:
 				adminTranslationCreateHandler(w, r)
+			default:
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+		}
+		adminTourStepsReorderAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			adminTourStepsReorderHandler(w, r)
+		}
+		adminTourStepsByIDAPIHandler = adminTourStepsByIDHandler
+		adminTourStepsAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				adminTourStepsListHandler(w, r)
+			case http.MethodPost:
+				adminTourStepsCreateHandler(w, r)
 			default:
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			}
@@ -1034,6 +1070,10 @@ func main() {
 		AdminTranslationsReloadHandler:   adminTranslationsReloadAPIHandler,
 		AdminTranslationByIDHandler:      adminTranslationByIDAPIHandler,
 		AdminTranslationsHandler:         adminTranslationsAPIHandler,
+		APITourStepsHandler:              tourStepsPublicHandler,
+		AdminTourStepsReorderHandler:     adminTourStepsReorderAPIHandler,
+		AdminTourStepsByIDHandler:        adminTourStepsByIDAPIHandler,
+		AdminTourStepsHandler:            adminTourStepsAPIHandler,
 		APISensorsHandler:                restHandler.handleSensors,
 		APISensorsExportHandler:          restHandler.handleSensorsExport,
 		APISensorByIDHandler:             restHandler.handleSensor,

--- a/cmd/unified-server/public_html/admin-tour.html
+++ b/cmd/unified-server/public_html/admin-tour.html
@@ -1,0 +1,640 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tour Steps - Safecast Admin</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
+  <link rel="manifest" href="/static/images/site.webmanifest">
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+  <style>
+    :root {
+      --bg-primary: #f5f5f5; --bg-card: white; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --th-bg: #424242; --hover-bg: #f9f9f9; --btn-border-radius: 8px;
+      --tab-active-bg: #2196F3; --tab-active-text: white;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+        --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+        --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.1);
+        --th-bg: #616161; --hover-bg: #333; --tab-active-bg: #1976D2;
+        color-scheme: dark;
+      }
+    }
+    :root[data-theme='light'] {
+      --bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
+    }
+    :root[data-theme='dark'] {
+      --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+      --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+      --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+      --hover-bg: #333; --th-bg: #616161; color-scheme: dark;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+    .page-content { padding: 20px 24px; }
+    h1 { margin-bottom: 15px; font-size: 1.6em; }
+
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+    .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+    .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
+
+    .controls { display: flex; gap: 10px; align-items: center; margin-bottom: 15px; flex-wrap: wrap; }
+    .controls select { padding: 8px 12px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); font-size: 0.95em; }
+    .controls button { padding: 8px 16px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); cursor: pointer; font-size: 0.95em; }
+    .controls button:hover { background: var(--hover-bg); }
+    .controls .add-btn { background: #2196F3; color: white; border-color: #2196F3; }
+    .controls .add-btn:hover { background: #1976D2; }
+    .controls .preview-btn { background: #9C27B0; color: white; border-color: #9C27B0; }
+    .controls .preview-btn:hover { background: #7B1FA2; }
+
+    .summary { margin-bottom: 10px; color: var(--text-secondary); font-size: 0.9em; }
+
+    .table-wrap { overflow-x: auto; background: var(--bg-card); border-radius: 8px; box-shadow: var(--shadow); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    th { background: var(--th-bg); color: white; padding: 10px 12px; text-align: left; white-space: nowrap; position: sticky; top: 0; }
+    td { padding: 10px 12px; border-bottom: 1px solid var(--border-color); vertical-align: top; }
+    tr:hover { background: var(--hover-bg); }
+    tr.sortable-ghost { opacity: 0.4; background: var(--tab-active-bg) !important; }
+
+    .col-drag { width: 32px; cursor: grab; text-align: center; color: var(--text-muted); font-size: 1.2em; user-select: none; }
+    .col-drag:active { cursor: grabbing; }
+    .col-order { width: 48px; text-align: center; color: var(--text-muted); }
+    .col-key { width: 170px; font-family: monospace; font-size: 0.9em; }
+    .col-selector { width: 220px; }
+    .col-selector input { width: calc(100% - 40px); padding: 4px 6px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); color: var(--text-primary); font-family: monospace; font-size: 0.85em; }
+    .col-selector .pick-btn { width: 32px; padding: 4px; margin-left: 4px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); cursor: pointer; font-size: 1em; }
+    .col-selector .pick-btn:hover { background: var(--hover-bg); }
+    .col-text textarea { width: 100%; min-height: 60px; padding: 6px 8px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); color: var(--text-primary); font-size: 0.9em; resize: vertical; font-family: inherit; }
+    .col-conditions { width: 200px; }
+    .col-conditions .cond-badges { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+    .col-enabled { width: 70px; text-align: center; }
+    .col-actions { width: 140px; white-space: nowrap; }
+
+    .cond-badge { display: inline-block; padding: 2px 6px; border-radius: 3px; background: var(--border-color); color: var(--text-primary); font-size: 0.75em; }
+    .cond-badge.login { background: #4CAF50; color: white; }
+    .cond-badge.admin { background: #FF9800; color: white; }
+    .cond-badge.feature { background: #9C27B0; color: white; }
+    .cond-badge.viewport { background: #03A9F4; color: white; }
+    .cond-badge.firsttime { background: #795548; color: white; }
+
+    .btn-save { background: #4CAF50; color: white; border: none; padding: 6px 12px; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+    .btn-save:hover { background: #388E3C; }
+    .btn-save:disabled { background: #aaa; cursor: not-allowed; }
+    .btn-cond { background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border-color); padding: 6px 10px; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+    .btn-cond:hover { background: var(--hover-bg); }
+    .btn-delete { background: #f44336; color: white; border: none; padding: 6px 10px; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+    .btn-delete:hover { background: #d32f2f; }
+
+    .status-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; }
+    .status-dot.saved { background: #4CAF50; }
+    .status-dot.dirty { background: #FF9800; }
+    .row-status { font-size: 0.75em; color: var(--text-muted); display: block; margin-top: 4px; }
+
+    .toggle-switch { position: relative; display: inline-block; width: 40px; height: 22px; }
+    .toggle-switch input { opacity: 0; width: 0; height: 0; }
+    .toggle-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background: var(--border-color); border-radius: 22px; transition: 0.2s; }
+    .toggle-slider:before { position: absolute; content: ""; height: 16px; width: 16px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    input:checked + .toggle-slider { background: #4CAF50; }
+    input:checked + .toggle-slider:before { transform: translateX(18px); }
+
+    /* Modal */
+    .modal-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; }
+    .modal-overlay.visible { display: flex; align-items: center; justify-content: center; }
+    .modal { background: var(--bg-card); border-radius: 12px; padding: 24px; max-width: 560px; width: 95%; max-height: 90vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,0.3); }
+    .modal h3 { margin-bottom: 15px; }
+    .modal label { display: block; margin: 10px 0 4px; font-weight: 600; color: var(--text-secondary); font-size: 0.9em; }
+    .modal input[type="text"], .modal select { width: 100%; padding: 8px 12px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); font-size: 0.95em; }
+    .modal .tri-group { display: flex; gap: 6px; margin-top: 4px; }
+    .modal .tri-group button { flex: 1; padding: 8px; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); cursor: pointer; border-radius: 4px; }
+    .modal .tri-group button.active { background: var(--tab-active-bg); color: white; border-color: var(--tab-active-bg); }
+    .modal .btn-row { display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px; }
+    .modal .btn-save-modal { background: #4CAF50; color: white; border: none; padding: 10px 24px; border-radius: var(--btn-border-radius); cursor: pointer; font-size: 0.95em; }
+    .modal .btn-cancel { background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border-color); padding: 10px 24px; border-radius: var(--btn-border-radius); cursor: pointer; font-size: 0.95em; }
+
+    .no-data, .loading { text-align: center; padding: 40px; color: var(--text-muted); }
+  </style>
+</head>
+<body>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">Tour Steps</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
+
+<div class="admin-tabs" id="adminTabs"></div>
+
+<div class="controls">
+  <label for="langFilter" style="color:var(--text-secondary);font-size:0.9em;">Editing language:</label>
+  <select id="langFilter" onchange="onLangChange()">
+    <option value="en">English (en)</option>
+  </select>
+  <button class="add-btn" onclick="openConditionsModal(null, true)">+ New step</button>
+  <button class="preview-btn" onclick="previewTour()">▶ Preview tour</button>
+  <span class="summary" id="summary"></span>
+</div>
+
+<div class="table-wrap">
+  <div class="loading" id="loading">Loading...</div>
+  <table id="dataTable" style="display:none">
+    <thead>
+      <tr>
+        <th class="col-drag"></th>
+        <th class="col-order">#</th>
+        <th class="col-key">Step key</th>
+        <th class="col-selector">Target selector</th>
+        <th class="col-text">Text (in editing language)</th>
+        <th class="col-conditions">Conditions</th>
+        <th class="col-enabled">On</th>
+        <th class="col-actions">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="tableBody"></tbody>
+  </table>
+  <div class="no-data" id="noData" style="display:none">No tour steps yet — click "New step" above.</div>
+</div>
+
+<!-- Conditions / create modal -->
+<div class="modal-overlay" id="modalOverlay" onclick="closeModal()">
+  <div class="modal" onclick="event.stopPropagation()">
+    <h3 id="modalTitle">Edit conditions</h3>
+    <input type="hidden" id="modalId">
+
+    <div id="modalCreateFields" style="display:none">
+      <label for="modalStepKey">Step key (unique identifier)</label>
+      <input type="text" id="modalStepKey" placeholder="e.g. upload_btn" maxlength="64">
+      <label for="modalSelector">Target CSS selector</label>
+      <input type="text" id="modalSelector" placeholder="e.g. #upload-button">
+      <label style="display:inline-flex;align-items:center;gap:6px;font-weight:normal;">
+        <input type="checkbox" id="modalCenter"> Center the tooltip (no specific element spotlight)
+      </label>
+    </div>
+
+    <label>Require login</label>
+    <div class="tri-group" id="triRequireLogin"></div>
+
+    <label>Require admin</label>
+    <div class="tri-group" id="triRequireAdmin"></div>
+
+    <label for="modalFeature">Feature gate</label>
+    <select id="modalFeature">
+      <option value="">— none —</option>
+      <option value="ai_enabled">AI assistant enabled</option>
+      <option value="realtime_enabled">Realtime sensors enabled</option>
+      <option value="logged_in_uploads">Logged-in uploads</option>
+    </select>
+
+    <label for="modalViewport">Viewport</label>
+    <select id="modalViewport">
+      <option value="any">Any</option>
+      <option value="desktop">Desktop only</option>
+      <option value="mobile">Mobile only</option>
+    </select>
+
+    <label style="display:inline-flex;align-items:center;gap:6px;font-weight:normal;">
+      <input type="checkbox" id="modalFirstTimeOnly"> Show only on first-time tour run
+    </label>
+
+    <div class="btn-row">
+      <button class="btn-cancel" onclick="closeModal()">Cancel</button>
+      <button class="btn-save-modal" onclick="saveModal()">Save</button>
+    </div>
+  </div>
+</div>
+
+</div>
+
+<script>
+const PASSWORD = new URLSearchParams(window.location.search).get('password') || '';
+const AUTH_PARAM = PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '';
+const AUTH_APPEND = PASSWORD ? '&password=' + encodeURIComponent(PASSWORD) : '';
+
+let steps = [];              // raw step rows from the API
+let translationsMap = {};    // { step_key: { lang: value } }
+let languages = [];          // available language codes
+let editingLang = 'en';
+let creatingNew = false;     // whether modal is in create mode
+
+function toggleTheme() {
+  const cur = document.documentElement.getAttribute('data-theme') || 'light';
+  const next = cur === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('safecastDocTheme', next);
+  document.getElementById('theme-toggle').textContent = next === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode';
+}
+
+function buildAdminTabs() {
+  const tabs = [
+    { label: 'Users', href: '/admin/users' },
+    { label: 'Uploads', href: '/admin/uploads' },
+    { label: 'MCP Analytics', href: '/admin/mcp' },
+    { label: 'Realtime', href: '/admin/realtime' },
+    { label: 'Translations', href: '/admin/translations' },
+    { label: 'Tour Steps', href: '/admin/tour', active: true }
+  ];
+  const container = document.getElementById('adminTabs');
+  tabs.forEach(t => {
+    const href = t.href + (PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '');
+    container.innerHTML += `<a href="${href}" class="${t.active ? 'active' : ''}">${t.label}</a>`;
+  });
+}
+
+function escapeHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s == null ? '' : s;
+  return d.innerHTML;
+}
+
+async function fetchLanguages() {
+  // Reuse translations list endpoint to get available languages.
+  const res = await fetch('/api/admin/translations?limit=1' + AUTH_APPEND);
+  if (!res.ok) return;
+  const body = await res.json();
+  languages = body.languages || ['en'];
+  const sel = document.getElementById('langFilter');
+  sel.innerHTML = languages.map(l =>
+    `<option value="${l}" ${l === editingLang ? 'selected' : ''}>${l}</option>`
+  ).join('');
+}
+
+async function fetchSteps() {
+  const loading = document.getElementById('loading');
+  const table = document.getElementById('dataTable');
+  const noData = document.getElementById('noData');
+  loading.style.display = 'block';
+  table.style.display = 'none';
+  noData.style.display = 'none';
+
+  const res = await fetch('/api/admin/tour/steps' + AUTH_PARAM);
+  if (!res.ok) {
+    loading.textContent = 'Failed to load: ' + res.status;
+    return;
+  }
+  const body = await res.json();
+  steps = body.data || [];
+
+  // Fetch all tour.* translations so we can show/edit text in the current language.
+  const trRes = await fetch('/api/admin/translations?limit=1000&search=tour.' + AUTH_APPEND);
+  translationsMap = {};
+  if (trRes.ok) {
+    const trBody = await trRes.json();
+    (trBody.data || []).forEach(row => {
+      const m = /^tour\.([^.]+)\.text$/.exec(row.key);
+      if (!m) return;
+      const sk = m[1];
+      if (!translationsMap[sk]) translationsMap[sk] = {};
+      translationsMap[sk][row.language_code] = { id: row.id, value: row.value };
+    });
+  }
+
+  loading.style.display = 'none';
+  if (steps.length === 0) {
+    noData.style.display = 'block';
+    return;
+  }
+  table.style.display = 'table';
+  renderTable();
+}
+
+function renderTable() {
+  const tbody = document.getElementById('tableBody');
+  tbody.innerHTML = steps.map(renderRow).join('');
+  document.getElementById('summary').textContent =
+    steps.length + ' step' + (steps.length === 1 ? '' : 's');
+
+  // Enable drag-and-drop reordering.
+  if (window._sortable) window._sortable.destroy();
+  window._sortable = Sortable.create(tbody, {
+    handle: '.col-drag',
+    animation: 150,
+    onEnd: persistOrder
+  });
+}
+
+function conditionBadges(step) {
+  const badges = [];
+  if (step.require_login === true)  badges.push('<span class="cond-badge login">login</span>');
+  if (step.require_login === false) badges.push('<span class="cond-badge login">logged-out</span>');
+  if (step.require_admin === true)  badges.push('<span class="cond-badge admin">admin</span>');
+  if (step.show_if_feature)         badges.push(`<span class="cond-badge feature">${escapeHtml(step.show_if_feature)}</span>`);
+  if (step.viewport && step.viewport !== 'any') badges.push(`<span class="cond-badge viewport">${step.viewport}</span>`);
+  if (step.first_time_only)         badges.push('<span class="cond-badge firsttime">first-time</span>');
+  return badges.length ? badges.join(' ') : '<span style="color:var(--text-muted);font-size:0.8em;">none</span>';
+}
+
+function renderRow(step) {
+  const text = (translationsMap[step.step_key] && translationsMap[step.step_key][editingLang])
+    ? translationsMap[step.step_key][editingLang].value
+    : '';
+  const placeholderWarn = !text && editingLang !== 'en'
+    ? ' <span style="color:var(--text-muted);font-size:0.75em;">(empty — English fallback will be used)</span>'
+    : '';
+  return `
+    <tr data-id="${step.id}" data-step-key="${escapeHtml(step.step_key)}">
+      <td class="col-drag" title="Drag to reorder">☰</td>
+      <td class="col-order">${step.sort_order}</td>
+      <td class="col-key">${escapeHtml(step.step_key)}</td>
+      <td class="col-selector">
+        <input type="text" value="${escapeHtml(step.selector)}" data-field="selector"
+               oninput="markDirty(this)">
+        <button class="pick-btn" title="Pick element from map" onclick="pickElement(${step.id})">🎯</button>
+      </td>
+      <td class="col-text">
+        <textarea data-field="text" oninput="markDirty(this)">${escapeHtml(text)}</textarea>
+        ${placeholderWarn}
+      </td>
+      <td class="col-conditions">
+        <div class="cond-badges">${conditionBadges(step)}</div>
+        <button class="btn-cond" onclick="openConditionsModal(${step.id}, false)">Edit conditions</button>
+      </td>
+      <td class="col-enabled">
+        <label class="toggle-switch">
+          <input type="checkbox" ${step.enabled ? 'checked' : ''}
+                 onchange="toggleEnabled(${step.id}, this.checked)">
+          <span class="toggle-slider"></span>
+        </label>
+      </td>
+      <td class="col-actions">
+        <button class="btn-save" onclick="saveRow(${step.id})">Save</button>
+        <button class="btn-delete" onclick="deleteStep(${step.id})">Delete</button>
+        <span class="row-status" id="status-${step.id}"></span>
+      </td>
+    </tr>
+  `;
+}
+
+function markDirty(el) {
+  const tr = el.closest('tr');
+  const status = tr.querySelector('.row-status');
+  status.innerHTML = '<span class="status-dot dirty"></span> unsaved';
+}
+
+function rowById(id) {
+  return document.querySelector(`tr[data-id="${id}"]`);
+}
+
+function stepById(id) {
+  return steps.find(s => s.id === id);
+}
+
+async function saveRow(id) {
+  const tr = rowById(id);
+  const step = stepById(id);
+  if (!tr || !step) return;
+  const newSelector = tr.querySelector('[data-field="selector"]').value.trim();
+  const newText = tr.querySelector('[data-field="text"]').value;
+  const statusEl = document.getElementById('status-' + id);
+  statusEl.innerHTML = 'saving...';
+
+  // Save step metadata (selector may have changed).
+  const stepRes = await fetch('/api/admin/tour/steps/' + id + AUTH_PARAM, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      step_key: step.step_key,
+      selector: newSelector,
+      center: step.center,
+      enabled: step.enabled,
+      require_login: step.require_login,
+      require_admin: step.require_admin,
+      show_if_feature: step.show_if_feature,
+      viewport: step.viewport,
+      first_time_only: step.first_time_only
+    })
+  });
+  if (!stepRes.ok) {
+    statusEl.innerHTML = '<span style="color:#f44336;">save failed</span>';
+    return;
+  }
+
+  // Save the translation text (upsert).
+  const trRes = await fetch('/api/admin/translations' + AUTH_PARAM, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      language_code: editingLang,
+      key: 'tour.' + step.step_key + '.text',
+      value: newText
+    })
+  });
+  if (!trRes.ok) {
+    statusEl.innerHTML = '<span style="color:#f44336;">text save failed</span>';
+    return;
+  }
+
+  // Push a memory reload so the map picks up the change without a restart.
+  await fetch('/api/admin/translations/reload' + AUTH_PARAM, { method: 'POST' });
+
+  statusEl.innerHTML = '<span class="status-dot saved"></span> saved';
+  step.selector = newSelector;
+  if (!translationsMap[step.step_key]) translationsMap[step.step_key] = {};
+  translationsMap[step.step_key][editingLang] = { value: newText };
+}
+
+async function toggleEnabled(id, enabled) {
+  const step = stepById(id);
+  if (!step) return;
+  step.enabled = enabled;
+  await fetch('/api/admin/tour/steps/' + id + AUTH_PARAM, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      step_key: step.step_key,
+      selector: step.selector,
+      center: step.center,
+      enabled: step.enabled,
+      require_login: step.require_login,
+      require_admin: step.require_admin,
+      show_if_feature: step.show_if_feature,
+      viewport: step.viewport,
+      first_time_only: step.first_time_only
+    })
+  });
+}
+
+async function deleteStep(id) {
+  const step = stepById(id);
+  if (!step) return;
+  if (!confirm('Delete tour step "' + step.step_key + '"? This also removes its translations.')) return;
+  const res = await fetch('/api/admin/tour/steps/' + id + AUTH_PARAM, { method: 'DELETE' });
+  if (res.ok) fetchSteps();
+}
+
+async function persistOrder() {
+  const ids = Array.from(document.querySelectorAll('#tableBody tr')).map(tr => Number(tr.dataset.id));
+  await fetch('/api/admin/tour/steps/reorder' + AUTH_PARAM, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids })
+  });
+  // Refresh to pick up the new sort_order values.
+  fetchSteps();
+}
+
+// Conditions modal (reused for create)
+const TRI_STATES = [
+  { value: null,  label: 'Any' },
+  { value: true,  label: 'Yes' },
+  { value: false, label: 'No'  }
+];
+
+function buildTriGroup(elId, current) {
+  const el = document.getElementById(elId);
+  el.innerHTML = TRI_STATES.map((s, i) => `
+    <button type="button" data-value="${s.value === null ? '' : s.value}"
+            class="${s.value === current ? 'active' : ''}"
+            onclick="selectTri('${elId}', ${i})">${s.label}</button>
+  `).join('');
+}
+
+function selectTri(elId, idx) {
+  document.querySelectorAll(`#${elId} button`).forEach((b, i) => {
+    b.classList.toggle('active', i === idx);
+  });
+}
+
+function readTri(elId) {
+  const btn = document.querySelector(`#${elId} button.active`);
+  if (!btn || btn.dataset.value === '') return null;
+  return btn.dataset.value === 'true';
+}
+
+function openConditionsModal(id, isNew) {
+  creatingNew = !!isNew;
+  document.getElementById('modalId').value = id == null ? '' : id;
+  document.getElementById('modalCreateFields').style.display = isNew ? 'block' : 'none';
+  document.getElementById('modalTitle').textContent = isNew ? 'New tour step' : 'Edit conditions';
+
+  const step = isNew ? null : stepById(id);
+  document.getElementById('modalStepKey').value = '';
+  document.getElementById('modalSelector').value = '';
+  document.getElementById('modalCenter').checked = false;
+  document.getElementById('modalFeature').value = step?.show_if_feature || '';
+  document.getElementById('modalViewport').value = step?.viewport || 'any';
+  document.getElementById('modalFirstTimeOnly').checked = !!step?.first_time_only;
+  buildTriGroup('triRequireLogin', step ? step.require_login : null);
+  buildTriGroup('triRequireAdmin', step ? step.require_admin : null);
+
+  document.getElementById('modalOverlay').classList.add('visible');
+}
+
+function closeModal() {
+  document.getElementById('modalOverlay').classList.remove('visible');
+}
+
+async function saveModal() {
+  const feature = document.getElementById('modalFeature').value;
+  const viewport = document.getElementById('modalViewport').value;
+  const firstTimeOnly = document.getElementById('modalFirstTimeOnly').checked;
+  const requireLogin = readTri('triRequireLogin');
+  const requireAdmin = readTri('triRequireAdmin');
+
+  if (creatingNew) {
+    const stepKey = document.getElementById('modalStepKey').value.trim();
+    const selector = document.getElementById('modalSelector').value.trim();
+    const center = document.getElementById('modalCenter').checked;
+    if (!stepKey || !selector) { alert('Step key and selector are required'); return; }
+    const res = await fetch('/api/admin/tour/steps' + AUTH_PARAM, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        step_key: stepKey, selector: selector, center: center, enabled: true,
+        require_login: requireLogin, require_admin: requireAdmin,
+        show_if_feature: feature || null, viewport: viewport,
+        first_time_only: firstTimeOnly
+      })
+    });
+    if (!res.ok) { alert('Create failed'); return; }
+  } else {
+    const id = Number(document.getElementById('modalId').value);
+    const step = stepById(id);
+    if (!step) return;
+    const res = await fetch('/api/admin/tour/steps/' + id + AUTH_PARAM, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        step_key: step.step_key,
+        selector: step.selector,
+        center: step.center,
+        enabled: step.enabled,
+        require_login: requireLogin,
+        require_admin: requireAdmin,
+        show_if_feature: feature || null,
+        viewport: viewport,
+        first_time_only: firstTimeOnly
+      })
+    });
+    if (!res.ok) { alert('Save failed'); return; }
+  }
+  closeModal();
+  fetchSteps();
+}
+
+function onLangChange() {
+  editingLang = document.getElementById('langFilter').value || 'en';
+  renderTable();
+}
+
+// Element picker: open the map with ?pick=1 and listen for the selector.
+function pickElement(id) {
+  const w = window.open('/?pick=1', '_blank');
+  if (!w) { alert('Pop-up blocked — allow pop-ups and try again.'); return; }
+  const handler = function(ev) {
+    if (!ev.data || ev.data.type !== 'tour-selector-picked') return;
+    window.removeEventListener('message', handler);
+    const tr = rowById(id);
+    if (!tr) return;
+    const input = tr.querySelector('[data-field="selector"]');
+    input.value = ev.data.selector;
+    markDirty(input);
+  };
+  window.addEventListener('message', handler);
+}
+
+function previewTour() {
+  window.open('/?preview_tour=1', '_blank');
+}
+
+document.addEventListener('DOMContentLoaded', async function() {
+  document.getElementById('theme-toggle').textContent =
+    document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode';
+  buildAdminTabs();
+  await fetchLanguages();
+  await fetchSteps();
+});
+</script>
+</body>
+</html>

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -11595,6 +11595,97 @@ function selectHomeSearchResult(result, query) {
     })();
   </script>
 
+  <!-- Admin tour-step element picker (?pick=1) -->
+  <script>
+  (function() {
+    var params = new URLSearchParams(window.location.search);
+    if (params.get('pick') !== '1') return;
+
+    var banner = document.createElement('div');
+    banner.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#0066cc;color:#fff;padding:10px 16px;font:14px sans-serif;text-align:center;box-shadow:0 2px 6px rgba(0,0,0,0.3);';
+    banner.innerHTML = '<span style="font-weight:600;">Pick an element</span> — click any element to capture its selector. <button id="pick-cancel" style="margin-left:12px;padding:4px 10px;border:0;border-radius:4px;background:#fff;color:#0066cc;font-weight:600;cursor:pointer;">Cancel</button>';
+    document.body.appendChild(banner);
+
+    var highlight = document.createElement('div');
+    highlight.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483646;border:2px solid #ff6b00;background:rgba(255,107,0,0.15);border-radius:3px;display:none;transition:all 0.05s linear;';
+    document.body.appendChild(highlight);
+
+    function isOwnUI(el) {
+      return el === banner || banner.contains(el) || el === highlight;
+    }
+
+    function moveHighlight(el) {
+      if (!el) { highlight.style.display = 'none'; return; }
+      var r = el.getBoundingClientRect();
+      highlight.style.top = r.top + 'px';
+      highlight.style.left = r.left + 'px';
+      highlight.style.width = r.width + 'px';
+      highlight.style.height = r.height + 'px';
+      highlight.style.display = 'block';
+    }
+
+    function isUniqueSelector(sel) {
+      try { return document.querySelectorAll(sel).length === 1; } catch (e) { return false; }
+    }
+
+    function buildSelector(el) {
+      if (!el || el === document || el === document.documentElement) return '';
+      if (el.id && isUniqueSelector('#' + CSS.escape(el.id))) return '#' + el.id;
+
+      // Try each class individually
+      if (el.classList && el.classList.length) {
+        for (var i = 0; i < el.classList.length; i++) {
+          var cls = '.' + CSS.escape(el.classList[i]);
+          if (isUniqueSelector(cls)) return cls;
+        }
+      }
+
+      // Walk up to nearest ancestor with an id, build nth-child path
+      var path = [];
+      var node = el;
+      while (node && node.nodeType === 1 && node !== document.body) {
+        var seg = node.tagName.toLowerCase();
+        if (node.id) { path.unshift('#' + CSS.escape(node.id)); break; }
+        var parent = node.parentElement;
+        if (parent) {
+          var idx = Array.prototype.indexOf.call(parent.children, node) + 1;
+          seg += ':nth-child(' + idx + ')';
+        }
+        path.unshift(seg);
+        node = parent;
+      }
+      return path.join(' > ');
+    }
+
+    var lastHover = null;
+    document.addEventListener('mousemove', function(e) {
+      var el = e.target;
+      if (isOwnUI(el)) { lastHover = null; highlight.style.display = 'none'; return; }
+      if (el === lastHover) return;
+      lastHover = el;
+      moveHighlight(el);
+    }, true);
+
+    document.addEventListener('click', function(e) {
+      var el = e.target;
+      if (isOwnUI(el)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      var selector = buildSelector(el);
+      try {
+        if (window.opener && !window.opener.closed) {
+          window.opener.postMessage({ type: 'tour-selector-picked', selector: selector }, '*');
+        }
+      } catch (err) { /* cross-origin safety */ }
+      window.close();
+    }, true);
+
+    document.getElementById('pick-cancel').addEventListener('click', function() {
+      window.close();
+    });
+  })();
+  </script>
+
   <!-- Tutorial / Tour / Story Wall wiring -->
   <script>
   (function() {
@@ -11607,32 +11698,48 @@ function selectHomeSearchResult(result, query) {
     var tourText        = document.getElementById('tour-text');
     var helpBtn         = document.getElementById('persistent-help-btn');
 
-    // --- Tour steps ---
-    var tourSteps = [
-      { selector: '#map', center: true,
-        text: 'Welcome to the Safecast map — an open platform where people worldwide share dosimeter readings for science, ecology, education, and safety. Each coloured dot is a real measurement with a timestamp and GPS location. The colour shows the dose rate — see the legend for the scale. Treat this as a community snapshot, not a precise survey.' },
-      { selector: '.upload-btn-container',
-        text: 'Upload your own radiation measurements. Supported formats include CSV, LOG, and KML files from devices such as bGeigie Nano, Radnote, and GammaScout. Your data appears on the map once processing is complete.' },
-      { selector: '#loginButton',
-        text: 'Log in to link uploads to your account, track your measurement history, and access your profile page. Registration is free and open to everyone.' },
-      { selector: '#legend',
-        text: 'This colour scale shows the radiation dose rate. The scale adapts to the data on screen — hover it for a full explanation.' },
-      { selector: '#safecast-ai-toggle',
-        text: 'Ask our AI assistant anything about the map, the data, or radiation safety. It knows Safecast data in depth.' },
-      { selector: '#track-insights-btn',
-        text: 'When you click on a track, this button appears. It asks the AI to analyse that specific track — summarising the route, radiation levels, and any notable patterns it finds.' },
-      { selector: '.date-slider-box',
-        text: 'Drag the time slider to filter measurements by date. Switch between Year and Month mode for broad or fine-grained control, and press the reset button to show all data again.' },
-      { selector: '#sfLive-row',
-        text: 'The large circles with numbers on the map are live readings from Safecast realtime sensors, updated every few minutes. The number shows the current dose rate in µSv/h, and the colour matches the legend scale. Click a circle to open its full measurement history. Uncheck this box to hide realtime sensors.' },
-      { selector: '#sfSpectrum-row',
-        text: 'Toggle gamma spectrum measurements. These come from spectral sensors that record the full energy distribution of detected radiation, not just a single dose rate. Click a spectrum point on the map to see its spectral distribution chart and identify which isotopes contributed to the reading.' },
-      { selector: '#speed-filter-ctrl',
-        text: 'Filter measurements by travel speed: airplane, car, or walking. Use these to focus on the type of measurements you are interested in.' },
-      { selector: '#searchInput',
-        text: 'Search for any city or address to jump straight to that location on the map.' },
-    ];
+    // --- Tour steps (loaded from /api/tour/steps) ---
+    var tourSteps = [];
     var tourIndex = 0;
+    var tourLoaded = false;
+
+    function viewportIsMobile() {
+      return !!(window.matchMedia && window.matchMedia('(max-width: 768px)').matches);
+    }
+
+    function stepMatchesConditions(step) {
+      var isLoggedIn = !!(typeof currentUser !== 'undefined' && currentUser);
+      if (step.require_login === true && !isLoggedIn) return false;
+      if (step.require_login === false && isLoggedIn) return false;
+
+      var isAdmin = !!(typeof currentUser !== 'undefined' && currentUser && currentUser.is_admin);
+      if (step.require_admin === true && !isAdmin) return false;
+      if (step.require_admin === false && isAdmin) return false;
+
+      if (step.show_if_feature) {
+        if (step.show_if_feature === 'realtime_enabled' && !window.safecastRealtimeEnabled) return false;
+        if (step.show_if_feature === 'ai_enabled' && !document.getElementById('safecast-ai-toggle')) return false;
+      }
+
+      if (step.viewport === 'mobile' && !viewportIsMobile()) return false;
+      if (step.viewport === 'desktop' && viewportIsMobile()) return false;
+
+      if (step.first_time_only && localStorage.getItem(STORAGE_KEY)) return false;
+
+      return true;
+    }
+
+    function loadTourSteps() {
+      var lang = (typeof currentLang !== 'undefined' && currentLang) ? currentLang : 'en';
+      return fetch('/api/tour/steps?lang=' + encodeURIComponent(lang))
+        .then(function(r) { return r.ok ? r.json() : { steps: [] }; })
+        .then(function(data) {
+          var steps = (data && data.steps) || [];
+          tourSteps = steps.filter(stepMatchesConditions);
+          tourLoaded = true;
+        })
+        .catch(function() { tourSteps = []; tourLoaded = true; });
+    }
 
     // --- Story wall helpers ---
     function loadStories() {
@@ -11722,8 +11829,12 @@ function selectHomeSearchResult(result, query) {
     }
 
     function startTour() {
-      tourIndex = 0;
-      showTourStep(0);
+      var run = function() {
+        tourIndex = 0;
+        if (!tourSteps.length) { endTour(); return; }
+        showTourStep(0);
+      };
+      if (tourLoaded) { run(); } else { loadTourSteps().then(run); }
     }
 
     // --- Show/hide tutorial ---
@@ -11777,8 +11888,16 @@ function selectHomeSearchResult(result, query) {
       showTutorial();
     });
 
-    // --- Auto-show on first visit ---
-    if (!localStorage.getItem(STORAGE_KEY)) {
+    // Preload tour steps so first click on the help button is instant.
+    loadTourSteps();
+
+    // --- Auto-show on first visit, or when ?preview_tour=1 is set (admin preview) ---
+    var urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('preview_tour') === '1') {
+      setTimeout(function() {
+        loadTourSteps().then(startTour);
+      }, 1000);
+    } else if (!localStorage.getItem(STORAGE_KEY)) {
       setTimeout(showTutorial, 1000);
     }
   })();

--- a/cmd/unified-server/tour_steps.go
+++ b/cmd/unified-server/tour_steps.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// tourStepColumns lists the sortable columns for the admin list endpoint.
+var tourStepColumns = []string{
+	"id", "step_key", "sort_order", "selector", "enabled", "updated_at",
+}
+
+// tourStep is the full row shape used by the admin API.
+type tourStep struct {
+	ID             int64          `json:"id"`
+	StepKey        string         `json:"step_key"`
+	SortOrder      int            `json:"sort_order"`
+	Selector       string         `json:"selector"`
+	Center         bool           `json:"center"`
+	Enabled        bool           `json:"enabled"`
+	RequireLogin   sql.NullBool   `json:"-"`
+	RequireAdmin   sql.NullBool   `json:"-"`
+	ShowIfFeature  sql.NullString `json:"-"`
+	Viewport       string         `json:"viewport"`
+	FirstTimeOnly  bool           `json:"first_time_only"`
+	UpdatedAt      interface{}    `json:"updated_at"`
+}
+
+// MarshalJSON emits nullable columns as JSON null (not zero values) so the
+// admin UI can distinguish "don't care" from "must be false".
+func (t tourStep) toMap() map[string]interface{} {
+	m := map[string]interface{}{
+		"id":              t.ID,
+		"step_key":        t.StepKey,
+		"sort_order":      t.SortOrder,
+		"selector":        t.Selector,
+		"center":          t.Center,
+		"enabled":         t.Enabled,
+		"viewport":        t.Viewport,
+		"first_time_only": t.FirstTimeOnly,
+		"updated_at":      t.UpdatedAt,
+	}
+	if t.RequireLogin.Valid {
+		m["require_login"] = t.RequireLogin.Bool
+	} else {
+		m["require_login"] = nil
+	}
+	if t.RequireAdmin.Valid {
+		m["require_admin"] = t.RequireAdmin.Bool
+	} else {
+		m["require_admin"] = nil
+	}
+	if t.ShowIfFeature.Valid {
+		m["show_if_feature"] = t.ShowIfFeature.String
+	} else {
+		m["show_if_feature"] = nil
+	}
+	return m
+}
+
+// tourStepInput is the writable subset used by Create/Update.
+type tourStepInput struct {
+	StepKey        string  `json:"step_key"`
+	Selector       string  `json:"selector"`
+	Center         bool    `json:"center"`
+	Enabled        bool    `json:"enabled"`
+	RequireLogin   *bool   `json:"require_login"`
+	RequireAdmin   *bool   `json:"require_admin"`
+	ShowIfFeature  *string `json:"show_if_feature"`
+	Viewport       string  `json:"viewport"`
+	FirstTimeOnly  bool    `json:"first_time_only"`
+}
+
+// tourPublicStep is the shape returned by the public /api/tour/steps endpoint.
+// Text is resolved for the requested language; conditions are a nested object
+// so the client can filter cheaply.
+type tourPublicStep struct {
+	StepKey    string                 `json:"step_key"`
+	Selector   string                 `json:"selector"`
+	Center     bool                   `json:"center"`
+	Text       string                 `json:"text"`
+	Conditions map[string]interface{} `json:"conditions"`
+}
+
+type tourService struct{}
+
+func newTourService() *tourService { return &tourService{} }
+
+// List returns all tour steps ordered by sort_order (admin use).
+func (s *tourService) List(sortCol, order string) ([]map[string]interface{}, error) {
+	if !isValidColumn(sortCol, tourStepColumns) {
+		sortCol = "sort_order"
+	}
+	order = strings.ToUpper(order)
+	if order != "DESC" {
+		order = "ASC"
+	}
+	q := fmt.Sprintf(`
+		SELECT id, step_key, sort_order, selector, center, enabled,
+		       require_login, require_admin, show_if_feature,
+		       viewport, first_time_only, updated_at
+		  FROM tour_steps ORDER BY %s %s`, sortCol, order)
+	rows, err := db.DB.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]map[string]interface{}, 0, 16)
+	for rows.Next() {
+		var t tourStep
+		if err := rows.Scan(&t.ID, &t.StepKey, &t.SortOrder, &t.Selector,
+			&t.Center, &t.Enabled, &t.RequireLogin, &t.RequireAdmin,
+			&t.ShowIfFeature, &t.Viewport, &t.FirstTimeOnly, &t.UpdatedAt); err != nil {
+			log.Printf("tourService.List scan: %v", err)
+			continue
+		}
+		out = append(out, t.toMap())
+	}
+	return out, nil
+}
+
+// ListPublic returns enabled steps with text resolved for the requested
+// language (falling back to English). Used by the map's tour loader.
+func (s *tourService) ListPublic(lang string) ([]tourPublicStep, error) {
+	if lang == "" {
+		lang = "en"
+	}
+	rows, err := db.DB.Query(`
+		SELECT step_key, selector, center,
+		       require_login, require_admin, show_if_feature,
+		       viewport, first_time_only
+		  FROM tour_steps
+		 WHERE enabled = TRUE
+		 ORDER BY sort_order ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	translationsMu.RLock()
+	tr := translations
+	translationsMu.RUnlock()
+
+	resolve := func(key string) string {
+		if m, ok := tr[lang]; ok {
+			if v, ok := m[key]; ok && v != "" {
+				return v
+			}
+		}
+		if m, ok := tr["en"]; ok {
+			if v, ok := m[key]; ok {
+				return v
+			}
+		}
+		return ""
+	}
+
+	out := make([]tourPublicStep, 0, 16)
+	for rows.Next() {
+		var (
+			stepKey, selector, viewport string
+			center, firstTimeOnly       bool
+			reqLogin, reqAdmin          sql.NullBool
+			showIf                      sql.NullString
+		)
+		if err := rows.Scan(&stepKey, &selector, &center,
+			&reqLogin, &reqAdmin, &showIf, &viewport, &firstTimeOnly); err != nil {
+			log.Printf("tourService.ListPublic scan: %v", err)
+			continue
+		}
+
+		conds := map[string]interface{}{
+			"viewport":        viewport,
+			"first_time_only": firstTimeOnly,
+		}
+		if reqLogin.Valid {
+			conds["require_login"] = reqLogin.Bool
+		} else {
+			conds["require_login"] = nil
+		}
+		if reqAdmin.Valid {
+			conds["require_admin"] = reqAdmin.Bool
+		} else {
+			conds["require_admin"] = nil
+		}
+		if showIf.Valid {
+			conds["show_if_feature"] = showIf.String
+		} else {
+			conds["show_if_feature"] = nil
+		}
+
+		out = append(out, tourPublicStep{
+			StepKey:    stepKey,
+			Selector:   selector,
+			Center:     center,
+			Text:       resolve("tour." + stepKey + ".text"),
+			Conditions: conds,
+		})
+	}
+	return out, nil
+}
+
+// Create inserts a new step at the end of the current order.
+func (s *tourService) Create(in tourStepInput) (int64, error) {
+	if in.StepKey == "" || in.Selector == "" {
+		return 0, fmt.Errorf("step_key and selector are required")
+	}
+	if in.Viewport == "" {
+		in.Viewport = "any"
+	}
+	var nextOrder int
+	if err := db.DB.QueryRow(
+		`SELECT COALESCE(MAX(sort_order), 0) + 1 FROM tour_steps`,
+	).Scan(&nextOrder); err != nil {
+		return 0, err
+	}
+
+	var id int64
+	err := db.DB.QueryRow(`
+		INSERT INTO tour_steps (
+			step_key, sort_order, selector, center, enabled,
+			require_login, require_admin, show_if_feature,
+			viewport, first_time_only
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+		RETURNING id`,
+		in.StepKey, nextOrder, in.Selector, in.Center, in.Enabled,
+		nullBool(in.RequireLogin), nullBool(in.RequireAdmin),
+		nullString(in.ShowIfFeature), in.Viewport, in.FirstTimeOnly,
+	).Scan(&id)
+	return id, err
+}
+
+// Update rewrites all mutable columns on a row. Full replace is simpler than
+// building a dynamic UPDATE and matches how the admin UI sends the record
+// back after editing.
+func (s *tourService) Update(id int64, in tourStepInput) error {
+	if in.Viewport == "" {
+		in.Viewport = "any"
+	}
+	_, err := db.DB.Exec(`
+		UPDATE tour_steps
+		   SET step_key = $1, selector = $2, center = $3, enabled = $4,
+		       require_login = $5, require_admin = $6, show_if_feature = $7,
+		       viewport = $8, first_time_only = $9, updated_at = NOW()
+		 WHERE id = $10`,
+		in.StepKey, in.Selector, in.Center, in.Enabled,
+		nullBool(in.RequireLogin), nullBool(in.RequireAdmin),
+		nullString(in.ShowIfFeature), in.Viewport, in.FirstTimeOnly, id,
+	)
+	return err
+}
+
+// Delete drops the step row and its tour.<step_key>.* translation rows so the
+// translations table does not accumulate orphans.
+func (s *tourService) Delete(id int64) error {
+	tx, err := db.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var stepKey string
+	if err := tx.QueryRow(`SELECT step_key FROM tour_steps WHERE id = $1`, id).Scan(&stepKey); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM tour_steps WHERE id = $1`, id); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM translations WHERE key LIKE 'tour.' || $1 || '.%'`, stepKey,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Reorder rewrites sort_order to match the given slice of IDs (index 0 ⇒
+// order 1). Uses a single transaction and a temporary offset to avoid
+// violating any potential future unique-ordering constraint.
+func (s *tourService) Reorder(ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	tx, err := db.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Phase 1: move every target into a high, non-colliding range so the
+	// final assignment can never conflict with a row not yet updated.
+	for i, id := range ids {
+		if _, err := tx.Exec(
+			`UPDATE tour_steps SET sort_order = $1 WHERE id = $2`,
+			10000+i, id,
+		); err != nil {
+			return err
+		}
+	}
+	// Phase 2: assign the real, compact order.
+	for i, id := range ids {
+		if _, err := tx.Exec(
+			`UPDATE tour_steps SET sort_order = $1, updated_at = NOW() WHERE id = $2`,
+			i+1, id,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func nullBool(p *bool) interface{} {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullString(p *string) interface{} {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return *p
+}

--- a/cmd/unified-server/tour_steps_seed.go
+++ b/cmd/unified-server/tour_steps_seed.go
@@ -1,0 +1,130 @@
+package main
+
+import "log"
+
+// defaultTourStep is the seed shape — only the fields needed to bootstrap the
+// table. Admin edits are protected by ON CONFLICT DO NOTHING, so re-running
+// the seeder on every startup is safe.
+type defaultTourStep struct {
+	StepKey  string
+	Selector string
+	Center   bool
+	TextEN   string
+}
+
+// defaultTourSteps mirrors the previous hardcoded JS array in map.html so the
+// tour stays identical after migration. Keep the order stable; sort_order is
+// assigned by the seeder in slice order.
+var defaultTourSteps = []defaultTourStep{
+	{
+		StepKey:  "welcome",
+		Selector: "#map",
+		Center:   true,
+		TextEN:   "Welcome to the Safecast map — an open platform where people worldwide share dosimeter readings for science, ecology, education, and safety. Each coloured dot is a real measurement with a timestamp and GPS location. The colour shows the dose rate — see the legend for the scale. Treat this as a community snapshot, not a precise survey.",
+	},
+	{
+		StepKey:  "upload",
+		Selector: ".upload-btn-container",
+		TextEN:   "Upload your own radiation measurements. Supported formats include CSV, LOG, and KML files from devices such as bGeigie Nano, Radnote, and GammaScout. Your data appears on the map once processing is complete.",
+	},
+	{
+		StepKey:  "login",
+		Selector: "#loginButton",
+		TextEN:   "Log in to link uploads to your account, track your measurement history, and access your profile page. Registration is free and open to everyone.",
+	},
+	{
+		StepKey:  "legend",
+		Selector: "#legend",
+		TextEN:   "This colour scale shows the radiation dose rate. The scale adapts to the data on screen — hover it for a full explanation.",
+	},
+	{
+		StepKey:  "ai_toggle",
+		Selector: "#safecast-ai-toggle",
+		TextEN:   "Ask our AI assistant anything about the map, the data, or radiation safety. It knows Safecast data in depth.",
+	},
+	{
+		StepKey:  "track_insights",
+		Selector: "#track-insights-btn",
+		TextEN:   "When you click on a track, this button appears. It asks the AI to analyse that specific track — summarising the route, radiation levels, and any notable patterns it finds.",
+	},
+	{
+		StepKey:  "date_slider",
+		Selector: ".date-slider-box",
+		TextEN:   "Drag the time slider to filter measurements by date. Switch between Year and Month mode for broad or fine-grained control, and press the reset button to show all data again.",
+	},
+	{
+		StepKey:  "realtime_sensors",
+		Selector: "#sfLive-row",
+		TextEN:   "The large circles with numbers on the map are live readings from Safecast realtime sensors, updated every few minutes. The number shows the current dose rate in µSv/h, and the colour matches the legend scale. Click a circle to open its full measurement history. Uncheck this box to hide realtime sensors.",
+	},
+	{
+		StepKey:  "gamma_spectrum",
+		Selector: "#sfSpectrum-row",
+		TextEN:   "Toggle gamma spectrum measurements. These come from spectral sensors that record the full energy distribution of detected radiation, not just a single dose rate. Click a spectrum point on the map to see its spectral distribution chart and identify which isotopes contributed to the reading.",
+	},
+	{
+		StepKey:  "speed_filter",
+		Selector: "#speed-filter-ctrl",
+		TextEN:   "Filter measurements by travel speed: airplane, car, or walking. Use these to focus on the type of measurements you are interested in.",
+	},
+	{
+		StepKey:  "search",
+		Selector: "#searchInput",
+		TextEN:   "Search for any city or address to jump straight to that location on the map.",
+	},
+}
+
+// seedTourStepsDB idempotently inserts the default tour steps and their
+// English text. Existing rows are never overwritten, so admin edits survive.
+func seedTourStepsDB() {
+	if db == nil || db.DB == nil {
+		return
+	}
+
+	tx, err := db.DB.Begin()
+	if err != nil {
+		log.Printf("[tour] Cannot begin seed transaction: %v", err)
+		return
+	}
+	defer tx.Rollback()
+
+	stepsInserted, textsInserted := 0, 0
+	for i, step := range defaultTourSteps {
+		res, err := tx.Exec(`
+			INSERT INTO tour_steps (step_key, sort_order, selector, center)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (step_key) DO NOTHING`,
+			step.StepKey, i+1, step.Selector, step.Center,
+		)
+		if err != nil {
+			log.Printf("[tour] Seed step %s: %v", step.StepKey, err)
+			continue
+		}
+		if rows, _ := res.RowsAffected(); rows > 0 {
+			stepsInserted++
+		}
+
+		res, err = tx.Exec(`
+			INSERT INTO translations (language_code, key, value)
+			VALUES ('en', 'tour.' || $1 || '.text', $2)
+			ON CONFLICT (language_code, key) DO NOTHING`,
+			step.StepKey, step.TextEN,
+		)
+		if err != nil {
+			log.Printf("[tour] Seed text %s: %v", step.StepKey, err)
+			continue
+		}
+		if rows, _ := res.RowsAffected(); rows > 0 {
+			textsInserted++
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Printf("[tour] Cannot commit seed transaction: %v", err)
+		return
+	}
+	if stepsInserted > 0 || textsInserted > 0 {
+		log.Printf("[tour] Seeded %d new steps and %d English text entries",
+			stepsInserted, textsInserted)
+	}
+}

--- a/migrations/add_tour_steps_table.sql
+++ b/migrations/add_tour_steps_table.sql
@@ -1,0 +1,24 @@
+-- Migration: Add tour_steps table for DB-backed, multilingual map tour
+-- Run: psql -h 127.0.0.1 -U postgres -d safecast -f migrations/add_tour_steps_table.sql
+--
+-- Structural data (selector, order, conditions) lives here; per-language text
+-- lives in the existing `translations` table under keys of the form
+-- `tour.<step_key>.text`.
+
+CREATE TABLE IF NOT EXISTS tour_steps (
+  id              BIGSERIAL PRIMARY KEY,
+  step_key        VARCHAR(64) NOT NULL UNIQUE,
+  sort_order      INTEGER     NOT NULL,
+  selector        TEXT        NOT NULL,
+  center          BOOLEAN     NOT NULL DEFAULT FALSE,
+  enabled         BOOLEAN     NOT NULL DEFAULT TRUE,
+  require_login   BOOLEAN,
+  require_admin   BOOLEAN,
+  show_if_feature VARCHAR(64),
+  viewport        VARCHAR(16) NOT NULL DEFAULT 'any',
+  first_time_only BOOLEAN     NOT NULL DEFAULT FALSE,
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT tour_steps_viewport_check CHECK (viewport IN ('any', 'desktop', 'mobile'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tour_steps_order ON tour_steps(sort_order);

--- a/pkg/httpapi/page_routes.go
+++ b/pkg/httpapi/page_routes.go
@@ -26,6 +26,7 @@ type PageRoutesConfig struct {
 	AdminMCPPageHandler          http.HandlerFunc
 	AdminRealtimePageHandler     http.HandlerFunc
 	AdminTranslationsPageHandler http.HandlerFunc
+	AdminTourPageHandler         http.HandlerFunc
 }
 
 // RegisterPageRoutes attaches UI/admin page routes to mux.
@@ -84,4 +85,5 @@ func RegisterPageRoutes(mux *http.ServeMux, cfg PageRoutesConfig) {
 	registerOptionalAdmin("/admin/mcp", cfg.AdminMCPPageHandler)
 	registerOptionalAdmin("/admin/realtime", cfg.AdminRealtimePageHandler)
 	registerOptionalAdmin("/admin/translations", cfg.AdminTranslationsPageHandler)
+	registerOptionalAdmin("/admin/tour", cfg.AdminTourPageHandler)
 }

--- a/pkg/httpapi/public_routes.go
+++ b/pkg/httpapi/public_routes.go
@@ -41,6 +41,10 @@ const (
 	RouteAPIAdminTranslationsReload   = "/api/admin/translations/reload"
 	RouteAPIAdminTranslationsByID     = "/api/admin/translations/"
 	RouteAPIAdminTranslations         = "/api/admin/translations"
+	RouteAPITourSteps                 = "/api/tour/steps"
+	RouteAPIAdminTourStepsReorder     = "/api/admin/tour/steps/reorder"
+	RouteAPIAdminTourStepsByID        = "/api/admin/tour/steps/"
+	RouteAPIAdminTourSteps            = "/api/admin/tour/steps"
 
 	RouteAPISensors              = "/api/sensors"
 	RouteAPISensorsExport        = "/api/sensors/export"

--- a/pkg/httpapi/register.go
+++ b/pkg/httpapi/register.go
@@ -58,6 +58,10 @@ type RegisterConfig struct {
 	AdminTranslationsReloadHandler   http.HandlerFunc
 	AdminTranslationByIDHandler      http.HandlerFunc
 	AdminTranslationsHandler         http.HandlerFunc
+	APITourStepsHandler              http.HandlerFunc
+	AdminTourStepsReorderHandler     http.HandlerFunc
+	AdminTourStepsByIDHandler        http.HandlerFunc
+	AdminTourStepsHandler            http.HandlerFunc
 
 	Logf func(string, ...any)
 }
@@ -179,6 +183,11 @@ func registerAuthAndAdminRoutes(mux *http.ServeMux, cfg RegisterConfig) {
 	registerOptionalAdmin(RouteAPIAdminTranslationsReload, cfg.AdminTranslationsReloadHandler)
 	registerOptionalAdmin(RouteAPIAdminTranslationsByID, cfg.AdminTranslationByIDHandler)
 	registerOptionalAdmin(RouteAPIAdminTranslations, cfg.AdminTranslationsHandler)
+	// Tour step admin endpoints: reorder must be registered before the
+	// {id} pattern because mux longest-match prefers the more specific path.
+	registerOptionalAdmin(RouteAPIAdminTourStepsReorder, cfg.AdminTourStepsReorderHandler)
+	registerOptionalAdmin(RouteAPIAdminTourStepsByID, cfg.AdminTourStepsByIDHandler)
+	registerOptionalAdmin(RouteAPIAdminTourSteps, cfg.AdminTourStepsHandler)
 
 	registerOptionalPublic := func(path string, handler http.HandlerFunc) {
 		if handler == nil {
@@ -191,6 +200,7 @@ func registerAuthAndAdminRoutes(mux *http.ServeMux, cfg RegisterConfig) {
 	registerOptionalPublic(RouteAPISensorByID, cfg.APISensorByIDHandler)
 	registerOptionalPublic(RouteAPIFeedback, cfg.APIFeedbackHandler)
 	registerOptionalPublic(RoutePatternAPITrackInsights, cfg.APITrackInsightsHandler)
+	registerOptionalPublic(RouteAPITourSteps, cfg.APITourStepsHandler)
 }
 
 // checkAdminAccess returns true if the request is from an admin user or carries the admin password.


### PR DESCRIPTION
## Summary
- Migrates the hardcoded map tour array to a managed admin surface at `/admin/tour` with drag-reorder, per-language text editing, tri-state conditions, and an in-map element picker.
- New Postgres `tour_steps` table holds structural data only; tour copy lives in the existing `translations` table under `tour.<step_key>.text`, so existing i18n tooling applies.
- Public `GET /api/tour/steps` resolves text for the requested language (EN fallback); admin CRUD + reorder endpoints are protected by admin session/password.
- Map loads tour dynamically with client-side condition matching (`require_login`, `require_admin`, `show_if_feature`, `viewport`, `first_time_only`); adds `?preview_tour=1` (force-run ignoring seen-flag) and `?pick=1` (hover-highlight + postMessage to opener).

## Test plan
- [ ] `/admin/tour?password=admin123` — list renders, drag reorder persists, Save updates row + translation, Delete works, "+ New step" creates a row.
- [ ] "🎯 Pick Element" button opens map in pick mode, clicking an element returns its selector to the admin row.
- [ ] "▶ Preview tour" opens the map with `?preview_tour=1` and runs the tour regardless of `safecast_tutorial_seen`.
- [ ] Main map: help button runs DB-backed steps; switching `?lang=ja` falls back to EN text until a JA row is added.
- [ ] `curl /api/tour/steps` returns `{"steps":[...]}` (11 seeded rows with EN text).
- [ ] Swagger (`/map-api/`) lists the 4 new endpoints under `tour` / `admin` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)