### PR TITLE
fix: add Tour Steps tab to all admin pages

### DIFF
--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -359,7 +359,8 @@ function buildAdminTabs() {
     { label: 'Uploads', href: '/admin/uploads' },
     { label: 'MCP Analytics', href: '/admin/mcp', active: true },
     { label: 'Realtime', href: '/admin/realtime' },
-    { label: 'Translations', href: '/admin/translations' }
+    { label: 'Translations', href: '/admin/translations' },
+    { label: 'Tour Steps', href: '/admin/tour' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-realtime.html
+++ b/cmd/unified-server/public_html/admin-realtime.html
@@ -215,7 +215,8 @@ function buildAdminTabs() {
     { label: 'Uploads', href: '/admin/uploads' },
     { label: 'MCP Analytics', href: '/admin/mcp' },
     { label: 'Realtime', href: '/admin/realtime', active: true },
-    { label: 'Translations', href: '/admin/translations' }
+    { label: 'Translations', href: '/admin/translations' },
+    { label: 'Tour Steps', href: '/admin/tour' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-translations.html
+++ b/cmd/unified-server/public_html/admin-translations.html
@@ -228,7 +228,8 @@ function buildAdminTabs() {
     { label: 'Uploads', href: '/admin/uploads' },
     { label: 'MCP Analytics', href: '/admin/mcp' },
     { label: 'Realtime', href: '/admin/realtime' },
-    { label: 'Translations', href: '/admin/translations', active: true }
+    { label: 'Translations', href: '/admin/translations', active: true },
+    { label: 'Tour Steps', href: '/admin/tour' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -377,7 +377,8 @@
         { label: 'Uploads', href: '/admin/uploads' },
         { label: 'MCP Analytics', href: '/admin/mcp' },
         { label: 'Realtime', href: '/admin/realtime' },
-        { label: 'Translations', href: '/admin/translations' }
+        { label: 'Translations', href: '/admin/translations' },
+        { label: 'Tour Steps', href: '/admin/tour' }
       ];
       const container = document.getElementById('adminTabs');
       tabs.forEach(t => {


### PR DESCRIPTION
## Summary
- /admin/tour was reachable by URL but the tab was missing on the four peer admin pages (users, translations, mcp, realtime), so admins had no link to it.

## Test plan
- [ ] Visit /admin/users, /admin/uploads, /admin/mcp, /admin/realtime, /admin/translations — each shows a "Tour Steps" tab that links to /admin/tour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)