### PR TITLE
perf(markers): batch SSE flushes + serve /js/ from embed.FS

### DIFF
--- a/cmd/unified-server/handlers_tracks.go
+++ b/cmd/unified-server/handlers_tracks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/vmihailenco/msgpack/v5"
 	"safecast-new-map/pkg/database"
@@ -668,18 +670,44 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 	}
 	w.Header().Set("Cache-Control", "no-cache")
+	// Disable nginx response buffering so chunks reach the client as they're flushed.
+	w.Header().Set("X-Accel-Buffering", "no")
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
 		return
 	}
 
+	// Coalesce small per-marker writes into ~64KB chunks before they hit the
+	// chunked HTTP encoder. Without this, each marker becomes its own chunk +
+	// flush, which serializes ~70k tiny writes for a single viewport.
+	bw := bufio.NewWriterSize(w, 64*1024)
+
+	// Batch network flushes: flush when the buffered writer fills naturally,
+	// or every flushEveryMarkers, or every flushEveryDur — whichever comes first.
+	const flushEveryMarkers = 256
+	const flushEveryDur = 50 * time.Millisecond
+	pending := 0
+	lastFlush := time.Now()
+	flush := func() {
+		_ = bw.Flush()
+		flusher.Flush()
+		pending = 0
+		lastFlush = time.Now()
+	}
+	maybeFlush := func() {
+		pending++
+		if pending >= flushEveryMarkers || time.Since(lastFlush) >= flushEveryDur {
+			flush()
+		}
+	}
+
 	// Helper to write a msgpack frame: 4-byte length prefix + data
 	writeMsgpackFrame := func(data []byte) {
 		lenBuf := make([]byte, 4)
 		binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
-		w.Write(lenBuf)
-		w.Write(data)
+		bw.Write(lenBuf)
+		bw.Write(data)
 	}
 
 	// Emit realtime markers first when enabled.
@@ -689,10 +717,10 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 			writeMsgpackFrame(b)
 		} else {
 			b, _ := json.Marshal(m)
-			fmt.Fprintf(w, "data: %s\n\n", b)
+			fmt.Fprintf(bw, "data: %s\n\n", b)
 		}
 	}
-	flusher.Flush()
+	flush()
 
 	for {
 		select {
@@ -706,11 +734,11 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				if useMsgpack {
 					// Send zero-length frame as error indicator
-					w.Write([]byte{0, 0, 0, 0})
+					bw.Write([]byte{0, 0, 0, 0})
 				} else {
-					fmt.Fprintf(w, "event: done\ndata: %v\n\n", err)
+					fmt.Fprintf(bw, "event: done\ndata: %v\n\n", err)
 				}
-				flusher.Flush()
+				flush()
 				return
 			}
 			errCh = nil
@@ -718,11 +746,11 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				if useMsgpack {
 					// Send zero-length frame as end marker
-					w.Write([]byte{0, 0, 0, 0})
+					bw.Write([]byte{0, 0, 0, 0})
 				} else {
-					fmt.Fprint(w, "event: done\ndata: end\n\n")
+					fmt.Fprint(bw, "event: done\ndata: end\n\n")
 				}
-				flusher.Flush()
+				flush()
 				return
 			}
 			if useMsgpack {
@@ -730,9 +758,9 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 				writeMsgpackFrame(b)
 			} else {
 				b, _ := json.Marshal(m)
-				fmt.Fprintf(w, "data: %s\n\n", b)
+				fmt.Fprintf(bw, "data: %s\n\n", b)
 			}
-			flusher.Flush()
+			maybeFlush()
 		}
 	}
 }

--- a/pkg/httpapi/static_routes.go
+++ b/pkg/httpapi/static_routes.go
@@ -12,16 +12,18 @@ type StaticRoutesConfig struct {
 }
 
 // RegisterStaticRoutes attaches static asset routes to mux.
-// /static serves files from embedded assets and /js serves files from a
-// filesystem directory for runtime JS worker compatibility.
+// Both /static/ and /js/ serve from the embedded StaticFS so they work
+// regardless of the process working directory in production.
 func RegisterStaticRoutes(mux *http.ServeMux, cfg StaticRoutesConfig) {
 	if mux == nil {
 		return
 	}
 	if cfg.StaticFS != nil {
-		mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(cfg.StaticFS))))
-	}
-	if cfg.JSDir != "" {
+		fileServer := http.FileServer(http.FS(cfg.StaticFS))
+		mux.Handle("/static/", http.StripPrefix("/static/", fileServer))
+		// /js/foo.js → js/foo.js inside StaticFS (i.e. public_html/js/foo.js).
+		mux.Handle("/js/", fileServer)
+	} else if cfg.JSDir != "" {
 		mux.Handle("/js/", http.StripPrefix("/js/", http.FileServer(http.Dir(cfg.JSDir))))
 	}
 }


### PR DESCRIPTION
## Summary
- `streamMarkersHandler` flushed once per marker (~70k flushes per viewport request). Wrap the response in a 64KB `bufio.Writer` and flush every 256 markers or 50ms. Also send `X-Accel-Buffering: no` so nginx stops buffering the SSE stream.
- `/js/` was served via `http.Dir("public_html/")` — a relative path resolved against runtime cwd. In production the binary lives in `/usr/local/bin`, no `public_html/` next to it, so `/js/marker-worker.js` 404'd and marker JSON parsing fell back to the main thread. Serve `/js/` from the embedded `StaticFS` instead.

## Why
WebPagetest comparison (simplemap.safecast.org vs pelora.org, same viewport): simplemap took ~29s for `/stream_markers` vs pelora's ~7.5s for a similar payload, plus a reproducible `404 /js/marker-worker.js`. Both come from this code path.

## Test plan
- [x] `go build -tags duckdb -o safecast-new-map ./cmd/unified-server/`
- [x] `go vet -tags duckdb ./cmd/unified-server/ ./pkg/httpapi/`
- [x] `go test -tags duckdb ./pkg/httpapi/ -run TestRegisterStaticRoutes`
- [ ] Re-run WebPagetest after deploy and confirm `stream_markers` wall-clock drops and `/js/marker-worker.js` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)