### PR TITLE
feat(map): add detailed-dashboard link to realtime sensor modal

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -1701,6 +1701,31 @@ body, html {
           color: var(--modal-text);
         }
 
+        .live-modal-actions {
+          display: flex;
+          gap: 8px;
+          align-self: flex-end;
+          align-items: center;
+          margin-top: 8px;
+        }
+
+        .live-modal-radnote-btn {
+          padding: 6px 14px;
+          background: #2a7de1;
+          border: 1px solid #2a7de1;
+          border-radius: 6px;
+          color: #ffffff;
+          font-family: inherit;
+          font-size: var(--font-size-sm);
+          text-decoration: none;
+          cursor: pointer;
+          transition: background 0.15s ease;
+        }
+        .live-modal-radnote-btn:hover {
+          background: #1a5fb4;
+          border-color: #1a5fb4;
+        }
+
         /* --- Tutorial overlay --- */
         #tutorial-overlay {
           position: fixed;
@@ -2270,7 +2295,10 @@ body, html {
         <p id="liveChartEmpty" class="live-chart-empty"></p>
       </div>
     </div>
-    <button type="button" class="live-modal-close" id="liveModalClose"></button>
+    <div class="live-modal-actions">
+      <a id="liveModalRadnoteBtn" class="live-modal-radnote-btn" href="#" target="_blank" rel="noopener noreferrer" style="display:none;"></a>
+      <button type="button" class="live-modal-close" id="liveModalClose"></button>
+    </div>
   </div>
 </div>
 
@@ -7179,6 +7207,20 @@ async function openLiveModal(deviceID, fallback) {
 
   const closeBtn = document.getElementById('liveModalClose');
   if (closeBtn) closeBtn.textContent = translate('live_chart_close');
+
+  const radnoteBtn = document.getElementById('liveModalRadnoteBtn');
+  if (radnoteBtn) {
+    if (deviceID) {
+      const radnoteDevice = deviceID.startsWith('note:dev:')
+        ? deviceID.slice('note:'.length)
+        : 'dev:' + deviceID;
+      radnoteBtn.href = 'https://dashboard.radnote.org/d/cdq671mxg2cjka/radnote-overview?orgId=1&var-device=' + encodeURIComponent(radnoteDevice) + '&kiosk';
+      radnoteBtn.textContent = translate('live_marker_radnote_link');
+      radnoteBtn.style.display = '';
+    } else {
+      radnoteBtn.style.display = 'none';
+    }
+  }
 
   const fallbackMarker = {
     deviceID: fallback && fallback.device ? String(fallback.device) : (fallback && fallback.id ? String(fallback.id) : ''),

--- a/cmd/unified-server/public_html/translations.json
+++ b/cmd/unified-server/public_html/translations.json
@@ -1488,6 +1488,7 @@
     "live_chart_day": "Last 24 hours",
     "live_chart_month": "Last 30 days",
     "live_marker_chart_link": "Open radiation charts",
+    "live_marker_radnote_link": "View on detailed dashboard",
     "live_marker_country": "Country hint",
     "live_marker_desc_generic": "This Safecast sensor",
     "live_marker_desc_location": "reports from [[place]]",


### PR DESCRIPTION
## Summary
- Adds a colored "View on detailed dashboard" button next to Close in the realtime sensor chart modal.
- Opens `dashboard.radnote.org` in a new tab, pre-filtered to the device via `var-device=dev:<id>`.
- Notehub IDs (`note:dev:...`) are normalized to `dev:...` so the dashboard's URL parameter resolves correctly.

## Test plan
- [x] Click a `geigiecast-zen` realtime marker → modal shows blue button → opens dashboard with `var-device=dev:geigiecast-zen:<id>`
- [x] Click a `note:dev:...` realtime marker → opens dashboard with `var-device=dev:<numeric-id>` (no double `note:dev:` prefix)
- [x] Local server build with `-tags duckdb` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)