### PR TITLE
fix(mcp): parameterize query_extreme_readings SQL + annotate remaining read-only tools

### DIFF
--- a/cmd/unified-server/tool_analytics.go
+++ b/cmd/unified-server/tool_analytics.go
@@ -11,6 +11,7 @@ import (
 
 var queryAnalyticsToolDef = mcp.NewTool("query_analytics",
 	mcp.WithDescription("Get usage statistics for MCP tools (call counts, duration). Powered by DuckDB local logs."),
+	mcp.WithReadOnlyHintAnnotation(true),
 )
 
 var radiationStatsToolDef = mcp.NewTool("radiation_stats",
@@ -20,6 +21,7 @@ var radiationStatsToolDef = mcp.NewTool("radiation_stats",
 		mcp.Enum("year", "month", "overall"),
 		mcp.DefaultString("year"),
 	),
+	mcp.WithReadOnlyHintAnnotation(true),
 )
 
 // Handlers

--- a/cmd/unified-server/tool_extreme_readings.go
+++ b/cmd/unified-server/tool_extreme_readings.go
@@ -39,6 +39,7 @@ var queryExtremeReadingsToolDef = mcp.NewTool("query_extreme_readings",
 	mcp.WithString("exclude_areas",
 		mcp.Description("JSON array of geographic bounding boxes to exclude. Format: [{\"min_lat\":51.8,\"max_lat\":52.0,\"min_lon\":-8.6,\"max_lon\":-8.3}] to exclude Cork, Ireland. Can specify multiple areas to exclude."),
 	),
+	mcp.WithReadOnlyHintAnnotation(true),
 )
 
 // Handler
@@ -87,35 +88,33 @@ func handleQueryExtremeReadings(ctx context.Context, req mcp.CallToolRequest) (*
 		}
 	}
 
-	// Build WHERE clause with exclusions
-	var whereConditions []string
-	whereConditions = append(whereConditions, "doserate > 0 AND doserate < 10000")
+	// Build WHERE clause with parameterized values. User-supplied strings
+	// (device IDs) and floats (bounds) go through ? placeholders so DuckDB's
+	// driver handles escaping. Only `orderDir` and `limit` are interpolated,
+	// and both are validated earlier: orderDir is derived from the "direction"
+	// enum, limit is clamped to 1..100.
+	whereConditions := []string{"doserate > 0 AND doserate < 10000"}
+	var args []any
 
-	// Add geographic filter
 	if hasGeoFilter {
-		whereConditions = append(whereConditions, fmt.Sprintf(
-			"lat BETWEEN %.6f AND %.6f AND lon BETWEEN %.6f AND %.6f",
-			minLat, maxLat, minLon, maxLon,
-		))
+		whereConditions = append(whereConditions, "lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?")
+		args = append(args, minLat, maxLat, minLon, maxLon)
 	}
 
-	// Add device exclusions
 	if len(excludeDevices) > 0 {
-		deviceList := make([]string, len(excludeDevices))
+		placeholders := make([]string, len(excludeDevices))
 		for i, dev := range excludeDevices {
-			deviceList[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(dev, "'", "''"))
+			placeholders[i] = "?"
+			args = append(args, dev)
 		}
 		whereConditions = append(whereConditions, fmt.Sprintf(
-			"device_id NOT IN (%s)", strings.Join(deviceList, ", "),
+			"device_id NOT IN (%s)", strings.Join(placeholders, ", "),
 		))
 	}
 
-	// Add area exclusions
 	for _, area := range excludeAreas {
-		whereConditions = append(whereConditions, fmt.Sprintf(
-			"NOT (lat BETWEEN %.6f AND %.6f AND lon BETWEEN %.6f AND %.6f)",
-			area.MinLat, area.MaxLat, area.MinLon, area.MaxLon,
-		))
+		whereConditions = append(whereConditions, "NOT (lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?)")
+		args = append(args, area.MinLat, area.MaxLat, area.MinLon, area.MaxLon)
 	}
 
 	query := fmt.Sprintf(`
@@ -135,7 +134,7 @@ func handleQueryExtremeReadings(ctx context.Context, req mcp.CallToolRequest) (*
 	`, strings.Join(whereConditions, " AND "), orderDir, limit)
 
 	// Execute query
-	rows, err := duckDB.Query(query)
+	rows, err := duckDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Query failed: %v", err)), nil
 	}


### PR DESCRIPTION
## Summary

Follow-up to [#122](https://github.com/Safecast/safecast-new-map/pull/122), closing out the two remaining items from the audit in [#121](https://github.com/Safecast/safecast-new-map/pull/121).

### 1. Parameterize `query_extreme_readings`

[`handleQueryExtremeReadings`](cmd/unified-server/tool_extreme_readings.go) built its WHERE clause with `fmt.Sprintf` and a naive `'` → `''` escape for user-supplied `device_id` values. Switched to `?` placeholders:

- Device IDs → `device_id NOT IN (?, ?, ?)` with one placeholder per element.
- Geographic bounds → `lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?` (floats were already injection-safe via `%.6f` but placeholders are cleaner).
- `orderDir` and `limit` stay interpolated because `?` isn't allowed in those positions; both are validated earlier (`orderDir` from an enum, `limit` clamped to 1..100).
- Swapped `Query()` → `QueryContext()` for cancellation propagation.

### 2. Annotate the 3 tools that were missing `WithReadOnlyHintAnnotation(true)`

`query_analytics`, `radiation_stats`, `query_extreme_readings` were read-only in behavior but didn't advertise it to MCP clients. All 19 tools now carry the annotation.

## Test plan

- [x] `go build -tags duckdb ./cmd/unified-server/` — clean
- [x] `go test -tags duckdb ./cmd/unified-server/ ./cmd/unified-server/model-adapter/ ./pkg/httpapi/` — all pass
- [ ] Production smoke: `query_extreme_readings` with `exclude_devices: ["bGeigie-1", "bGeigie-2"]` + a geo filter returns sensible results (no syntax error from the `?` rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)