### PR TITLE
docs: add Codeberg mirror notice for issues, projects, and commits

### DIFF
--- a/.gitea/ISSUE_TEMPLATE.md
+++ b/.gitea/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+# Issues are tracked on GitHub
+
+This repository is a **mirror** of [github.com/Safecast/safecast-new-map](https://github.com/Safecast/safecast-new-map).
+
+Please open issues there:
+
+👉 **[Open an issue on GitHub](https://github.com/Safecast/safecast-new-map/issues/new)**
+
+Issues opened here on Codeberg will not be monitored.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Natural background radiation is typically low and safe. This map helps identify 
 
 ---
 
+## Contributing & Community
+
+> **Mirror notice:** This repository is mirrored on [Codeberg](https://codeberg.org/Safecast/safecast-new-map). All activity is managed on **GitHub**:
+>
+> - **Issues & bug reports:** [github.com/Safecast/safecast-new-map/issues](https://github.com/Safecast/safecast-new-map/issues)
+> - **Projects & roadmap:** [github.com/Safecast/safecast-new-map/projects](https://github.com/Safecast/safecast-new-map/projects)
+> - **Commits & pull requests:** pushed to both GitHub and Codeberg simultaneously via dual-remote
+
+Please open issues and contribute on GitHub. The Codeberg mirror exists for redundancy and to serve users who prefer FOSS hosting.
+
+---
+
 ## Quick Start
 
 ### Option 1: Binary (Recommended)


### PR DESCRIPTION
Adds a Contributing & Community section to README.md directing users to GitHub for issues, projects, and PRs. Adds .gitea/ISSUE_TEMPLATE.md so Codeberg shows a redirect notice when someone tries to open an issue there.

## At a high level, what changes were made?

## Why were these changes made?

## How were these changes made?

## What context, visual (i.e. screenshots) or otherwise, do reviewers need to understand or use this feature?

## How Was the Code Tested?

## Other Notes, Context, or Anything that Remains to be Addressed