### PR TITLE
fix(mcp): tighten SELECT-only guard on query_duckdb_logs

### DIFF
--- a/cmd/unified-server/tool_duckdb_logs.go
+++ b/cmd/unified-server/tool_duckdb_logs.go
@@ -16,9 +16,40 @@ var queryDuckDBLogsToolDef = mcp.NewTool(
 	mcp.WithString(
 		"query",
 		mcp.Required(),
-		mcp.Description("SQL SELECT query to execute against mcp_ai_query_log"),
+		mcp.Description("SQL SELECT (or WITH ... SELECT) query to execute against mcp_ai_query_log. Must be a single statement; semicolons other than a trailing terminator are rejected."),
 	),
+	mcp.WithReadOnlyHintAnnotation(true),
 )
+
+// validateReadOnlyQuery enforces that a user-supplied DuckDB query is a single
+// read-only statement. Returns the cleaned query (trailing semicolons stripped)
+// and an error message suitable for returning to the MCP client. On success the
+// error string is empty.
+//
+// The previous implementation only checked HasPrefix("SELECT"), which is
+// trivially bypassed by "SELECT 1; DELETE FROM foo;" — DuckDB's Go driver can
+// execute multi-statement payloads through Query(). This guard also accepts
+// leading WITH (CTEs), since they're a common read-only shape.
+func validateReadOnlyQuery(q string) (string, string) {
+	cleaned := strings.TrimSpace(q)
+	// Allow one or more trailing semicolons (common from copy/paste) then
+	// re-trim whitespace that may have sat between them.
+	cleaned = strings.TrimRight(cleaned, "; \t\r\n")
+	if cleaned == "" {
+		return "", "Empty query"
+	}
+	upper := strings.ToUpper(cleaned)
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
+		return "", "Only SELECT or WITH … SELECT queries are allowed"
+	}
+	// After stripping the trailing terminator, no further semicolons are
+	// permitted. This rejects stacked statements like "SELECT 1; DROP TABLE x"
+	// as well as semicolons hidden in block comments.
+	if strings.Contains(cleaned, ";") {
+		return "", "Multi-statement queries are not allowed; remove inner ';' characters"
+	}
+	return cleaned, ""
+}
 
 func handleQueryDuckDBLogs(
 	ctx context.Context,
@@ -38,12 +69,12 @@ func handleQueryDuckDBLogs(
 		return mcp.NewToolResultText("Missing or invalid 'query' argument"), nil
 	}
 
-	query := strings.TrimSpace(q)
-	if !strings.HasPrefix(strings.ToUpper(query), "SELECT") {
-		return mcp.NewToolResultText("Only SELECT queries are allowed"), nil
+	query, vErr := validateReadOnlyQuery(q)
+	if vErr != "" {
+		return mcp.NewToolResultText(vErr), nil
 	}
 
-	rows, err := duckDB.Query(query)
+	rows, err := duckDB.QueryContext(ctx, query)
 	if err != nil {
 		return mcp.NewToolResultText(fmt.Sprintf("Query error: %v", err)), nil
 	}

--- a/cmd/unified-server/tool_duckdb_logs_test.go
+++ b/cmd/unified-server/tool_duckdb_logs_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestValidateReadOnlyQuery(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantErr     bool
+		wantCleaned string
+	}{
+		{"plain select", "SELECT 1", false, "SELECT 1"},
+		{"lowercase select", "select 1", false, "select 1"},
+		{"trailing semicolon", "SELECT 1;", false, "SELECT 1"},
+		{"multiple trailing semicolons and whitespace", "SELECT 1 ;; \n", false, "SELECT 1"},
+		{"leading/trailing whitespace", "  SELECT now()  ", false, "SELECT now()"},
+		{"with cte", "WITH t AS (SELECT 1) SELECT * FROM t", false, "WITH t AS (SELECT 1) SELECT * FROM t"},
+		{"lowercase with cte", "with t as (select 1) select * from t;", false, "with t as (select 1) select * from t"},
+
+		{"empty", "", true, ""},
+		{"only semicolons", ";;;", true, ""},
+		{"only whitespace", "   \n\t", true, ""},
+		{"non-select verb", "DELETE FROM mcp_query_log", true, ""},
+		{"drop table", "DROP TABLE foo", true, ""},
+		{"update", "UPDATE foo SET x=1", true, ""},
+		{"insert", "INSERT INTO foo VALUES (1)", true, ""},
+
+		{"stacked select then delete", "SELECT 1; DELETE FROM foo", true, ""},
+		{"stacked with stray whitespace", "SELECT 1 ; DELETE FROM foo ;", true, ""},
+		{"inner semicolon in comment", "SELECT 1 /* ; */", true, ""},
+		{"inner semicolon in string literal", "SELECT ';'", true, ""}, // false-positive reject is safer than allowing stacked DDL
+
+		{"attach statement", "ATTACH 'evil.db' AS x", true, ""},
+		{"pragma", "PRAGMA disable_verification", true, ""},
+		{"copy", "COPY foo FROM 'file'", true, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleaned, errMsg := validateReadOnlyQuery(tc.in)
+			if tc.wantErr {
+				if errMsg == "" {
+					t.Fatalf("expected error for %q, got cleaned=%q", tc.in, cleaned)
+				}
+				return
+			}
+			if errMsg != "" {
+				t.Fatalf("unexpected error for %q: %s", tc.in, errMsg)
+			}
+			if cleaned != tc.wantCleaned {
+				t.Fatalf("cleaned mismatch for %q: got %q want %q", tc.in, cleaned, tc.wantCleaned)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The previous check in [`tool_duckdb_logs.go`](cmd/unified-server/tool_duckdb_logs.go) was `HasPrefix(strings.ToUpper(q), "SELECT")`, which is trivially bypassed by stacked statements like `SELECT 1; DELETE FROM mcp_query_log`. DuckDB's Go driver can execute multi-statement payloads via `Query()`, so that gave the AI chatbot a potential write path even though the tool is meant to be strictly read-only.

## Fix

New `validateReadOnlyQuery()` helper:
- strips one or more trailing semicolons + whitespace
- requires the cleaned query to start with `SELECT` or `WITH` (allowing CTEs)
- rejects any remaining semicolons after the trim (catches stacked statements and `;`-in-comment tricks)

Queries that legitimately contain `;` inside a string literal would need to be rephrased — an acceptable trade-off for analytics-log queries.

Also:
- swap `Query()` → `QueryContext()` so cancellations propagate
- add `WithReadOnlyHintAnnotation(true)` so MCP clients see the tool as read-only
- 21-case unit test covering the accept/reject matrix

## Test plan

- [x] `go test -run TestValidateReadOnlyQuery ./cmd/unified-server/` — 21/21 pass
- [x] Full test sweep — `unified-server`, `model-adapter`, `httpapi` all green
- [x] Build clean with `-tags duckdb`
- [ ] Production smoke: `curl` `query_duckdb_logs` with a legit `SELECT` (expect results) and a stacked `SELECT 1; DROP TABLE x;` (expect reject)

## Related

Follow-up from [#121](https://github.com/Safecast/safecast-new-map/pull/121) audit. Remaining items to consider in a future PR:
- `query_extreme_readings` builds SQL with `fmt.Sprintf` + quote escaping — parameterize with `?` placeholders.
- `query_analytics`, `radiation_stats`, `query_extreme_readings` missing `WithReadOnlyHintAnnotation(true)` (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)