### PR TITLE
feat(admin): AI Hints editor — DB-backed, history, embedded seed

### DIFF
--- a/cmd/unified-server/admin_ai_hints.go
+++ b/cmd/unified-server/admin_ai_hints.go
@@ -1,0 +1,721 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	modeladapter "safecast-new-map/cmd/unified-server/model-adapter"
+)
+
+// =============================================================================
+// Request/response payloads
+// =============================================================================
+
+// aiHintPayload is the structured JSON exchanged with the admin UI. It mirrors
+// the on-disk JSON files and the ai_hints row shape so a single payload can be
+// used for both create and import.
+type aiHintPayload struct {
+	Model                 string                                  `json:"model,omitempty"`
+	DisplayName           string                                  `json:"display_name"`
+	Capabilities          []string                                `json:"capabilities"`
+	SystemPrompt          string                                  `json:"system_prompt"`
+	Tools                 map[string]*modeladapter.ToolHintJSON   `json:"tools"`
+	GlobalFormattingRules map[string]string                       `json:"global_formatting_rules"`
+}
+
+type aiHintListItem struct {
+	Model        string     `json:"model"`
+	DisplayName  string     `json:"display_name"`
+	Capabilities []string   `json:"capabilities"`
+	UpdatedAt    *time.Time `json:"updated_at"`
+	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
+}
+
+type aiHintFullRow struct {
+	ID                    int64                                 `json:"id"`
+	Model                 string                                `json:"model"`
+	DisplayName           string                                `json:"display_name"`
+	Capabilities          []string                              `json:"capabilities"`
+	SystemPrompt          string                                `json:"system_prompt"`
+	Tools                 map[string]*modeladapter.ToolHintJSON `json:"tools"`
+	GlobalFormattingRules map[string]string                     `json:"global_formatting_rules"`
+	CreatedAt             *time.Time                            `json:"created_at"`
+	UpdatedAt             *time.Time                            `json:"updated_at"`
+	DeletedAt             *time.Time                            `json:"deleted_at,omitempty"`
+}
+
+type aiHintHistoryItem struct {
+	ID         int64      `json:"id"`
+	Model      string     `json:"model"`
+	ChangeKind string     `json:"change_kind"`
+	ChangedAt  *time.Time `json:"changed_at"`
+	Snapshot   json.RawMessage `json:"snapshot,omitempty"`
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// modelSlugPattern: lowercase alphanumerics and dashes only; no leading/trailing dash.
+func validateModelSlug(s string) error {
+	if s == "" {
+		return fmt.Errorf("model slug is required")
+	}
+	if len(s) > 64 {
+		return fmt.Errorf("model slug too long (max 64 chars)")
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			// ok
+		case r == '-':
+			if i == 0 || i == len(s)-1 {
+				return fmt.Errorf("model slug cannot start or end with dash")
+			}
+		default:
+			return fmt.Errorf("model slug may only contain lowercase letters, digits, and dashes")
+		}
+	}
+	return nil
+}
+
+// modelFromPath extracts the {model} path parameter from URLs like
+// /api/admin/ai-hints/claude or /api/admin/ai-hints/claude/history.
+func modelFromPath(path string, basePath string, trailingSegments int) (string, []string, error) {
+	stripped := strings.TrimPrefix(path, basePath)
+	stripped = strings.Trim(stripped, "/")
+	parts := strings.Split(stripped, "/")
+	if len(parts) < 1 || parts[0] == "" {
+		return "", nil, fmt.Errorf("missing model slug in path")
+	}
+	model := parts[0]
+	if err := validateModelSlug(model); err != nil {
+		return "", nil, err
+	}
+	rest := parts[1:]
+	if len(rest) != trailingSegments {
+		return "", nil, fmt.Errorf("unexpected path segments")
+	}
+	return model, rest, nil
+}
+
+// writeAIHintJSON emits a JSON response with sensible defaults.
+func writeAIHintJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if body != nil {
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// marshalHintPayload converts an aiHintPayload into the JSONB column values.
+func marshalHintPayload(p *aiHintPayload) (capsJSON, toolsJSON, rulesJSON string) {
+	caps, _ := json.Marshal(valueOrEmptyStringSlice(p.Capabilities))
+	tools, _ := json.Marshal(valueOrEmptyToolMap(p.Tools))
+	rules, _ := json.Marshal(valueOrEmptyStringMap(p.GlobalFormattingRules))
+	return string(caps), string(tools), string(rules)
+}
+
+// fetchFullHintRow reads a single row (including soft-deleted) by model slug.
+func fetchFullHintRow(model string) (*aiHintFullRow, error) {
+	row := db.DB.QueryRow(`
+		SELECT id, model, display_name, capabilities, system_prompt, tools,
+		       global_formatting_rules, created_at, updated_at, deleted_at
+		FROM ai_hints WHERE model = $1`, model)
+
+	var (
+		id                                  int64
+		modelOut, displayName, systemPrompt string
+		capsJSON, toolsJSON, rulesJSON      sql.NullString
+		createdAt, updatedAt, deletedAt     sql.NullTime
+	)
+	if err := row.Scan(&id, &modelOut, &displayName, &capsJSON, &systemPrompt, &toolsJSON, &rulesJSON, &createdAt, &updatedAt, &deletedAt); err != nil {
+		return nil, err
+	}
+
+	out := &aiHintFullRow{
+		ID:                    id,
+		Model:                 modelOut,
+		DisplayName:           displayName,
+		SystemPrompt:          systemPrompt,
+		Capabilities:          []string{},
+		Tools:                 map[string]*modeladapter.ToolHintJSON{},
+		GlobalFormattingRules: map[string]string{},
+	}
+	if capsJSON.Valid && capsJSON.String != "" {
+		_ = json.Unmarshal([]byte(capsJSON.String), &out.Capabilities)
+	}
+	if toolsJSON.Valid && toolsJSON.String != "" {
+		_ = json.Unmarshal([]byte(toolsJSON.String), &out.Tools)
+	}
+	if rulesJSON.Valid && rulesJSON.String != "" {
+		_ = json.Unmarshal([]byte(rulesJSON.String), &out.GlobalFormattingRules)
+	}
+	if createdAt.Valid {
+		out.CreatedAt = &createdAt.Time
+	}
+	if updatedAt.Valid {
+		out.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		out.DeletedAt = &deletedAt.Time
+	}
+	return out, nil
+}
+
+// snapshotHint writes the current full row for model into ai_hints_history.
+// changeKind is a short tag like "update", "delete", "restore", "manual".
+func snapshotHint(model string, changeKind string) error {
+	current, err := fetchFullHintRow(model)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil // nothing to snapshot (create path)
+		}
+		return err
+	}
+	snap, err := json.Marshal(current)
+	if err != nil {
+		return err
+	}
+	_, err = db.DB.Exec(`
+		INSERT INTO ai_hints_history (model, snapshot, change_kind)
+		VALUES ($1, $2, $3)`, model, string(snap), changeKind)
+	return err
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+// adminAIHintsListHandler handles GET /api/admin/ai-hints.
+// Query params: include_deleted=true to include soft-deleted rows.
+func adminAIHintsListHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+
+	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
+	q := `SELECT model, display_name, capabilities, updated_at, deleted_at FROM ai_hints`
+	if !includeDeleted {
+		q += ` WHERE deleted_at IS NULL`
+	}
+	q += ` ORDER BY display_name ASC`
+
+	rows, err := db.DB.Query(q)
+	if err != nil {
+		log.Printf("admin ai-hints list error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	defer rows.Close()
+
+	out := []aiHintListItem{}
+	for rows.Next() {
+		var (
+			model, display             string
+			capsJSON                   sql.NullString
+			updatedAt, deletedAt       sql.NullTime
+		)
+		if err := rows.Scan(&model, &display, &capsJSON, &updatedAt, &deletedAt); err != nil {
+			log.Printf("admin ai-hints list scan error: %v", err)
+			continue
+		}
+		item := aiHintListItem{Model: model, DisplayName: display, Capabilities: []string{}}
+		if capsJSON.Valid && capsJSON.String != "" {
+			_ = json.Unmarshal([]byte(capsJSON.String), &item.Capabilities)
+		}
+		if updatedAt.Valid {
+			t := updatedAt.Time
+			item.UpdatedAt = &t
+		}
+		if deletedAt.Valid {
+			t := deletedAt.Time
+			item.DeletedAt = &t
+		}
+		out = append(out, item)
+	}
+
+	writeAIHintJSON(w, http.StatusOK, map[string]interface{}{"data": out})
+}
+
+// adminAIHintGetHandler handles GET /api/admin/ai-hints/{model}.
+func adminAIHintGetHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 0)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	row, err := fetchFullHintRow(model)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "Not found")
+		return
+	}
+	if err != nil {
+		log.Printf("admin ai-hint get error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, row)
+}
+
+// adminAIHintCreateHandler handles POST /api/admin/ai-hints.
+// Body: aiHintPayload. model slug is derived from display_name unless provided
+// explicitly; the caller may supply a slug to break slugify ties.
+func adminAIHintCreateHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+
+	var p aiHintPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	if strings.TrimSpace(p.DisplayName) == "" {
+		writeError(w, http.StatusBadRequest, "display_name is required")
+		return
+	}
+	slug := strings.TrimSpace(p.Model)
+	if slug == "" {
+		slug = slugifyModel(p.DisplayName)
+	}
+	if err := validateModelSlug(slug); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	capsJSON, toolsJSON, rulesJSON := marshalHintPayload(&p)
+
+	_, err := db.DB.Exec(`
+		INSERT INTO ai_hints (model, display_name, capabilities, system_prompt, tools, global_formatting_rules)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		slug, p.DisplayName, capsJSON, p.SystemPrompt, toolsJSON, rulesJSON,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
+			writeError(w, http.StatusConflict, "A bot with this model slug already exists")
+			return
+		}
+		log.Printf("admin ai-hint create error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Create failed")
+		return
+	}
+
+	writeAIHintJSON(w, http.StatusCreated, map[string]string{"status": "ok", "model": slug})
+}
+
+// adminAIHintUpdateHandler handles PUT /api/admin/ai-hints/{model}.
+func adminAIHintUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 0)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var p aiHintPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	if strings.TrimSpace(p.DisplayName) == "" {
+		writeError(w, http.StatusBadRequest, "display_name is required")
+		return
+	}
+
+	if err := snapshotHint(model, "update"); err != nil {
+		log.Printf("admin ai-hint snapshot error: %v", err)
+	}
+
+	capsJSON, toolsJSON, rulesJSON := marshalHintPayload(&p)
+	res, err := db.DB.Exec(`
+		UPDATE ai_hints
+		SET display_name = $2,
+		    capabilities = $3,
+		    system_prompt = $4,
+		    tools = $5,
+		    global_formatting_rules = $6,
+		    updated_at = NOW()
+		WHERE model = $1`,
+		model, p.DisplayName, capsJSON, p.SystemPrompt, toolsJSON, rulesJSON,
+	)
+	if err != nil {
+		log.Printf("admin ai-hint update error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Update failed")
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "Not found")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminAIHintDeleteHandler handles DELETE /api/admin/ai-hints/{model}.
+// Soft-deletes by setting deleted_at.
+func adminAIHintDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 0)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := snapshotHint(model, "delete"); err != nil {
+		log.Printf("admin ai-hint snapshot(delete) error: %v", err)
+	}
+
+	res, err := db.DB.Exec(`
+		UPDATE ai_hints SET deleted_at = NOW(), updated_at = NOW()
+		WHERE model = $1 AND deleted_at IS NULL`, model)
+	if err != nil {
+		log.Printf("admin ai-hint delete error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Delete failed")
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "Not found or already deleted")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminAIHintRestoreHandler handles POST /api/admin/ai-hints/{model}/restore.
+func adminAIHintRestoreHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 1)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := snapshotHint(model, "restore"); err != nil {
+		log.Printf("admin ai-hint snapshot(restore) error: %v", err)
+	}
+
+	res, err := db.DB.Exec(`
+		UPDATE ai_hints SET deleted_at = NULL, updated_at = NOW()
+		WHERE model = $1 AND deleted_at IS NOT NULL`, model)
+	if err != nil {
+		log.Printf("admin ai-hint restore error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Restore failed")
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "Not found or not deleted")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminAIHintSnapshotHandler handles POST /api/admin/ai-hints/{model}/snapshot.
+// Manually records the current state into history.
+func adminAIHintSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 1)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, err := fetchFullHintRow(model); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "Not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	if err := snapshotHint(model, "manual"); err != nil {
+		log.Printf("admin ai-hint manual snapshot error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Snapshot failed")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminAIHintHistoryListHandler handles GET /api/admin/ai-hints/{model}/history.
+func adminAIHintHistoryListHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 1)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rows, err := db.DB.Query(`
+		SELECT id, model, change_kind, changed_at
+		FROM ai_hints_history
+		WHERE model = $1
+		ORDER BY changed_at DESC
+		LIMIT 200`, model)
+	if err != nil {
+		log.Printf("admin ai-hint history list error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+	defer rows.Close()
+
+	out := []aiHintHistoryItem{}
+	for rows.Next() {
+		var (
+			id         int64
+			m, kind    string
+			changedAt  sql.NullTime
+		)
+		if err := rows.Scan(&id, &m, &kind, &changedAt); err != nil {
+			continue
+		}
+		item := aiHintHistoryItem{ID: id, Model: m, ChangeKind: kind}
+		if changedAt.Valid {
+			t := changedAt.Time
+			item.ChangedAt = &t
+		}
+		out = append(out, item)
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]interface{}{"data": out})
+}
+
+// adminAIHintHistoryRestoreHandler handles
+// POST /api/admin/ai-hints/{model}/history/{id}/restore.
+func adminAIHintHistoryRestoreHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	// Path looks like /api/admin/ai-hints/{model}/history/{id}/restore
+	stripped := strings.TrimPrefix(r.URL.Path, "/api/admin/ai-hints/")
+	stripped = strings.Trim(stripped, "/")
+	parts := strings.Split(stripped, "/")
+	if len(parts) != 4 || parts[1] != "history" || parts[3] != "restore" {
+		writeError(w, http.StatusBadRequest, "Invalid history restore path")
+		return
+	}
+	model := parts[0]
+	if err := validateModelSlug(model); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	historyID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid history id")
+		return
+	}
+
+	var snapJSON string
+	err = db.DB.QueryRow(`
+		SELECT snapshot FROM ai_hints_history WHERE id = $1 AND model = $2`,
+		historyID, model,
+	).Scan(&snapJSON)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "History entry not found")
+		return
+	}
+	if err != nil {
+		log.Printf("admin ai-hint history restore fetch error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+
+	var snap aiHintFullRow
+	if err := json.Unmarshal([]byte(snapJSON), &snap); err != nil {
+		writeError(w, http.StatusInternalServerError, "Corrupt snapshot")
+		return
+	}
+
+	// Snapshot the pre-restore state first so the current version is itself
+	// recoverable from history.
+	if err := snapshotHint(model, "restore"); err != nil {
+		log.Printf("admin ai-hint snapshot(restore-pre) error: %v", err)
+	}
+
+	caps, _ := json.Marshal(valueOrEmptyStringSlice(snap.Capabilities))
+	tools, _ := json.Marshal(valueOrEmptyToolMap(snap.Tools))
+	rules, _ := json.Marshal(valueOrEmptyStringMap(snap.GlobalFormattingRules))
+
+	res, err := db.DB.Exec(`
+		UPDATE ai_hints
+		SET display_name = $2,
+		    capabilities = $3,
+		    system_prompt = $4,
+		    tools = $5,
+		    global_formatting_rules = $6,
+		    deleted_at = NULL,
+		    updated_at = NOW()
+		WHERE model = $1`,
+		model, snap.DisplayName, string(caps), snap.SystemPrompt, string(tools), string(rules),
+	)
+	if err != nil {
+		log.Printf("admin ai-hint history restore update error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Restore failed")
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		// Row was hard-deleted externally; re-insert from snapshot.
+		_, err = db.DB.Exec(`
+			INSERT INTO ai_hints (model, display_name, capabilities, system_prompt, tools, global_formatting_rules)
+			VALUES ($1, $2, $3, $4, $5, $6)`,
+			model, snap.DisplayName, string(caps), snap.SystemPrompt, string(tools), string(rules),
+		)
+		if err != nil {
+			log.Printf("admin ai-hint history restore insert error: %v", err)
+			writeError(w, http.StatusInternalServerError, "Restore failed")
+			return
+		}
+	}
+
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// adminAIHintReloadHandler handles POST /api/admin/ai-hints/reload.
+// Rebuilds the in-memory HintsLoader from DB state.
+func adminAIHintReloadHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	if mcpHintsLoader == nil {
+		writeError(w, http.StatusServiceUnavailable, "Hints loader not initialized")
+		return
+	}
+	count, err := loadAIHintsFromDB(mcpHintsLoader)
+	if err != nil {
+		log.Printf("admin ai-hint reload error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Reload failed")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]interface{}{"status": "ok", "loaded": count})
+}
+
+// adminAIHintExportHandler handles GET /api/admin/ai-hints/{model}/export.
+// Returns the hint formatted exactly like the on-disk JSON files so the
+// response can be committed back to the repo if desired.
+func adminAIHintExportHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	model, _, err := modelFromPath(r.URL.Path, "/api/admin/ai-hints/", 1)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	row, err := fetchFullHintRow(model)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "Not found")
+		return
+	}
+	if err != nil {
+		log.Printf("admin ai-hint export error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Query failed")
+		return
+	}
+
+	exportShape := modeladapter.ModelHint{
+		Model:                 row.Model,
+		DisplayName:           row.DisplayName,
+		Capabilities:          row.Capabilities,
+		SystemPrompt:          row.SystemPrompt,
+		Tools:                 row.Tools,
+		GlobalFormattingRules: row.GlobalFormattingRules,
+	}
+	body, err := json.MarshalIndent(exportShape, "", "  ")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Encode failed")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.json"`, model))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// adminAIHintImportHandler handles POST /api/admin/ai-hints/import.
+// Body is a single JSON file contents matching the on-disk hint format.
+// If the model exists, it is updated; otherwise a new row is created.
+func adminAIHintImportHandler(w http.ResponseWriter, r *http.Request) {
+	if db == nil || db.DB == nil {
+		writeError(w, http.StatusServiceUnavailable, "Database not available")
+		return
+	}
+	data, err := io.ReadAll(io.LimitReader(r.Body, 2*1024*1024)) // 2MB hard cap
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Failed to read body")
+		return
+	}
+	var p aiHintPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+	slug := strings.TrimSpace(p.Model)
+	if slug == "" {
+		slug = slugifyModel(p.DisplayName)
+	}
+	if err := validateModelSlug(slug); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(p.DisplayName) == "" {
+		writeError(w, http.StatusBadRequest, "display_name is required")
+		return
+	}
+
+	// If the row exists, snapshot before overwriting.
+	if _, err := fetchFullHintRow(slug); err == nil {
+		if err := snapshotHint(slug, "import"); err != nil {
+			log.Printf("admin ai-hint import snapshot error: %v", err)
+		}
+	}
+
+	capsJSON, toolsJSON, rulesJSON := marshalHintPayload(&p)
+	_, err = db.DB.Exec(`
+		INSERT INTO ai_hints (model, display_name, capabilities, system_prompt, tools, global_formatting_rules)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (model) DO UPDATE SET
+			display_name = EXCLUDED.display_name,
+			capabilities = EXCLUDED.capabilities,
+			system_prompt = EXCLUDED.system_prompt,
+			tools = EXCLUDED.tools,
+			global_formatting_rules = EXCLUDED.global_formatting_rules,
+			deleted_at = NULL,
+			updated_at = NOW()`,
+		slug, p.DisplayName, capsJSON, p.SystemPrompt, toolsJSON, rulesJSON,
+	)
+	if err != nil {
+		log.Printf("admin ai-hint import error: %v", err)
+		writeError(w, http.StatusInternalServerError, "Import failed")
+		return
+	}
+	writeAIHintJSON(w, http.StatusOK, map[string]string{"status": "ok", "model": slug})
+}

--- a/cmd/unified-server/admin_ai_hints_test.go
+++ b/cmd/unified-server/admin_ai_hints_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSlugifyModel(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"Claude 3.5 Sonnet", "claude-3-5-sonnet"},
+		{"GPT-4o", "gpt-4o"},
+		{"Kimi  K2", "kimi-k2"},
+		{"  Qwen/2.5 ", "qwen-2-5"},
+		{"日本語 Bot", "bot"},
+		{"---weird---name---", "weird-name"},
+	}
+	for _, c := range cases {
+		if got := slugifyModel(c.in); got != c.out {
+			t.Errorf("slugifyModel(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestValidateModelSlug(t *testing.T) {
+	ok := []string{"claude", "gpt-4o", "kimi-k2", "a1", "my-custom-bot-2"}
+	bad := []string{"", "Claude", "gpt_4", "-lead", "trail-", "with space", strings.Repeat("a", 65)}
+	for _, s := range ok {
+		if err := validateModelSlug(s); err != nil {
+			t.Errorf("validateModelSlug(%q) should be valid, got %v", s, err)
+		}
+	}
+	for _, s := range bad {
+		if err := validateModelSlug(s); err == nil {
+			t.Errorf("validateModelSlug(%q) should be invalid", s)
+		}
+	}
+}
+
+func TestModelFromPath(t *testing.T) {
+	model, rest, err := modelFromPath("/api/admin/ai-hints/claude", "/api/admin/ai-hints/", 0)
+	if err != nil || model != "claude" || len(rest) != 0 {
+		t.Errorf("simple model: got model=%q rest=%v err=%v", model, rest, err)
+	}
+	model, rest, err = modelFromPath("/api/admin/ai-hints/gpt-4o/history", "/api/admin/ai-hints/", 1)
+	if err != nil || model != "gpt-4o" || len(rest) != 1 || rest[0] != "history" {
+		t.Errorf("model/history: got model=%q rest=%v err=%v", model, rest, err)
+	}
+	if _, _, err := modelFromPath("/api/admin/ai-hints/", "/api/admin/ai-hints/", 0); err == nil {
+		t.Errorf("empty model should fail")
+	}
+	if _, _, err := modelFromPath("/api/admin/ai-hints/BadSlug", "/api/admin/ai-hints/", 0); err == nil {
+		t.Errorf("invalid slug should fail")
+	}
+}
+
+// The following tests assume the global `db` is nil at package scope (no main()
+// initialization during `go test`). They check that handlers fail closed with
+// 503 when the DB is unavailable, matching the pattern in admin_mcp_test.go.
+
+func TestAdminAIHintsHandlers_DatabaseUnavailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		body    string
+		handler http.HandlerFunc
+	}{
+		{"list", http.MethodGet, "/api/admin/ai-hints", "", adminAIHintsListHandler},
+		{"get", http.MethodGet, "/api/admin/ai-hints/claude", "", adminAIHintGetHandler},
+		{"create", http.MethodPost, "/api/admin/ai-hints", `{"display_name":"Test"}`, adminAIHintCreateHandler},
+		{"update", http.MethodPut, "/api/admin/ai-hints/claude", `{"display_name":"X"}`, adminAIHintUpdateHandler},
+		{"delete", http.MethodDelete, "/api/admin/ai-hints/claude", "", adminAIHintDeleteHandler},
+		{"restore", http.MethodPost, "/api/admin/ai-hints/claude/restore", "", adminAIHintRestoreHandler},
+		{"snapshot", http.MethodPost, "/api/admin/ai-hints/claude/snapshot", "", adminAIHintSnapshotHandler},
+		{"history-list", http.MethodGet, "/api/admin/ai-hints/claude/history", "", adminAIHintHistoryListHandler},
+		{"history-restore", http.MethodPost, "/api/admin/ai-hints/claude/history/1/restore", "", adminAIHintHistoryRestoreHandler},
+		{"export", http.MethodGet, "/api/admin/ai-hints/claude/export", "", adminAIHintExportHandler},
+		{"import", http.MethodPost, "/api/admin/ai-hints/import", `{"display_name":"Imported"}`, adminAIHintImportHandler},
+		{"reload", http.MethodPost, "/api/admin/ai-hints/reload", "", adminAIHintReloadHandler},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			var body *strings.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			var req *http.Request
+			if body != nil {
+				req = httptest.NewRequest(tc.method, tc.path, body)
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req = httptest.NewRequest(tc.method, tc.path, nil)
+			}
+			tc.handler(rec, req)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("expected 503 with db=nil, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAdminAIHintCreateHandler_ValidationBeforeDB(t *testing.T) {
+	// With db=nil we'd normally get 503 first, so invalid JSON cases can't be
+	// distinguished here without a DB stub. This test documents the guard order
+	// by asserting that the 503 short-circuit happens even for malformed input.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/ai-hints", strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	adminAIHintCreateHandler(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (db guard runs first), got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/cmd/unified-server/ai_hints.go
+++ b/cmd/unified-server/ai_hints.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	modeladapter "safecast-new-map/cmd/unified-server/model-adapter"
+)
+
+// aiHintRow mirrors the ai_hints table row. JSONB columns are decoded into
+// their concrete Go types on read.
+type aiHintRow struct {
+	Model                 string
+	DisplayName           string
+	Capabilities          []string
+	SystemPrompt          string
+	Tools                 map[string]*modeladapter.ToolHintJSON
+	GlobalFormattingRules map[string]string
+}
+
+// toModelHint converts a DB row into the in-memory ModelHint shape the MCP
+// server consumes.
+func (r *aiHintRow) toModelHint() *modeladapter.ModelHint {
+	return &modeladapter.ModelHint{
+		Model:                 r.Model,
+		DisplayName:           r.DisplayName,
+		Capabilities:          r.Capabilities,
+		SystemPrompt:          r.SystemPrompt,
+		Tools:                 r.Tools,
+		GlobalFormattingRules: r.GlobalFormattingRules,
+	}
+}
+
+// seedAIHintsDB inserts the on-disk hint JSON files into ai_hints for any
+// models that are not already present. Delegates to seedAIHintsDBFromFS.
+func seedAIHintsDB(hintsDir string) {
+	seedAIHintsDBFromFS(os.DirFS(hintsDir), hintsDir)
+}
+
+// seedAIHintsDBFromFS is the fs.FS-aware seeder. Accepts either a real-disk
+// fs (os.DirFS) or an embedded tree (fs.Sub(embeddedHintsFS, "hints")).
+// `label` is used only for log output. Matches the translations seeding
+// pattern — never overwrites admin edits.
+func seedAIHintsDBFromFS(fsys fs.FS, label string) {
+	if db == nil || db.DB == nil {
+		return
+	}
+	if fsys == nil {
+		return
+	}
+
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		log.Printf("[ai_hints] Cannot read hints source %s for seeding: %v", label, err)
+		return
+	}
+
+	inserted := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := fs.ReadFile(fsys, entry.Name())
+		if err != nil {
+			log.Printf("[ai_hints] Cannot read %s/%s: %v", label, entry.Name(), err)
+			continue
+		}
+
+		var hint modeladapter.ModelHint
+		if err := json.Unmarshal(data, &hint); err != nil {
+			log.Printf("[ai_hints] Cannot parse %s/%s: %v", label, entry.Name(), err)
+			continue
+		}
+
+		model := hint.Model
+		if entry.Name() == "default.json" {
+			model = "unknown"
+		}
+		if model == "" {
+			continue
+		}
+
+		capsJSON, _ := json.Marshal(valueOrEmptyStringSlice(hint.Capabilities))
+		toolsJSON, _ := json.Marshal(valueOrEmptyToolMap(hint.Tools))
+		rulesJSON, _ := json.Marshal(valueOrEmptyStringMap(hint.GlobalFormattingRules))
+
+		_, err = db.DB.Exec(`
+			INSERT INTO ai_hints (model, display_name, capabilities, system_prompt, tools, global_formatting_rules)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (model) DO NOTHING`,
+			model, hint.DisplayName, string(capsJSON), hint.SystemPrompt, string(toolsJSON), string(rulesJSON),
+		)
+		if err != nil {
+			log.Printf("[ai_hints] Error seeding %s: %v", model, err)
+			continue
+		}
+		inserted++
+	}
+	if inserted > 0 {
+		log.Printf("[ai_hints] Seeded up to %d hint rows from %s (skipping existing)", inserted, label)
+	}
+}
+
+// loadAIHintsFromDB reads all non-deleted ai_hints rows and atomically swaps
+// them into the shared HintsLoader. Returns the number loaded.
+func loadAIHintsFromDB(loader *modeladapter.HintsLoader) (int, error) {
+	if db == nil || db.DB == nil || loader == nil {
+		return 0, nil
+	}
+
+	rows, err := db.DB.Query(`
+		SELECT model, display_name, capabilities, system_prompt, tools, global_formatting_rules
+		FROM ai_hints
+		WHERE deleted_at IS NULL`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	hints := make(map[string]*modeladapter.ModelHint)
+	for rows.Next() {
+		row, err := scanAIHintRow(rows)
+		if err != nil {
+			log.Printf("[ai_hints] Scan error: %v", err)
+			continue
+		}
+		hints[row.Model] = row.toModelHint()
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	loader.SetHints(hints)
+	return len(hints), nil
+}
+
+// scanAIHintRow decodes a single row from a SELECT that returns the six
+// canonical ai_hints columns (model, display_name, capabilities, system_prompt,
+// tools, global_formatting_rules).
+func scanAIHintRow(scanner interface {
+	Scan(dest ...interface{}) error
+}) (*aiHintRow, error) {
+	var (
+		model, displayName, systemPrompt string
+		capsJSON, toolsJSON, rulesJSON   sql.NullString
+	)
+	if err := scanner.Scan(&model, &displayName, &capsJSON, &systemPrompt, &toolsJSON, &rulesJSON); err != nil {
+		return nil, err
+	}
+
+	row := &aiHintRow{
+		Model:        model,
+		DisplayName:  displayName,
+		SystemPrompt: systemPrompt,
+		Capabilities: []string{},
+		Tools:        map[string]*modeladapter.ToolHintJSON{},
+		GlobalFormattingRules: map[string]string{},
+	}
+	if capsJSON.Valid && capsJSON.String != "" {
+		_ = json.Unmarshal([]byte(capsJSON.String), &row.Capabilities)
+	}
+	if toolsJSON.Valid && toolsJSON.String != "" {
+		_ = json.Unmarshal([]byte(toolsJSON.String), &row.Tools)
+	}
+	if rulesJSON.Valid && rulesJSON.String != "" {
+		_ = json.Unmarshal([]byte(rulesJSON.String), &row.GlobalFormattingRules)
+	}
+	return row, nil
+}
+
+// slugifyModel turns a display name into a safe MCP routing slug. "Claude 3.5
+// Sonnet" becomes "claude-3-5-sonnet". Only used when creating a new bot
+// group; the slug is readonly after that point.
+func slugifyModel(displayName string) string {
+	s := strings.ToLower(strings.TrimSpace(displayName))
+	var b strings.Builder
+	lastDash := true
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func valueOrEmptyStringSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func valueOrEmptyToolMap(m map[string]*modeladapter.ToolHintJSON) map[string]*modeladapter.ToolHintJSON {
+	if m == nil {
+		return map[string]*modeladapter.ToolHintJSON{}
+	}
+	return m
+}
+
+func valueOrEmptyStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}

--- a/cmd/unified-server/handlers_admin.go
+++ b/cmd/unified-server/handlers_admin.go
@@ -437,6 +437,12 @@ func adminUploadsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return ""
 	}() + `">Tour Steps</a>
+		<a href="/admin/ai-hints` + func() string {
+		if password != "" {
+			return "?password=" + password
+		}
+		return ""
+	}() + `">AI Hints</a>
 	</div>
 	<div class="nav">
 		<div class="nav-left">
@@ -2424,6 +2430,12 @@ func adminTracksHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return ""
 	}() + `">Tour Steps</a>
+		<a href="/admin/ai-hints` + func() string {
+		if password != "" {
+			return "?password=" + password
+		}
+		return ""
+	}() + `">AI Hints</a>
 	</div>
 	<div class="nav">
 		<div class="nav-left">

--- a/cmd/unified-server/hints/README.md
+++ b/cmd/unified-server/hints/README.md
@@ -6,6 +6,19 @@ This directory contains model-specific hints and prompts for the Safecast MCP se
 
 The hints system allows the MCP server to provide tailored descriptions, examples, and formatting guidance to different AI models (Claude, Qwen, Kimi, GPT, etc.) that connect to the Safecast database.
 
+## Source of Truth
+
+> **Runtime source of truth is the `ai_hints` table in PostgreSQL**, not the JSON files in this directory.
+>
+> On startup the server:
+> 1. Loads JSON files from this directory into memory (bootstrap/fallback).
+> 2. Seeds any missing rows into `ai_hints` with `ON CONFLICT (model) DO NOTHING` — existing DB rows are never overwritten by the JSON files.
+> 3. Reloads all non-deleted rows from `ai_hints` into memory and hands them to the MCP server.
+>
+> Admins edit hints through the **`/admin/ai-hints`** page (structured forms, history, soft delete, import/export). Changes in the DB take effect after clicking **Reload into Memory** (or restarting the service). The JSON files here are treated as seed templates and are **not** re-read at runtime unless the DB row is missing.
+>
+> To sync DB edits back into the repo, use **Export JSON** in the admin UI and commit the file.
+
 ## Files
 
 | File | Model | Description |
@@ -71,10 +84,20 @@ Default: `./hints/` relative to the binary location.
 
 ## Adding a New Model
 
-1. Create a new JSON file: `hints/newmodel.json`
-2. Set `"model": "newmodel"` in the JSON
-3. Add the model to `model_detection.go` detection logic
-4. Add the model constant to `hints.go`
+The recommended path is the admin UI:
+
+1. Open `/admin/ai-hints?password=...` (or log in as an admin user).
+2. Click **+ Add bot**, fill in the display name (the `model` slug is derived automatically), then save.
+3. Fill in capabilities, system prompt, global rules, and per-tool hints via the structured editor.
+4. Click **Reload into Memory** so the MCP server picks up the change without a restart.
+5. (Optional) Update `model_detection.go` so the server can auto-detect the new model from the `User-Agent` header.
+
+If you prefer to seed a new bot via JSON (e.g. for a fresh environment):
+
+1. Create a new JSON file: `hints/newmodel.json`.
+2. Set `"model": "newmodel"` in the JSON — this is the slug that will be inserted into `ai_hints`.
+3. Restart the server — the row will be seeded into the DB on the next startup.
+4. Add detection logic to `model_detection.go` and (optionally) a constant to `hints.go`.
 
 Example detection addition:
 
@@ -156,15 +179,18 @@ curl -H "User-Agent: UnknownBot/1.0" \
 
 ## Runtime Behavior
 
-1. **Startup**: All hints JSON files are loaded and cached in memory
-2. **Request**: Model is detected from `User-Agent` or `X-AI-Model` header
-3. **Response**: Tool results include model-specific formatting hints as metadata
+1. **Startup (file bootstrap)**: JSON files in this directory are loaded and cached in memory.
+2. **Startup (DB seed)**: Missing rows are inserted into `ai_hints` with `ON CONFLICT DO NOTHING`; existing DB rows are left alone.
+3. **Startup (DB load)**: All rows where `deleted_at IS NULL` are read from `ai_hints` and swapped into memory — this becomes the authoritative in-memory state.
+4. **Admin edit**: Writes go to `ai_hints` (with a history snapshot to `ai_hints_history`). The in-memory copy is refreshed on **Reload into Memory**.
+5. **Request**: Model is detected from `User-Agent` or `X-AI-Model` header.
+6. **Response**: Tool results include model-specific formatting hints as metadata.
 
 ## Performance
 
-- Hints are loaded once at startup (~10ms for all files)
-- No per-request file I/O
-- Thread-safe access via read-write mutex
+- Hints are loaded once at startup and on admin reload (no per-request file or DB I/O).
+- Thread-safe access via read-write mutex.
+- Atomic in-memory swap on reload (`SetHints`) — no half-loaded state.
 
 ## Troubleshooting
 

--- a/cmd/unified-server/hints_embed.go
+++ b/cmd/unified-server/hints_embed.go
@@ -1,0 +1,11 @@
+package main
+
+import "embed"
+
+// embeddedHintsFS carries the on-disk hint JSON templates into the compiled
+// binary. Used as the default source when MCP_HINTS_DIR is unset (e.g. in
+// production where the binary lives at /usr/local/bin/ without a neighbouring
+// hints/ directory).
+//
+//go:embed hints/*.json
+var embeddedHintsFS embed.FS

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -834,6 +834,7 @@ func main() {
 	var adminRealtimePageHandler http.HandlerFunc
 	var adminTranslationsPageHandler http.HandlerFunc
 	var adminTourPageHandler http.HandlerFunc
+	var adminAIHintsPageHandler http.HandlerFunc
 
 	// Register authentication and admin page handlers only when auth is enabled.
 	if authManager != nil {
@@ -941,6 +942,16 @@ func main() {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Write(data)
 		}
+
+		adminAIHintsPageHandler = func(w http.ResponseWriter, r *http.Request) {
+			data, err := content.ReadFile("public_html/admin-ai-hints.html")
+			if err != nil {
+				http.Error(w, "Page not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(data)
+		}
 	}
 
 	httpapi.RegisterPageRoutes(http.DefaultServeMux, httpapi.PageRoutesConfig{
@@ -958,6 +969,7 @@ func main() {
 		AdminRealtimePageHandler:     adminRealtimePageHandler,
 		AdminTranslationsPageHandler: adminTranslationsPageHandler,
 		AdminTourPageHandler:         adminTourPageHandler,
+		AdminAIHintsPageHandler:      adminAIHintsPageHandler,
 	})
 
 	// Legacy public endpoints (non-/api) live in one registrar to keep route
@@ -995,6 +1007,10 @@ func main() {
 	var adminTourStepsReorderAPIHandler http.HandlerFunc
 	var adminTourStepsByIDAPIHandler http.HandlerFunc
 	var adminTourStepsAPIHandler http.HandlerFunc
+	var adminAIHintsReloadAPIHandler http.HandlerFunc
+	var adminAIHintsImportAPIHandler http.HandlerFunc
+	var adminAIHintsByIDAPIHandler http.HandlerFunc
+	var adminAIHintsAPIHandler http.HandlerFunc
 	if authManager != nil {
 		adminMCPDataAPIHandler = adminMCPDataHandler
 		adminMCPExportAPIHandler = adminMCPExportHandler
@@ -1042,6 +1058,63 @@ func main() {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			}
 		}
+
+		adminAIHintsReloadAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			adminAIHintReloadHandler(w, r)
+		}
+		adminAIHintsImportAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			adminAIHintImportHandler(w, r)
+		}
+		// Subtree dispatcher for /api/admin/ai-hints/{model}[/history[/{id}/restore]|/restore|/snapshot|/export].
+		adminAIHintsByIDAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			stripped := strings.TrimPrefix(r.URL.Path, "/api/admin/ai-hints/")
+			stripped = strings.Trim(stripped, "/")
+			parts := strings.Split(stripped, "/")
+			switch {
+			case len(parts) == 1:
+				// /api/admin/ai-hints/{model}
+				switch r.Method {
+				case http.MethodGet:
+					adminAIHintGetHandler(w, r)
+				case http.MethodPut, http.MethodPatch:
+					adminAIHintUpdateHandler(w, r)
+				case http.MethodDelete:
+					adminAIHintDeleteHandler(w, r)
+				default:
+					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				}
+			case len(parts) == 2 && parts[1] == "restore" && r.Method == http.MethodPost:
+				adminAIHintRestoreHandler(w, r)
+			case len(parts) == 2 && parts[1] == "snapshot" && r.Method == http.MethodPost:
+				adminAIHintSnapshotHandler(w, r)
+			case len(parts) == 2 && parts[1] == "export" && r.Method == http.MethodGet:
+				adminAIHintExportHandler(w, r)
+			case len(parts) == 2 && parts[1] == "history" && r.Method == http.MethodGet:
+				adminAIHintHistoryListHandler(w, r)
+			case len(parts) == 4 && parts[1] == "history" && parts[3] == "restore" && r.Method == http.MethodPost:
+				adminAIHintHistoryRestoreHandler(w, r)
+			default:
+				http.Error(w, "Not found", http.StatusNotFound)
+			}
+		}
+		adminAIHintsAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				adminAIHintsListHandler(w, r)
+			case http.MethodPost:
+				adminAIHintCreateHandler(w, r)
+			default:
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			}
+		}
 	}
 
 	httpapi.Register(http.DefaultServeMux, httpapi.RegisterConfig{
@@ -1077,6 +1150,10 @@ func main() {
 		AdminTourStepsReorderHandler:     adminTourStepsReorderAPIHandler,
 		AdminTourStepsByIDHandler:        adminTourStepsByIDAPIHandler,
 		AdminTourStepsHandler:            adminTourStepsAPIHandler,
+		AdminAIHintsReloadHandler:        adminAIHintsReloadAPIHandler,
+		AdminAIHintsImportHandler:        adminAIHintsImportAPIHandler,
+		AdminAIHintsByIDHandler:          adminAIHintsByIDAPIHandler,
+		AdminAIHintsHandler:              adminAIHintsAPIHandler,
 		APISensorsHandler:                restHandler.handleSensors,
 		APISensorsExportHandler:          restHandler.handleSensorsExport,
 		APISensorByIDHandler:             restHandler.handleSensor,

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -10,10 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -552,18 +552,42 @@ func RegisterMCP() {
 		log.Printf("Warning: DuckDB initialization failed: %v (analytics features disabled)", err)
 	}
 
-	// Initialize hints loader
-	hintsDir := os.Getenv("MCP_HINTS_DIR")
-	if hintsDir == "" {
-		execPath, _ := os.Executable()
-		hintsDir = filepath.Join(filepath.Dir(execPath), "hints")
+	// Initialize hints source. MCP_HINTS_DIR overrides with an on-disk path
+	// (useful for devs who want to edit JSON without rebuilds). Otherwise we
+	// fall back to the hints directory embedded into the binary — this works
+	// regardless of where the binary runs from (production /usr/local/bin,
+	// local dev CWD, etc.).
+	var (
+		hintsFS    fs.FS
+		hintsLabel string
+	)
+	if mcpHintsDir := os.Getenv("MCP_HINTS_DIR"); mcpHintsDir != "" {
+		hintsFS = os.DirFS(mcpHintsDir)
+		hintsLabel = mcpHintsDir
+	} else {
+		sub, err := fs.Sub(embeddedHintsFS, "hints")
+		if err != nil {
+			log.Fatalf("[ai_hints] failed to open embedded hints: %v", err)
+		}
+		hintsFS = sub
+		hintsLabel = "embedded://hints"
 	}
 
-	mcpHintsLoader = modeladapter.NewHintsLoader(hintsDir)
+	mcpHintsLoader = modeladapter.NewHintsLoaderFS(hintsFS)
+	// File-based load runs first so the loader is usable even when the DB is
+	// down. seedAIHintsDBFromFS copies missing rows into Postgres, then the DB
+	// load replaces the in-memory map so admin edits become the source of
+	// truth.
 	if err := mcpHintsLoader.Load(); err != nil {
-		log.Printf("Warning: failed to load hints: %v (using default hints)", err)
+		log.Printf("Warning: failed to load hints from %s: %v", hintsLabel, err)
+	}
+	seedAIHintsDBFromFS(hintsFS, hintsLabel)
+	if count, err := loadAIHintsFromDB(mcpHintsLoader); err != nil {
+		log.Printf("Warning: failed to load hints from DB: %v (using %s)", err, hintsLabel)
+	} else if count > 0 {
+		log.Printf("Loaded %d AI hint rows from DB: %v", count, mcpHintsLoader.GetAllModels())
 	} else {
-		log.Printf("Loaded hints for models: %v", mcpHintsLoader.GetAllModels())
+		log.Printf("Loaded hints for models from %s: %v", hintsLabel, mcpHintsLoader.GetAllModels())
 	}
 
 	mcpModelAdapter = modeladapter.NewAdapter()
@@ -679,7 +703,7 @@ func RegisterMCP() {
 	log.Printf("MCP Server starting on port %s", mcpPort)
 	log.Println("  SSE endpoint: /mcp/sse")
 	log.Println("  Streamable HTTP endpoint: /mcp-http")
-	log.Printf("  Hints directory: %s", hintsDir)
+	log.Printf("  Hints source: %s", hintsLabel)
 	log.Println("  REST API: /api/...")
 	log.Println("  Swagger UI: /mcp-api/")
 

--- a/cmd/unified-server/model-adapter/hints.go
+++ b/cmd/unified-server/model-adapter/hints.go
@@ -2,6 +2,7 @@ package modeladapter
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -122,10 +123,12 @@ func (q *qwenHintProvider) GetDefaultExample(toolName string) string {
 }
 
 // HintsLoader manages loading model-specific hints from JSON files.
+// The filesystem is abstracted via fs.FS so the loader can read from a real
+// directory (os.DirFS) or an embedded tree (embed.FS via fs.Sub).
 type HintsLoader struct {
-	hintsDir string
-	hints    map[string]*ModelHint // keyed by model name
-	mu       sync.RWMutex
+	fsys  fs.FS                 // always non-nil; rooted at the hints directory
+	hints map[string]*ModelHint // keyed by model name
+	mu    sync.RWMutex
 }
 
 // ModelHint represents the JSON structure for model hints.
@@ -148,20 +151,29 @@ type ToolHintJSON struct {
 	Metadata          map[string]string `json:"metadata"`
 }
 
-// NewHintsLoader creates a new HintsLoader for the given directory.
+// NewHintsLoader creates a new HintsLoader rooted at the given on-disk
+// directory. Equivalent to NewHintsLoaderFS(os.DirFS(hintsDir)).
 func NewHintsLoader(hintsDir string) *HintsLoader {
+	return NewHintsLoaderFS(os.DirFS(hintsDir))
+}
+
+// NewHintsLoaderFS creates a new HintsLoader backed by the given filesystem.
+// Pass os.DirFS(path) for a real directory or fs.Sub(embeddedFS, "hints") for
+// an embedded tree. The FS should be rooted at the hints directory itself
+// (so ReadDir(".") yields the *.json files).
+func NewHintsLoaderFS(fsys fs.FS) *HintsLoader {
 	return &HintsLoader{
-		hintsDir: hintsDir,
-		hints:    make(map[string]*ModelHint),
+		fsys:  fsys,
+		hints: make(map[string]*ModelHint),
 	}
 }
 
-// Load reads all JSON hint files from the hints directory.
+// Load reads all JSON hint files from the configured filesystem.
 func (h *HintsLoader) Load() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	entries, err := os.ReadDir(h.hintsDir)
+	entries, err := fs.ReadDir(h.fsys, ".")
 	if err != nil {
 		return err
 	}
@@ -171,8 +183,7 @@ func (h *HintsLoader) Load() error {
 			continue
 		}
 
-		path := filepath.Join(h.hintsDir, entry.Name())
-		data, err := os.ReadFile(path)
+		data, err := fs.ReadFile(h.fsys, entry.Name())
 		if err != nil {
 			continue
 		}
@@ -198,6 +209,19 @@ func (h *HintsLoader) GetHints(model ModelName) *ModelHint {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.hints[string(model)]
+}
+
+// SetHints atomically replaces the entire in-memory hints map. Used by the
+// admin reload endpoint to re-hydrate hints from the database without a
+// restart.
+func (h *HintsLoader) SetHints(hints map[string]*ModelHint) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	copied := make(map[string]*ModelHint, len(hints))
+	for k, v := range hints {
+		copied[k] = v
+	}
+	h.hints = copied
 }
 
 // GetAllModels returns a list of all loaded model names.

--- a/cmd/unified-server/public_html/admin-ai-hints.html
+++ b/cmd/unified-server/public_html/admin-ai-hints.html
@@ -1,0 +1,1058 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>AI Hints - Safecast Admin</title>
+  <script>
+  (function() {
+    var saved = localStorage.getItem('safecastDocTheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+  })();
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
+  <link rel="manifest" href="/static/images/site.webmanifest">
+  <style>
+    :root {
+      --bg-primary: #f5f5f5;
+      --bg-card: white;
+      --text-primary: #333;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-color: #ddd;
+      --link-color: #0066cc;
+      --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --th-bg: #424242;
+      --hover-bg: #f9f9f9;
+      --btn-border-radius: 8px;
+      --tab-active-bg: #2196F3;
+      --tab-active-text: white;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1a1a1a;
+        --bg-card: #2b2b2b;
+        --text-primary: #eee;
+        --text-secondary: #aaa;
+        --text-muted: #777;
+        --border-color: #444;
+        --link-color: #90caf9;
+        --shadow: 0 1px 3px rgba(255,255,255,0.1);
+        --th-bg: #616161;
+        --hover-bg: #333;
+        --tab-active-bg: #1976D2;
+        color-scheme: dark;
+      }
+    }
+    :root[data-theme='light'] {
+      --bg-primary: #f5f5f5; --bg-card: #fff; --text-primary: #333;
+      --text-secondary: #666; --text-muted: #999; --border-color: #ddd;
+      --link-color: #0066cc; --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --hover-bg: #f9f9f9; --th-bg: #424242; color-scheme: light;
+    }
+    :root[data-theme='dark'] {
+      --bg-primary: #1a1a1a; --bg-card: #2b2b2b; --text-primary: #eee;
+      --text-secondary: #aaa; --text-muted: #777; --border-color: #444;
+      --link-color: #90caf9; --shadow: 0 1px 3px rgba(255,255,255,0.07);
+      --hover-bg: #333; --th-bg: #616161; color-scheme: dark;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); transition: background 0.2s, color 0.2s; }
+
+    .top-nav { background: #1a3a5c; color: #fff; padding: 0 24px; display: flex; align-items: center; gap: 16px; height: 52px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); position: sticky; top: 0; z-index: 100; }
+    .nav-logo { display: flex; align-items: center; gap: 8px; text-decoration: none; color: #fff; font-weight: 700; font-size: 17px; white-space: nowrap; }
+    .nav-logo img { height: 28px; width: 28px; object-fit: contain; }
+    .nav-sep { color: rgba(255,255,255,0.3); font-size: 18px; }
+    .nav-title { font-size: 15px; font-weight: 600; color: #d0e8ff; white-space: nowrap; }
+    .nav-spacer { flex: 1; }
+    .back-link { color: #afd4f5; text-decoration: none; font-size: 13px; white-space: nowrap; }
+    .back-link:hover { color: #fff; }
+    #theme-toggle { background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); border-radius: 6px; padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+    #theme-toggle:hover { background: rgba(255,255,255,0.22); }
+
+    .page-content { padding: 20px 24px; }
+    h1 { margin-bottom: 15px; font-size: 1.6em; }
+
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; }
+    .admin-tabs a, .admin-tabs span { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+    .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+    .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
+
+    .layout { display: grid; grid-template-columns: 280px 1fr; gap: 16px; margin-top: 12px; }
+    .sidebar { background: var(--bg-card); border-radius: 8px; padding: 12px; box-shadow: var(--shadow); max-height: calc(100vh - 160px); overflow-y: auto; }
+    .sidebar h3 { font-size: 0.95em; margin-bottom: 10px; color: var(--text-secondary); }
+    .sidebar-actions { display: flex; gap: 6px; margin-bottom: 10px; }
+    .sidebar-actions button { flex: 1; padding: 6px 8px; font-size: 0.85em; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); border-radius: 6px; cursor: pointer; }
+    .sidebar-actions button.primary { background: #2196F3; color: white; border-color: #2196F3; }
+    .sidebar-actions button.primary:hover { background: #1976D2; }
+    .bot-list { list-style: none; }
+    .bot-list li { padding: 8px 10px; border-radius: 6px; cursor: pointer; color: var(--text-primary); margin-bottom: 2px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    .bot-list li:hover { background: var(--hover-bg); }
+    .bot-list li.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
+    .bot-list li.deleted { opacity: 0.55; font-style: italic; }
+    .bot-list .slug { font-size: 0.75em; color: var(--text-muted); font-family: monospace; }
+    .bot-list li.active .slug { color: rgba(255,255,255,0.85); }
+
+    .editor { background: var(--bg-card); border-radius: 8px; padding: 16px; box-shadow: var(--shadow); min-height: 400px; }
+    .editor-header { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border-color); padding-bottom: 10px; margin-bottom: 12px; }
+    .editor-header h2 { font-size: 1.2em; }
+    .editor-header .actions { display: flex; flex-wrap: wrap; gap: 6px; }
+    .btn { padding: 7px 14px; font-size: 0.9em; border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); border-radius: 6px; cursor: pointer; }
+    .btn:hover { background: var(--hover-bg); }
+    .btn.primary { background: #4CAF50; color: white; border-color: #4CAF50; }
+    .btn.primary:hover { background: #388E3C; }
+    .btn.danger { background: #f44336; color: white; border-color: #f44336; }
+    .btn.danger:hover { background: #d32f2f; }
+    .btn.warn { background: #FF9800; color: white; border-color: #FF9800; }
+    .btn.warn:hover { background: #F57C00; }
+
+    .sub-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border-color); margin-bottom: 14px; }
+    .sub-tabs button { background: none; border: none; padding: 9px 18px; cursor: pointer; color: var(--text-secondary); font-weight: 500; border-bottom: 3px solid transparent; font-size: 0.95em; }
+    .sub-tabs button.active { color: var(--tab-active-bg); border-bottom-color: var(--tab-active-bg); }
+
+    .pane { display: none; }
+    .pane.active { display: block; }
+
+    .field { margin-bottom: 14px; }
+    .field label { display: block; font-weight: 600; color: var(--text-secondary); margin-bottom: 4px; font-size: 0.9em; }
+    .field .hint { font-size: 0.8em; color: var(--text-muted); margin-bottom: 4px; }
+    .field input[type=text], .field textarea, .field select { width: 100%; padding: 8px 10px; border: 1px solid var(--border-color); border-radius: 6px; background: var(--bg-card); color: var(--text-primary); font-size: 0.95em; font-family: inherit; }
+    .field textarea { min-height: 100px; resize: vertical; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.45; }
+    .field textarea.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; }
+    .field .slug-display { font-family: monospace; font-size: 0.85em; color: var(--text-muted); padding: 4px 0; }
+
+    .tag-row { display: flex; flex-wrap: wrap; gap: 6px; padding: 6px; border: 1px solid var(--border-color); border-radius: 6px; min-height: 40px; align-items: center; }
+    .tag { background: var(--tab-active-bg); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; display: inline-flex; align-items: center; gap: 5px; }
+    .tag .remove { cursor: pointer; opacity: 0.8; }
+    .tag .remove:hover { opacity: 1; }
+    .tag-row .tag-input-wrap { display: flex; gap: 4px; align-items: center; flex: 1; min-width: 200px; }
+    .tag-row select, .tag-row input { border: none; outline: none; background: transparent; color: var(--text-primary); font-size: 0.9em; padding: 2px 4px; }
+
+    .kv-rows { display: flex; flex-direction: column; gap: 6px; }
+    .kv-row { display: flex; gap: 6px; align-items: center; }
+    .kv-row input { flex: 1; padding: 6px 8px; border: 1px solid var(--border-color); border-radius: 6px; background: var(--bg-card); color: var(--text-primary); font-size: 0.9em; }
+    .kv-row .btn-del { background: transparent; color: var(--text-muted); border: none; cursor: pointer; font-size: 1.1em; padding: 0 6px; }
+    .kv-row .btn-del:hover { color: #f44336; }
+
+    .list-rows { display: flex; flex-direction: column; gap: 6px; }
+    .list-row { display: flex; gap: 6px; }
+    .list-row input, .list-row textarea { flex: 1; padding: 6px 8px; border: 1px solid var(--border-color); border-radius: 6px; background: var(--bg-card); color: var(--text-primary); font-size: 0.9em; }
+
+    .tool-card { border: 1px solid var(--border-color); border-radius: 8px; margin-bottom: 12px; background: var(--bg-card); }
+    .tool-head { display: flex; gap: 8px; align-items: center; padding: 10px 12px; cursor: pointer; user-select: none; }
+    .tool-head .arrow { transition: transform 0.15s; color: var(--text-muted); }
+    .tool-card.open .tool-head .arrow { transform: rotate(90deg); }
+    .tool-head .name { font-family: monospace; font-weight: 600; flex: 1; }
+    .tool-head .actions { display: flex; gap: 6px; }
+    .tool-body { display: none; padding: 12px; border-top: 1px solid var(--border-color); }
+    .tool-card.open .tool-body { display: block; }
+
+    .example-card { border: 1px dashed var(--border-color); border-radius: 6px; padding: 10px; margin-bottom: 8px; }
+    .example-card .example-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; font-size: 0.85em; color: var(--text-secondary); }
+
+    .history-row { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-bottom: 1px solid var(--border-color); font-size: 0.9em; }
+    .history-row:last-child { border-bottom: none; }
+    .change-kind { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; text-transform: uppercase; }
+    .change-kind.update { background: #FFC107; color: #333; }
+    .change-kind.delete { background: #f44336; color: white; }
+    .change-kind.restore { background: #4CAF50; color: white; }
+    .change-kind.manual { background: #2196F3; color: white; }
+    .change-kind.import { background: #9C27B0; color: white; }
+
+    .empty { text-align: center; color: var(--text-muted); padding: 40px; }
+    .status { padding: 6px 10px; font-size: 0.85em; color: var(--text-secondary); min-height: 18px; }
+    .status.ok { color: #4CAF50; }
+    .status.err { color: #f44336; }
+
+    @media (max-width: 900px) {
+      .layout { grid-template-columns: 1fr; }
+      .sidebar { max-height: 250px; }
+    }
+  </style>
+</head>
+<body>
+<nav class="top-nav">
+  <a href="/" class="nav-logo">
+    <img src="/static/images/safecast-logo-squared.png" alt="Safecast">
+    Safecast
+  </a>
+  <span class="nav-sep">|</span>
+  <span class="nav-title">AI Hints</span>
+  <span class="nav-spacer"></span>
+  <a href="/" class="back-link">← Back to Map</a>
+  <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark Mode</button>
+</nav>
+<div class="page-content">
+
+<div class="admin-tabs" id="adminTabs"></div>
+
+<div class="layout">
+  <aside class="sidebar">
+    <h3>Bot groups</h3>
+    <div class="sidebar-actions">
+      <button class="primary" onclick="addNewBot()">+ Add bot</button>
+      <button onclick="toggleDeleted()" id="toggleDeletedBtn">Show deleted</button>
+    </div>
+    <ul class="bot-list" id="botList"></ul>
+    <div class="status" id="listStatus"></div>
+  </aside>
+
+  <main class="editor">
+    <div class="editor-header">
+      <h2 id="editorTitle">Select a bot</h2>
+      <div class="actions" id="editorActions" style="display:none">
+        <button class="btn primary" onclick="saveCurrent()">Save</button>
+        <button class="btn" onclick="reloadIntoMemory()" title="Rebuild in-memory hints from DB">Reload into Memory</button>
+        <button class="btn" onclick="takeSnapshot()" title="Save a manual history snapshot">Snapshot</button>
+        <button class="btn" onclick="exportCurrent()">Export JSON</button>
+        <button class="btn warn" onclick="importJSON()">Import JSON</button>
+        <button class="btn danger" id="deleteBtn" onclick="deleteCurrent()">Delete</button>
+        <button class="btn primary" id="restoreBtn" style="display:none" onclick="restoreCurrent()">Restore</button>
+      </div>
+    </div>
+
+    <div id="editorPlaceholder" class="empty">
+      Select a bot from the list, or click "+ Add bot" to create a new one.
+    </div>
+
+    <div id="editorBody" style="display:none">
+      <div class="sub-tabs">
+        <button class="active" data-pane="general" onclick="showPane('general')">General</button>
+        <button data-pane="rules" onclick="showPane('rules')">Global rules</button>
+        <button data-pane="tools" onclick="showPane('tools')">Tools</button>
+        <button data-pane="history" onclick="showPane('history')">History</button>
+      </div>
+
+      <section class="pane active" id="pane-general">
+        <div class="field">
+          <label>Display name</label>
+          <div class="hint">Shown in the bot list. The model slug (used for MCP routing) is derived from this.</div>
+          <input type="text" id="displayName" oninput="onDisplayNameInput()">
+        </div>
+        <div class="field">
+          <label>Model slug</label>
+          <div class="hint">Readonly after creation — this is the MCP routing key.</div>
+          <input type="text" id="modelSlug" style="display:none">
+          <div class="slug-display" id="modelSlugReadonly"></div>
+        </div>
+        <div class="field">
+          <label>Capabilities</label>
+          <div class="hint">Pick from common capabilities or type a custom one.</div>
+          <div class="tag-row" id="capsRow"></div>
+        </div>
+        <div class="field">
+          <label>System prompt</label>
+          <textarea id="systemPrompt" rows="8"></textarea>
+        </div>
+      </section>
+
+      <section class="pane" id="pane-rules">
+        <div class="field">
+          <label>Global formatting rules</label>
+          <div class="hint">Key/value pairs applied across all tools. Examples: tone, coordinates, tables.</div>
+          <div class="kv-rows" id="globalRulesRows"></div>
+          <button class="btn" style="margin-top:8px" onclick="addGlobalRule()">+ Add rule</button>
+        </div>
+      </section>
+
+      <section class="pane" id="pane-tools">
+        <div id="toolsList"></div>
+        <button class="btn" onclick="addTool()">+ Add tool</button>
+      </section>
+
+      <section class="pane" id="pane-history">
+        <div id="historyList" class="empty">Loading history…</div>
+      </section>
+    </div>
+    <div class="status" id="editorStatus"></div>
+  </main>
+</div>
+</div>
+
+<input type="file" id="importFileInput" accept=".json,application/json" style="display:none" onchange="onImportFile(event)">
+
+<script>
+function toggleTheme() {
+  var cur = document.documentElement.getAttribute('data-theme') || 'light';
+  var next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('safecastDocTheme', next);
+  document.getElementById('theme-toggle').textContent = next === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode';
+}
+(function() {
+  var cur = document.documentElement.getAttribute('data-theme') || 'light';
+  document.getElementById('theme-toggle').textContent = cur === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode';
+})();
+
+const PASSWORD = new URLSearchParams(window.location.search).get('password') || '';
+const AUTH_PARAM = PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '';
+
+const COMMON_CAPABILITIES = [
+  'tool_use', 'function_calling', 'json_mode', 'long_context',
+  'complex_reasoning', 'bilingual', 'multilingual', 'vision', 'streaming'
+];
+
+let state = {
+  list: [],              // [{model, display_name, capabilities, updated_at, deleted_at}]
+  showDeleted: false,
+  current: null,         // currently-loaded full row, or { __new: true } when creating
+  dirty: false
+};
+
+function buildAdminTabs() {
+  const tabs = [
+    { label: 'Users', href: '/admin/users' },
+    { label: 'Uploads', href: '/admin/uploads' },
+    { label: 'MCP Analytics', href: '/admin/mcp' },
+    { label: 'Realtime', href: '/admin/realtime' },
+    { label: 'Translations', href: '/admin/translations' },
+    { label: 'Tour Steps', href: '/admin/tour' },
+    { label: 'AI Hints', href: '/admin/ai-hints', active: true }
+  ];
+  const container = document.getElementById('adminTabs');
+  tabs.forEach(t => {
+    const href = t.href + (PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '');
+    container.innerHTML += `<a href="${href}" class="${t.active ? 'active' : ''}">${t.label}</a>`;
+  });
+}
+
+function setStatus(id, msg, kind) {
+  const el = document.getElementById(id);
+  el.textContent = msg || '';
+  el.className = 'status' + (kind ? ' ' + kind : '');
+}
+
+async function apiFetch(path, opts = {}) {
+  const sep = path.indexOf('?') === -1 ? '?' : '&';
+  const url = path + (PASSWORD ? sep + 'password=' + encodeURIComponent(PASSWORD) : '');
+  const res = await fetch(url, Object.assign({ credentials: 'same-origin' }, opts));
+  const text = await res.text();
+  let data = null;
+  try { data = text ? JSON.parse(text) : null; } catch (e) { /* non-JSON */ }
+  if (!res.ok) {
+    const msg = data && data.error ? data.error : res.status + ' ' + res.statusText;
+    throw new Error(msg);
+  }
+  return data;
+}
+
+// -------- List --------
+async function loadList() {
+  setStatus('listStatus', 'Loading…');
+  try {
+    const data = await apiFetch('/api/admin/ai-hints' + (state.showDeleted ? '?include_deleted=true' : ''));
+    state.list = (data && data.data) || [];
+    renderList();
+    setStatus('listStatus', state.list.length + ' bot' + (state.list.length === 1 ? '' : 's'));
+  } catch (e) {
+    setStatus('listStatus', e.message, 'err');
+  }
+}
+
+function renderList() {
+  const ul = document.getElementById('botList');
+  if (!state.list.length) {
+    ul.innerHTML = '<li class="empty">No bots yet</li>';
+    return;
+  }
+  ul.innerHTML = state.list.map(b => {
+    const isActive = state.current && state.current.model === b.model;
+    const deleted = !!b.deleted_at;
+    return `<li class="${isActive ? 'active' : ''} ${deleted ? 'deleted' : ''}" onclick="selectBot('${b.model}')">
+      <div>
+        <div>${escapeHTML(b.display_name)}</div>
+        <div class="slug">${escapeHTML(b.model)}${deleted ? ' · deleted' : ''}</div>
+      </div>
+    </li>`;
+  }).join('');
+}
+
+function toggleDeleted() {
+  state.showDeleted = !state.showDeleted;
+  document.getElementById('toggleDeletedBtn').textContent = state.showDeleted ? 'Hide deleted' : 'Show deleted';
+  loadList();
+}
+
+// -------- Editor --------
+async function selectBot(model) {
+  if (state.dirty && !confirm('You have unsaved changes. Discard them?')) return;
+  state.dirty = false;
+  try {
+    const row = await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(model));
+    state.current = row;
+    renderEditor();
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+function addNewBot() {
+  if (state.dirty && !confirm('You have unsaved changes. Discard them?')) return;
+  state.current = {
+    __new: true,
+    model: '',
+    display_name: '',
+    capabilities: [],
+    system_prompt: '',
+    tools: {},
+    global_formatting_rules: {}
+  };
+  state.dirty = false;
+  renderEditor();
+}
+
+function renderEditor() {
+  const c = state.current;
+  document.getElementById('editorPlaceholder').style.display = c ? 'none' : 'block';
+  document.getElementById('editorBody').style.display = c ? 'block' : 'none';
+  document.getElementById('editorActions').style.display = c ? 'flex' : 'none';
+  if (!c) return;
+
+  document.getElementById('editorTitle').textContent = c.__new ? 'New bot' : c.display_name;
+
+  document.getElementById('displayName').value = c.display_name || '';
+  const slugInput = document.getElementById('modelSlug');
+  const slugReadonly = document.getElementById('modelSlugReadonly');
+  if (c.__new) {
+    slugInput.style.display = 'block';
+    slugInput.value = c.model || '';
+    slugInput.placeholder = 'auto-derived from display name';
+    slugReadonly.style.display = 'none';
+  } else {
+    slugInput.style.display = 'none';
+    slugReadonly.style.display = 'block';
+    slugReadonly.textContent = c.model;
+  }
+
+  document.getElementById('systemPrompt').value = c.system_prompt || '';
+  renderCapabilities(c.capabilities || []);
+  renderGlobalRules(c.global_formatting_rules || {});
+  renderTools(c.tools || {});
+  document.getElementById('historyList').innerHTML = '<div class="empty">Select the History tab to load</div>';
+
+  const delBtn = document.getElementById('deleteBtn');
+  const restoreBtn = document.getElementById('restoreBtn');
+  if (c.__new) {
+    delBtn.style.display = 'none';
+    restoreBtn.style.display = 'none';
+  } else if (c.deleted_at) {
+    delBtn.style.display = 'none';
+    restoreBtn.style.display = 'inline-block';
+  } else {
+    delBtn.style.display = 'inline-block';
+    restoreBtn.style.display = 'none';
+  }
+
+  renderList();
+  showPane('general');
+  setStatus('editorStatus', '');
+}
+
+function showPane(name) {
+  document.querySelectorAll('.sub-tabs button').forEach(b => b.classList.toggle('active', b.dataset.pane === name));
+  document.querySelectorAll('.pane').forEach(p => p.classList.toggle('active', p.id === 'pane-' + name));
+  if (name === 'history' && state.current && !state.current.__new) {
+    loadHistory(state.current.model);
+  }
+}
+
+function onDisplayNameInput() {
+  state.dirty = true;
+  if (state.current && state.current.__new) {
+    const slugInput = document.getElementById('modelSlug');
+    if (!slugInput.dataset.userEdited) {
+      slugInput.value = slugify(document.getElementById('displayName').value);
+    }
+  }
+}
+
+function slugify(s) {
+  return (s || '').toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// -------- Capabilities --------
+function renderCapabilities(caps) {
+  const row = document.getElementById('capsRow');
+  const userCaps = new Set(caps);
+  state.list.forEach(b => (b.capabilities || []).forEach(c => userCaps.add(c)));
+  const options = Array.from(new Set([...COMMON_CAPABILITIES, ...userCaps])).sort();
+
+  const tagsHTML = caps.map((c, i) => `
+    <span class="tag">${escapeHTML(c)}<span class="remove" onclick="removeCapability(${i})">×</span></span>
+  `).join('');
+
+  const optionsHTML = options
+    .filter(o => !caps.includes(o))
+    .map(o => `<option value="${escapeHTML(o)}">${escapeHTML(o)}</option>`)
+    .join('');
+
+  row.innerHTML = tagsHTML + `
+    <span class="tag-input-wrap">
+      <select id="capSelect" onchange="addCapabilityFromSelect()">
+        <option value="">Add existing…</option>
+        ${optionsHTML}
+      </select>
+      <input type="text" id="capInput" placeholder="+ custom" onkeydown="if(event.key==='Enter'){event.preventDefault();addCapabilityFromInput();}">
+    </span>
+  `;
+}
+
+function addCapabilityFromSelect() {
+  const sel = document.getElementById('capSelect');
+  if (!sel.value) return;
+  state.current.capabilities = [...(state.current.capabilities || []), sel.value];
+  state.dirty = true;
+  renderCapabilities(state.current.capabilities);
+}
+
+function addCapabilityFromInput() {
+  const inp = document.getElementById('capInput');
+  const v = inp.value.trim();
+  if (!v) return;
+  state.current.capabilities = [...(state.current.capabilities || []), v];
+  state.dirty = true;
+  renderCapabilities(state.current.capabilities);
+}
+
+function removeCapability(idx) {
+  state.current.capabilities.splice(idx, 1);
+  state.dirty = true;
+  renderCapabilities(state.current.capabilities);
+}
+
+// -------- Global rules --------
+function renderGlobalRules(rules) {
+  const rows = document.getElementById('globalRulesRows');
+  const entries = Object.entries(rules || {});
+  if (!entries.length) {
+    rows.innerHTML = '<div class="empty" style="padding:10px">No rules yet</div>';
+    return;
+  }
+  rows.innerHTML = entries.map(([k, v], i) => `
+    <div class="kv-row">
+      <input type="text" placeholder="key" value="${escapeHTML(k)}" onchange="updateGlobalRule(${i}, 'key', this.value)">
+      <input type="text" placeholder="value" value="${escapeHTML(v)}" onchange="updateGlobalRule(${i}, 'value', this.value)">
+      <button class="btn-del" onclick="deleteGlobalRule(${i})" title="Remove">×</button>
+    </div>
+  `).join('');
+}
+
+function addGlobalRule() {
+  state.current.global_formatting_rules = state.current.global_formatting_rules || {};
+  const base = 'rule';
+  let n = 1;
+  while (state.current.global_formatting_rules[base + n]) n++;
+  state.current.global_formatting_rules[base + n] = '';
+  state.dirty = true;
+  renderGlobalRules(state.current.global_formatting_rules);
+}
+
+function updateGlobalRule(idx, kind, value) {
+  const entries = Object.entries(state.current.global_formatting_rules || {});
+  const [k, v] = entries[idx];
+  const next = {};
+  entries.forEach(([ek, ev], i) => {
+    if (i === idx) {
+      if (kind === 'key') next[value] = v;
+      else next[k] = value;
+    } else next[ek] = ev;
+  });
+  state.current.global_formatting_rules = next;
+  state.dirty = true;
+}
+
+function deleteGlobalRule(idx) {
+  const entries = Object.entries(state.current.global_formatting_rules || {});
+  entries.splice(idx, 1);
+  state.current.global_formatting_rules = Object.fromEntries(entries);
+  state.dirty = true;
+  renderGlobalRules(state.current.global_formatting_rules);
+}
+
+// -------- Tools --------
+function renderTools(tools) {
+  const list = document.getElementById('toolsList');
+  const names = Object.keys(tools || {});
+  if (!names.length) {
+    list.innerHTML = '<div class="empty" style="padding:20px">No tools configured</div>';
+    return;
+  }
+  list.innerHTML = names.map(name => renderToolCard(name, tools[name] || {})).join('');
+}
+
+function renderToolCard(name, tool) {
+  const warningsHTML = (tool.warnings || []).map((w, i) => `
+    <div class="list-row">
+      <input type="text" value="${escapeHTML(w)}" onchange="updateToolListItem('${name}', 'warnings', ${i}, this.value)">
+      <button class="btn-del" onclick="deleteToolListItem('${name}', 'warnings', ${i})">×</button>
+    </div>
+  `).join('');
+
+  const rulesEntries = Object.entries(tool.formatting_rules || {});
+  const rulesHTML = rulesEntries.map(([k, v], i) => `
+    <div class="kv-row">
+      <input type="text" placeholder="key" value="${escapeHTML(k)}" onchange="updateToolRule('${name}', ${i}, 'key', this.value)">
+      <input type="text" placeholder="value" value="${escapeHTML(v)}" onchange="updateToolRule('${name}', ${i}, 'value', this.value)">
+      <button class="btn-del" onclick="deleteToolRule('${name}', ${i})">×</button>
+    </div>
+  `).join('');
+
+  const examplesHTML = (tool.examples || []).map((ex, i) => renderExampleCard(name, i, ex)).join('');
+
+  return `
+    <div class="tool-card" data-tool="${escapeHTML(name)}">
+      <div class="tool-head" onclick="toggleTool('${name}')">
+        <span class="arrow">▶</span>
+        <span class="name">${escapeHTML(name)}</span>
+        <span class="actions" onclick="event.stopPropagation()">
+          <button class="btn" onclick="renameTool('${name}')">Rename</button>
+          <button class="btn danger" onclick="deleteTool('${name}')">Delete</button>
+        </span>
+      </div>
+      <div class="tool-body">
+        <div class="field">
+          <label>Description</label>
+          <textarea onchange="updateToolField('${name}', 'description', this.value)">${escapeHTML(tool.description || '')}</textarea>
+        </div>
+        <div class="field">
+          <label>Output hints</label>
+          <textarea onchange="updateToolField('${name}', 'output_hints', this.value)">${escapeHTML(tool.output_hints || '')}</textarea>
+        </div>
+        <div class="field">
+          <label>Warnings</label>
+          <div class="list-rows">${warningsHTML}</div>
+          <button class="btn" style="margin-top:6px" onclick="addToolListItem('${name}', 'warnings')">+ Add warning</button>
+        </div>
+        <div class="field">
+          <label>Formatting rules</label>
+          <div class="kv-rows">${rulesHTML}</div>
+          <button class="btn" style="margin-top:6px" onclick="addToolRule('${name}')">+ Add rule</button>
+        </div>
+        <div class="field">
+          <label>Examples</label>
+          <div>${examplesHTML || '<div class="empty" style="padding:10px">No examples</div>'}</div>
+          <button class="btn" style="margin-top:6px" onclick="addExample('${name}')">+ Add example</button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderExampleCard(toolName, idx, ex) {
+  ex = ex || {};
+  const args = ex.tool_call && ex.tool_call.arguments ? ex.tool_call.arguments : {};
+  const argRows = Object.entries(args).map(([k, v], i) => `
+    <div class="kv-row">
+      <input type="text" placeholder="arg name" value="${escapeHTML(k)}" onchange="updateExampleArg('${toolName}', ${idx}, ${i}, 'key', this.value)">
+      <input type="text" placeholder="value" value="${escapeHTML(formatArgValue(v))}" onchange="updateExampleArg('${toolName}', ${idx}, ${i}, 'value', this.value)">
+      <button class="btn-del" onclick="deleteExampleArg('${toolName}', ${idx}, ${i})">×</button>
+    </div>
+  `).join('');
+
+  return `
+    <div class="example-card">
+      <div class="example-head">
+        <span>Example ${idx + 1}</span>
+        <button class="btn danger" onclick="deleteExample('${toolName}', ${idx})">Delete</button>
+      </div>
+      <div class="field">
+        <label>User query</label>
+        <input type="text" value="${escapeHTML(ex.user_query || '')}" onchange="updateExampleField('${toolName}', ${idx}, 'user_query', this.value)">
+      </div>
+      <div class="field">
+        <label>Tool call — name</label>
+        <input type="text" value="${escapeHTML((ex.tool_call && ex.tool_call.name) || toolName)}" onchange="updateExampleField('${toolName}', ${idx}, 'tool_call.name', this.value)">
+      </div>
+      <div class="field">
+        <label>Tool call — arguments</label>
+        <div class="kv-rows">${argRows}</div>
+        <button class="btn" style="margin-top:6px" onclick="addExampleArg('${toolName}', ${idx})">+ Add argument</button>
+      </div>
+    </div>
+  `;
+}
+
+function formatArgValue(v) {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function parseArgValue(s) {
+  if (s === '') return '';
+  if (/^-?\d+$/.test(s)) return parseInt(s, 10);
+  if (/^-?\d+\.\d+$/.test(s)) return parseFloat(s);
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if ((s.startsWith('{') && s.endsWith('}')) || (s.startsWith('[') && s.endsWith(']'))) {
+    try { return JSON.parse(s); } catch (_) { /* fall through */ }
+  }
+  return s;
+}
+
+function toggleTool(name) {
+  const card = document.querySelector(`.tool-card[data-tool="${CSS.escape(name)}"]`);
+  if (card) card.classList.toggle('open');
+}
+
+function addTool() {
+  const name = prompt('Tool name (e.g. query_radiation):');
+  if (!name) return;
+  if (!/^[a-z][a-z0-9_]*$/i.test(name)) {
+    alert('Tool name must start with a letter and contain only letters, digits, and underscores.');
+    return;
+  }
+  state.current.tools = state.current.tools || {};
+  if (state.current.tools[name]) {
+    alert('A tool with that name already exists.');
+    return;
+  }
+  state.current.tools[name] = { description: '', examples: [], output_hints: '', formatting_rules: {}, warnings: [] };
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function renameTool(oldName) {
+  const newName = prompt('New tool name:', oldName);
+  if (!newName || newName === oldName) return;
+  if (!/^[a-z][a-z0-9_]*$/i.test(newName)) {
+    alert('Tool name must start with a letter and contain only letters, digits, and underscores.');
+    return;
+  }
+  if (state.current.tools[newName]) {
+    alert('A tool with that name already exists.');
+    return;
+  }
+  state.current.tools[newName] = state.current.tools[oldName];
+  delete state.current.tools[oldName];
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function deleteTool(name) {
+  if (!confirm('Delete tool "' + name + '"?')) return;
+  delete state.current.tools[name];
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function updateToolField(name, field, value) {
+  state.current.tools[name] = state.current.tools[name] || {};
+  state.current.tools[name][field] = value;
+  state.dirty = true;
+}
+
+function addToolListItem(name, field) {
+  state.current.tools[name] = state.current.tools[name] || {};
+  state.current.tools[name][field] = state.current.tools[name][field] || [];
+  state.current.tools[name][field].push('');
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function updateToolListItem(name, field, idx, value) {
+  state.current.tools[name][field][idx] = value;
+  state.dirty = true;
+}
+
+function deleteToolListItem(name, field, idx) {
+  state.current.tools[name][field].splice(idx, 1);
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function addToolRule(name) {
+  state.current.tools[name].formatting_rules = state.current.tools[name].formatting_rules || {};
+  let i = 1;
+  while (state.current.tools[name].formatting_rules['rule' + i]) i++;
+  state.current.tools[name].formatting_rules['rule' + i] = '';
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function updateToolRule(name, idx, kind, value) {
+  const entries = Object.entries(state.current.tools[name].formatting_rules || {});
+  const [k, v] = entries[idx];
+  const next = {};
+  entries.forEach(([ek, ev], i) => {
+    if (i === idx) {
+      if (kind === 'key') next[value] = v;
+      else next[k] = value;
+    } else next[ek] = ev;
+  });
+  state.current.tools[name].formatting_rules = next;
+  state.dirty = true;
+}
+
+function deleteToolRule(name, idx) {
+  const entries = Object.entries(state.current.tools[name].formatting_rules || {});
+  entries.splice(idx, 1);
+  state.current.tools[name].formatting_rules = Object.fromEntries(entries);
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function addExample(name) {
+  state.current.tools[name].examples = state.current.tools[name].examples || [];
+  state.current.tools[name].examples.push({ user_query: '', tool_call: { name: name, arguments: {} } });
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function deleteExample(name, idx) {
+  state.current.tools[name].examples.splice(idx, 1);
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function updateExampleField(name, idx, field, value) {
+  const ex = state.current.tools[name].examples[idx];
+  if (field === 'user_query') {
+    ex.user_query = value;
+  } else if (field === 'tool_call.name') {
+    ex.tool_call = ex.tool_call || {};
+    ex.tool_call.name = value;
+  }
+  state.dirty = true;
+}
+
+function addExampleArg(name, idx) {
+  const ex = state.current.tools[name].examples[idx];
+  ex.tool_call = ex.tool_call || { name: name, arguments: {} };
+  ex.tool_call.arguments = ex.tool_call.arguments || {};
+  let i = 1;
+  while (ex.tool_call.arguments['arg' + i] !== undefined) i++;
+  ex.tool_call.arguments['arg' + i] = '';
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+function updateExampleArg(name, exIdx, argIdx, kind, value) {
+  const ex = state.current.tools[name].examples[exIdx];
+  const entries = Object.entries(ex.tool_call.arguments || {});
+  const [k, v] = entries[argIdx];
+  const next = {};
+  entries.forEach(([ek, ev], i) => {
+    if (i === argIdx) {
+      if (kind === 'key') next[value] = v;
+      else next[k] = parseArgValue(value);
+    } else next[ek] = ev;
+  });
+  ex.tool_call.arguments = next;
+  state.dirty = true;
+}
+
+function deleteExampleArg(name, exIdx, argIdx) {
+  const ex = state.current.tools[name].examples[exIdx];
+  const entries = Object.entries(ex.tool_call.arguments || {});
+  entries.splice(argIdx, 1);
+  ex.tool_call.arguments = Object.fromEntries(entries);
+  state.dirty = true;
+  renderTools(state.current.tools);
+}
+
+// -------- Save / Delete / Restore --------
+function collectPayload() {
+  const p = {
+    display_name: document.getElementById('displayName').value.trim(),
+    capabilities: state.current.capabilities || [],
+    system_prompt: document.getElementById('systemPrompt').value,
+    tools: state.current.tools || {},
+    global_formatting_rules: state.current.global_formatting_rules || {}
+  };
+  if (state.current.__new) {
+    const slug = document.getElementById('modelSlug').value.trim();
+    if (slug) p.model = slug;
+  }
+  return p;
+}
+
+async function saveCurrent() {
+  if (!state.current) return;
+  const payload = collectPayload();
+  if (!payload.display_name) {
+    setStatus('editorStatus', 'Display name is required', 'err');
+    return;
+  }
+  setStatus('editorStatus', 'Saving…');
+  try {
+    if (state.current.__new) {
+      const res = await apiFetch('/api/admin/ai-hints', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      state.dirty = false;
+      await loadList();
+      await selectBot(res.model);
+      setStatus('editorStatus', 'Created', 'ok');
+    } else {
+      await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(state.current.model), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      state.dirty = false;
+      await loadList();
+      await selectBot(state.current.model);
+      setStatus('editorStatus', 'Saved', 'ok');
+    }
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+async function deleteCurrent() {
+  if (!state.current || state.current.__new) return;
+  if (!confirm('Soft-delete "' + state.current.display_name + '"? You can restore it from the list with "Show deleted".')) return;
+  try {
+    await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(state.current.model), { method: 'DELETE' });
+    setStatus('editorStatus', 'Deleted', 'ok');
+    state.current = null;
+    await loadList();
+    renderEditor();
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+async function restoreCurrent() {
+  if (!state.current || state.current.__new) return;
+  try {
+    await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(state.current.model) + '/restore', { method: 'POST' });
+    await loadList();
+    await selectBot(state.current.model);
+    setStatus('editorStatus', 'Restored', 'ok');
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+async function takeSnapshot() {
+  if (!state.current || state.current.__new) return;
+  try {
+    await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(state.current.model) + '/snapshot', { method: 'POST' });
+    setStatus('editorStatus', 'Snapshot saved', 'ok');
+    if (document.querySelector('.sub-tabs button.active').dataset.pane === 'history') {
+      loadHistory(state.current.model);
+    }
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+async function reloadIntoMemory() {
+  setStatus('editorStatus', 'Reloading…');
+  try {
+    const res = await apiFetch('/api/admin/ai-hints/reload', { method: 'POST' });
+    setStatus('editorStatus', 'Reloaded ' + res.loaded + ' bot(s) into memory', 'ok');
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+function exportCurrent() {
+  if (!state.current || state.current.__new) return;
+  const url = '/api/admin/ai-hints/' + encodeURIComponent(state.current.model) + '/export' +
+    (PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '');
+  window.open(url, '_blank');
+}
+
+function importJSON() {
+  document.getElementById('importFileInput').click();
+}
+
+async function onImportFile(evt) {
+  const file = evt.target.files && evt.target.files[0];
+  evt.target.value = '';
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const payload = JSON.parse(text);
+    const res = await apiFetch('/api/admin/ai-hints/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    setStatus('editorStatus', 'Imported ' + res.model, 'ok');
+    await loadList();
+    await selectBot(res.model);
+  } catch (e) {
+    setStatus('editorStatus', 'Import failed: ' + e.message, 'err');
+  }
+}
+
+// -------- History --------
+async function loadHistory(model) {
+  const el = document.getElementById('historyList');
+  el.innerHTML = '<div class="empty">Loading…</div>';
+  try {
+    const data = await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(model) + '/history');
+    const items = (data && data.data) || [];
+    if (!items.length) {
+      el.innerHTML = '<div class="empty">No history snapshots yet</div>';
+      return;
+    }
+    el.innerHTML = items.map(it => `
+      <div class="history-row">
+        <div>
+          <span class="change-kind ${escapeHTML(it.change_kind)}">${escapeHTML(it.change_kind)}</span>
+          <span style="margin-left:10px">${escapeHTML(new Date(it.changed_at).toLocaleString())}</span>
+        </div>
+        <button class="btn" onclick="restoreHistory('${model}', ${it.id})">Restore this version</button>
+      </div>
+    `).join('');
+  } catch (e) {
+    el.innerHTML = '<div class="empty" style="color:#f44336">' + escapeHTML(e.message) + '</div>';
+  }
+}
+
+async function restoreHistory(model, id) {
+  if (!confirm('Restore this version? The current state will be snapshotted first.')) return;
+  try {
+    await apiFetch('/api/admin/ai-hints/' + encodeURIComponent(model) + '/history/' + id + '/restore', { method: 'POST' });
+    await loadList();
+    await selectBot(model);
+    showPane('history');
+    setStatus('editorStatus', 'Restored from history', 'ok');
+  } catch (e) {
+    setStatus('editorStatus', e.message, 'err');
+  }
+}
+
+// -------- Utils --------
+function escapeHTML(s) {
+  return String(s === null || s === undefined ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Track that the user hand-edited the slug so we stop auto-deriving it.
+document.addEventListener('DOMContentLoaded', function() {
+  const slugInput = document.getElementById('modelSlug');
+  if (slugInput) slugInput.addEventListener('input', function() { slugInput.dataset.userEdited = '1'; });
+  ['displayName', 'systemPrompt'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('input', function() { state.dirty = true; });
+  });
+  buildAdminTabs();
+  loadList();
+});
+
+window.addEventListener('beforeunload', function(e) {
+  if (state.dirty) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+});
+</script>
+</body>
+</html>

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -360,7 +360,8 @@ function buildAdminTabs() {
     { label: 'MCP Analytics', href: '/admin/mcp', active: true },
     { label: 'Realtime', href: '/admin/realtime' },
     { label: 'Translations', href: '/admin/translations' },
-    { label: 'Tour Steps', href: '/admin/tour' }
+    { label: 'Tour Steps', href: '/admin/tour' },
+    { label: 'AI Hints', href: '/admin/ai-hints' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-realtime.html
+++ b/cmd/unified-server/public_html/admin-realtime.html
@@ -216,7 +216,8 @@ function buildAdminTabs() {
     { label: 'MCP Analytics', href: '/admin/mcp' },
     { label: 'Realtime', href: '/admin/realtime', active: true },
     { label: 'Translations', href: '/admin/translations' },
-    { label: 'Tour Steps', href: '/admin/tour' }
+    { label: 'Tour Steps', href: '/admin/tour' },
+    { label: 'AI Hints', href: '/admin/ai-hints' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-tour.html
+++ b/cmd/unified-server/public_html/admin-tour.html
@@ -263,7 +263,8 @@ function buildAdminTabs() {
     { label: 'MCP Analytics', href: '/admin/mcp' },
     { label: 'Realtime', href: '/admin/realtime' },
     { label: 'Translations', href: '/admin/translations' },
-    { label: 'Tour Steps', href: '/admin/tour', active: true }
+    { label: 'Tour Steps', href: '/admin/tour', active: true },
+    { label: 'AI Hints', href: '/admin/ai-hints' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-translations.html
+++ b/cmd/unified-server/public_html/admin-translations.html
@@ -229,7 +229,8 @@ function buildAdminTabs() {
     { label: 'MCP Analytics', href: '/admin/mcp' },
     { label: 'Realtime', href: '/admin/realtime' },
     { label: 'Translations', href: '/admin/translations', active: true },
-    { label: 'Tour Steps', href: '/admin/tour' }
+    { label: 'Tour Steps', href: '/admin/tour' },
+    { label: 'AI Hints', href: '/admin/ai-hints' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -378,7 +378,8 @@
         { label: 'MCP Analytics', href: '/admin/mcp' },
         { label: 'Realtime', href: '/admin/realtime' },
         { label: 'Translations', href: '/admin/translations' },
-        { label: 'Tour Steps', href: '/admin/tour' }
+        { label: 'Tour Steps', href: '/admin/tour' },
+        { label: 'AI Hints', href: '/admin/ai-hints' }
       ];
       const container = document.getElementById('adminTabs');
       tabs.forEach(t => {

--- a/migrations/add_ai_hints_tables.sql
+++ b/migrations/add_ai_hints_tables.sql
@@ -1,0 +1,29 @@
+-- Migration: Add ai_hints + ai_hints_history tables
+-- Run: psql -h 127.0.0.1 -U postgres -d safecast -f migrations/add_ai_hints_tables.sql
+
+CREATE TABLE IF NOT EXISTS ai_hints (
+  id                      BIGSERIAL PRIMARY KEY,
+  model                   VARCHAR(64) NOT NULL UNIQUE,
+  display_name            TEXT NOT NULL,
+  capabilities            JSONB NOT NULL DEFAULT '[]'::jsonb,
+  system_prompt           TEXT NOT NULL DEFAULT '',
+  tools                   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  global_formatting_rules JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at              TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_model       ON ai_hints(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_deleted_at  ON ai_hints(deleted_at);
+
+CREATE TABLE IF NOT EXISTS ai_hints_history (
+  id          BIGSERIAL PRIMARY KEY,
+  model       VARCHAR(64) NOT NULL,
+  snapshot    JSONB NOT NULL,
+  change_kind VARCHAR(32) NOT NULL,
+  changed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_model      ON ai_hints_history(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_changed_at ON ai_hints_history(changed_at DESC);

--- a/pkg/httpapi/page_routes.go
+++ b/pkg/httpapi/page_routes.go
@@ -27,6 +27,7 @@ type PageRoutesConfig struct {
 	AdminRealtimePageHandler     http.HandlerFunc
 	AdminTranslationsPageHandler http.HandlerFunc
 	AdminTourPageHandler         http.HandlerFunc
+	AdminAIHintsPageHandler      http.HandlerFunc
 }
 
 // RegisterPageRoutes attaches UI/admin page routes to mux.
@@ -86,4 +87,5 @@ func RegisterPageRoutes(mux *http.ServeMux, cfg PageRoutesConfig) {
 	registerOptionalAdmin("/admin/realtime", cfg.AdminRealtimePageHandler)
 	registerOptionalAdmin("/admin/translations", cfg.AdminTranslationsPageHandler)
 	registerOptionalAdmin("/admin/tour", cfg.AdminTourPageHandler)
+	registerOptionalAdmin("/admin/ai-hints", cfg.AdminAIHintsPageHandler)
 }

--- a/pkg/httpapi/public_routes.go
+++ b/pkg/httpapi/public_routes.go
@@ -46,6 +46,13 @@ const (
 	RouteAPIAdminTourStepsByID        = "/api/admin/tour/steps/"
 	RouteAPIAdminTourSteps            = "/api/admin/tour/steps"
 
+	// AI Hints admin routes. Reload/import are static, then by-id, then the
+	// list root — order matters because ServeMux longest-prefix matches.
+	RouteAPIAdminAIHintsReload = "/api/admin/ai-hints/reload"
+	RouteAPIAdminAIHintsImport = "/api/admin/ai-hints/import"
+	RouteAPIAdminAIHintsByID   = "/api/admin/ai-hints/"
+	RouteAPIAdminAIHints       = "/api/admin/ai-hints"
+
 	RouteAPISensors              = "/api/sensors"
 	RouteAPISensorsExport        = "/api/sensors/export"
 	RouteAPISensorByID           = "/api/sensor/"

--- a/pkg/httpapi/register.go
+++ b/pkg/httpapi/register.go
@@ -62,6 +62,10 @@ type RegisterConfig struct {
 	AdminTourStepsReorderHandler     http.HandlerFunc
 	AdminTourStepsByIDHandler        http.HandlerFunc
 	AdminTourStepsHandler            http.HandlerFunc
+	AdminAIHintsReloadHandler        http.HandlerFunc
+	AdminAIHintsImportHandler        http.HandlerFunc
+	AdminAIHintsByIDHandler          http.HandlerFunc
+	AdminAIHintsHandler              http.HandlerFunc
 
 	Logf func(string, ...any)
 }
@@ -188,6 +192,13 @@ func registerAuthAndAdminRoutes(mux *http.ServeMux, cfg RegisterConfig) {
 	registerOptionalAdmin(RouteAPIAdminTourStepsReorder, cfg.AdminTourStepsReorderHandler)
 	registerOptionalAdmin(RouteAPIAdminTourStepsByID, cfg.AdminTourStepsByIDHandler)
 	registerOptionalAdmin(RouteAPIAdminTourSteps, cfg.AdminTourStepsHandler)
+
+	// AI Hints admin endpoints: reload and import are static, then per-model
+	// by-id subtree, then the list root. Order follows ServeMux rules.
+	registerOptionalAdmin(RouteAPIAdminAIHintsReload, cfg.AdminAIHintsReloadHandler)
+	registerOptionalAdmin(RouteAPIAdminAIHintsImport, cfg.AdminAIHintsImportHandler)
+	registerOptionalAdmin(RouteAPIAdminAIHintsByID, cfg.AdminAIHintsByIDHandler)
+	registerOptionalAdmin(RouteAPIAdminAIHints, cfg.AdminAIHintsHandler)
 
 	registerOptionalPublic := func(path string, handler http.HandlerFunc) {
 		if handler == nil {


### PR DESCRIPTION
## Summary

- New **/admin/ai-hints** page for editing the per-model MCP hints (Claude, Kimi, Qwen, GPT, etc.) that were previously only editable by hand-editing on-disk JSON files.
- DB becomes the runtime source of truth: on startup the server seeds missing rows from the embedded `hints/*.json` templates (`ON CONFLICT DO NOTHING`), then hot-loads non-deleted rows into the `HintsLoader`. Admin edits survive restarts and never get clobbered by the templates.
- Structured editor UI (no raw JSON textareas) with sub-tabs for General / Global rules / Tools / History. Actions: Save, Reload into Memory, Snapshot, Export JSON, Import JSON, soft-Delete / Restore. Auth matches Translations (admin session OR `?password=`).
- `hints/*.json` now embedded via `//go:embed` so the file loader works from `/usr/local/bin/` in production (where there is no neighbouring `hints/` dir). `MCP_HINTS_DIR` still overrides with an on-disk path for devs who want to edit JSON without rebuilds.

## Schema

New tables (see [migrations/add_ai_hints_tables.sql](migrations/add_ai_hints_tables.sql)):

- `ai_hints` — one row per bot slug. JSONB columns for `capabilities`, `tools`, `global_formatting_rules`. `deleted_at` for soft delete.
- `ai_hints_history` — one row per change (`create` / `update` / `delete` / `restore` / `import`) with the pre-change snapshot stored as JSONB.

Run on production **before** the deploy (service restart is fine either way — startup is idempotent):

```bash
psql -h 127.0.0.1 -U postgres -d safecast -f migrations/add_ai_hints_tables.sql
```

## Test plan

- [x] `go build -tags duckdb ./cmd/unified-server/` — clean
- [x] `go test -tags duckdb ./cmd/unified-server/ ./cmd/unified-server/model-adapter/ ./pkg/httpapi/` — all pass
- [x] Local: `strings safecast-new-map | grep "Claude 3.5 Sonnet"` — JSON templates embedded
- [ ] Production: run migration, redeploy, visit `/admin/ai-hints?password=...` — expect 5 seeded bots (claude, gpt, kimi, qwen, unknown)
- [ ] Edit a bot, click **Save**, click **Reload into Memory**, verify MCP picks up the change via `curl https://simplemap.safecast.org/mcp-http ...`
- [ ] Delete + Restore from history tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)