### PR TITLE
feat(admin): Q&A semantic-cache curation tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,41 @@ Access the admin panel at `/admin/users?password=your-secure-password` or log in
 | MCP Analytics | `/admin/mcp` | Monitor MCP tool usage and AI query logs |
 | Realtime | `/admin/realtime` | Manage real-time sensor device data |
 | Translations | `/admin/translations` | Edit, add, and delete UI translations for all 29 languages |
+| Q&A Cache | `/admin/qa-embeddings` | Browse, curate, promote/demote, or archive entries in the semantic chat cache |
+
+### Q&A Cache Curation
+
+The web-chat assistant uses a semantic cache so paraphrased repeat questions
+return without re-calling the LLM. Each answered chat is embedded (pure-Go
+feature hashing) and stored in DuckLake `qa_embeddings`. A new question is
+served from cache when its cosine similarity to a stored entry exceeds 0.85,
+the entry has `feedback_score > 0`, status is `active`, and language matches.
+
+**Admin tab** (`/admin/qa-embeddings`):
+- Searchable on question/answer text, sortable on every column
+- Filter by status (`active` / `demoted` / `archived`), language, and feedback-score sign
+- View full Q&A in a modal (the raw embedding vector is never sent to the browser)
+- Per-row actions:
+  - **Promote** — `feedback_score += 1`, force `status='active'`
+  - **Demote** — `feedback_score -= 1`, `status='demoted'` (hidden from cache, kept for audit)
+  - **Archive** — `status='archived'` (kept for audit only)
+  - **Restore** — bring `archived` / `demoted` rows back to `active`
+
+**Schema** (`qa_embeddings`, DuckLake catalog):
+- Base columns: `id`, `chat_id`, `question`, `answer`, `embedding`, `feedback_score`, `created_at`
+- Curation columns (added by `migrations/add_qa_embeddings_columns.sql`):
+  - `used_count INTEGER` — bumped on every cache hit
+  - `last_used_at TIMESTAMPTZ` — most recent cache hit
+  - `status VARCHAR` — `active` | `demoted` | `archived`
+  - `lang VARCHAR` — IETF language tag; lookups never cross languages
+
+The migration is applied automatically by `cmd/unified-server/duckdb_analytics.go`
+at startup via idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS` statements;
+the standalone SQL file is the authoritative record for ops.
+
+The cache only runs when the unified server is built with `-tags duckdb`. Without
+it, the table is never created and the admin tab returns "Analytics database not
+available."
 
 ### Translation Management
 

--- a/cmd/unified-server/admin_qa_embeddings.go
+++ b/cmd/unified-server/admin_qa_embeddings.go
@@ -1,0 +1,279 @@
+// Admin handlers for the /admin/qa-embeddings tab.
+//
+// Routes (wired in main.go):
+//   GET  /api/admin/qa-embeddings                  → searchable/sortable list
+//   GET  /api/admin/qa-embeddings/{id}             → full row including answer
+//   POST /api/admin/qa-embeddings/{id}/promote     → feedback_score += 1, status='active'
+//   POST /api/admin/qa-embeddings/{id}/demote      → feedback_score -= 1, status='demoted'
+//   POST /api/admin/qa-embeddings/{id}/archive     → status='archived' (audit-only)
+//   POST /api/admin/qa-embeddings/{id}/restore     → status='active'
+//
+// The cache lives in DuckLake (in-process DuckDB attached to the catalog), so
+// we query the package-global duckDB handle, not the PostgreSQL `db` handle
+// used by other admin pages.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// qaEmbeddingsColumns whitelists columns that may appear in ?sort=.
+// `embedding` is intentionally excluded — it's neither sortable nor sent to
+// the client (large, opaque to humans).
+var qaEmbeddingsColumns = []string{
+	"id", "chat_id", "question", "feedback_score",
+	"used_count", "last_used_at", "status", "lang", "created_at",
+}
+
+// adminQAEmbeddingsListHandler serves the searchable/sortable JSON listing.
+// GET /api/admin/qa-embeddings?search=&status=&lang=&score=&sort=&order=&limit=&offset=
+func adminQAEmbeddingsListHandler(w http.ResponseWriter, r *http.Request) {
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics database not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	sortCol := r.URL.Query().Get("sort")
+	if !isValidColumn(sortCol, qaEmbeddingsColumns) {
+		sortCol = "created_at"
+	}
+	order := strings.ToUpper(r.URL.Query().Get("order"))
+	if order != "ASC" {
+		order = "DESC"
+	}
+
+	search := r.URL.Query().Get("search")
+	statusFilter := r.URL.Query().Get("status")
+	langFilter := r.URL.Query().Get("lang")
+	// score filter: "pos" (>0), "neg" (<0), "zero" (=0); empty = all
+	scoreFilter := r.URL.Query().Get("score")
+
+	// DuckDB's Go driver uses `?` placeholders here (matches the pattern used
+	// elsewhere in semantic_cache.go).
+	var conditions []string
+	var args []interface{}
+
+	if search != "" {
+		conditions = append(conditions, "(question ILIKE ? OR answer ILIKE ?)")
+		args = append(args, "%"+search+"%", "%"+search+"%")
+	}
+	if statusFilter != "" {
+		conditions = append(conditions, "COALESCE(status, 'active') = ?")
+		args = append(args, statusFilter)
+	}
+	if langFilter != "" {
+		conditions = append(conditions, "COALESCE(lang, '') = ?")
+		args = append(args, langFilter)
+	}
+	switch scoreFilter {
+	case "pos":
+		conditions = append(conditions, "COALESCE(feedback_score, 0) > 0")
+	case "neg":
+		conditions = append(conditions, "COALESCE(feedback_score, 0) < 0")
+	case "zero":
+		conditions = append(conditions, "COALESCE(feedback_score, 0) = 0")
+	}
+
+	whereSQL := ""
+	if len(conditions) > 0 {
+		whereSQL = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	var total int
+	if err := duckDB.QueryRow(
+		fmt.Sprintf("SELECT COUNT(*) FROM qa_embeddings %s", whereSQL),
+		args...,
+	).Scan(&total); err != nil {
+		log.Printf("admin qa-embeddings count error: %v", err)
+		writeQAJSONError(w, err)
+		return
+	}
+
+	dataSQL := fmt.Sprintf(`
+		SELECT id, chat_id, question, feedback_score,
+		       COALESCE(used_count, 0)    AS used_count,
+		       last_used_at,
+		       COALESCE(status, 'active') AS status,
+		       COALESCE(lang, '')         AS lang,
+		       created_at,
+		       LENGTH(answer)             AS answer_len
+		FROM qa_embeddings %s
+		ORDER BY %s %s NULLS LAST
+		LIMIT %d OFFSET %d`,
+		whereSQL, sortCol, order, limit, offset,
+	)
+
+	rows, err := duckDB.Query(dataSQL, args...)
+	if err != nil {
+		log.Printf("admin qa-embeddings query error: %v", err)
+		writeQAJSONError(w, err)
+		return
+	}
+	defer rows.Close()
+
+	results := []map[string]interface{}{}
+	for rows.Next() {
+		var (
+			id, chatID               int64
+			question, status, lang   string
+			feedbackScore, usedCount int
+			lastUsedAt, createdAt    interface{}
+			answerLen                int
+		)
+		if err := rows.Scan(&id, &chatID, &question, &feedbackScore, &usedCount, &lastUsedAt, &status, &lang, &createdAt, &answerLen); err != nil {
+			log.Printf("admin qa-embeddings scan error: %v", err)
+			continue
+		}
+		results = append(results, map[string]interface{}{
+			"id":             id,
+			"chat_id":        chatID,
+			"question":       question,
+			"feedback_score": feedbackScore,
+			"used_count":     usedCount,
+			"last_used_at":   lastUsedAt,
+			"status":         status,
+			"lang":           lang,
+			"created_at":     createdAt,
+			"answer_len":     answerLen,
+		})
+	}
+
+	languages := distinctQAStrings("SELECT DISTINCT COALESCE(lang, '') FROM qa_embeddings ORDER BY 1")
+	statuses := distinctQAStrings("SELECT DISTINCT COALESCE(status, 'active') FROM qa_embeddings ORDER BY 1")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":      results,
+		"total":     total,
+		"languages": languages,
+		"statuses":  statuses,
+	})
+}
+
+// distinctQAStrings returns one column of distinct strings; empty slice on error.
+func distinctQAStrings(sqlStr string) []string {
+	rows, err := duckDB.Query(sqlStr)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if rows.Scan(&s) == nil {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// adminQAEmbeddingsDetailHandler returns the full row (including the answer
+// text) for the modal in the admin tab.
+// GET /api/admin/qa-embeddings/{id}
+func adminQAEmbeddingsDetailHandler(w http.ResponseWriter, r *http.Request, id int64) {
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics database not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	row := duckDB.QueryRow(`
+		SELECT id, chat_id, question, answer, feedback_score,
+		       COALESCE(used_count, 0), last_used_at,
+		       COALESCE(status, 'active'), COALESCE(lang, ''), created_at
+		FROM qa_embeddings WHERE id = ?`, id)
+
+	var (
+		dbID, chatID             int64
+		question, answer         string
+		status, lang             string
+		feedbackScore, usedCount int
+		lastUsedAt, createdAt    interface{}
+	)
+	if err := row.Scan(&dbID, &chatID, &question, &answer, &feedbackScore, &usedCount, &lastUsedAt, &status, &lang, &createdAt); err != nil {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":             dbID,
+		"chat_id":        chatID,
+		"question":       question,
+		"answer":         answer,
+		"feedback_score": feedbackScore,
+		"used_count":     usedCount,
+		"last_used_at":   lastUsedAt,
+		"status":         status,
+		"lang":           lang,
+		"created_at":     createdAt,
+	})
+}
+
+// adminQAEmbeddingsActionHandler applies promote/demote/archive/restore.
+// POST /api/admin/qa-embeddings/{id}/{action}
+func adminQAEmbeddingsActionHandler(w http.ResponseWriter, r *http.Request, id int64, action string) {
+	if !duckDBAvailable() {
+		http.Error(w, "Analytics database not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var query string
+	switch action {
+	case "promote":
+		query = `UPDATE qa_embeddings
+		         SET feedback_score = COALESCE(feedback_score, 0) + 1,
+		             status = 'active'
+		         WHERE id = ?`
+	case "demote":
+		query = `UPDATE qa_embeddings
+		         SET feedback_score = COALESCE(feedback_score, 0) - 1,
+		             status = 'demoted'
+		         WHERE id = ?`
+	case "archive":
+		query = `UPDATE qa_embeddings SET status = 'archived' WHERE id = ?`
+	case "restore":
+		query = `UPDATE qa_embeddings SET status = 'active' WHERE id = ?`
+	default:
+		http.Error(w, "Unknown action", http.StatusBadRequest)
+		return
+	}
+
+	res, err := duckDB.Exec(query, id)
+	if err != nil {
+		log.Printf("admin qa-embeddings %s error: %v", action, err)
+		writeQAJSONError(w, err)
+		return
+	}
+	rowsAffected, _ := res.RowsAffected()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":            true,
+		"action":        action,
+		"id":            id,
+		"rows_affected": rowsAffected,
+	})
+}
+
+func writeQAJSONError(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": fmt.Sprintf("Query failed: %v", err),
+	})
+}

--- a/cmd/unified-server/duckdb_analytics.go
+++ b/cmd/unified-server/duckdb_analytics.go
@@ -175,6 +175,10 @@ func createDuckDBSchema() error {
 		)`,
 		// Semantic cache: stores embeddings + user feedback for past Q&A pairs.
 		// embedding is stored as a JSON array of float32 values (VARCHAR).
+		// status: 'active' | 'demoted' | 'archived' — only 'active' rows are
+		// eligible for cache hits / RAG retrieval. used_count and last_used_at
+		// power popularity sorting in the admin tab. lang scopes lookups so a
+		// Japanese question never matches an English cached answer.
 		`CREATE TABLE IF NOT EXISTS qa_embeddings (
 			id BIGINT,
 			chat_id BIGINT,
@@ -182,6 +186,10 @@ func createDuckDBSchema() error {
 			answer VARCHAR,
 			embedding VARCHAR,
 			feedback_score INTEGER DEFAULT 0,
+			used_count INTEGER DEFAULT 0,
+			last_used_at TIMESTAMPTZ,
+			status VARCHAR DEFAULT 'active',
+			lang VARCHAR DEFAULT '',
 			created_at TIMESTAMPTZ DEFAULT now()
 		)`,
 		// Curated geographic knowledge: confirmed explanations for elevated/unusual
@@ -200,6 +208,22 @@ func createDuckDBSchema() error {
 	for _, ddl := range tables {
 		if _, err := duckDB.Exec(ddl); err != nil {
 			return fmt.Errorf("create schema: %w", err)
+		}
+	}
+
+	// In-place column migrations for existing installs. CREATE TABLE IF NOT
+	// EXISTS will not add new columns to a pre-existing table, so we issue
+	// idempotent ALTER TABLE ADD COLUMN IF NOT EXISTS statements after.
+	// Failures are non-fatal (most commonly: column already added).
+	migrations := []string{
+		`ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS used_count INTEGER DEFAULT 0`,
+		`ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ`,
+		`ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS status VARCHAR DEFAULT 'active'`,
+		`ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS lang VARCHAR DEFAULT ''`,
+	}
+	for _, m := range migrations {
+		if _, err := duckDB.Exec(m); err != nil {
+			log.Printf("qa_embeddings migration warning (may already be applied): %v", err)
 		}
 	}
 

--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -836,6 +836,7 @@ func main() {
 	var adminTourPageHandler http.HandlerFunc
 	var adminAIHintsPageHandler http.HandlerFunc
 	var adminHelpPageHandler http.HandlerFunc
+	var adminQAEmbeddingsPageHandler http.HandlerFunc
 
 	// Register authentication and admin page handlers only when auth is enabled.
 	if authManager != nil {
@@ -963,6 +964,16 @@ func main() {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Write(data)
 		}
+
+		adminQAEmbeddingsPageHandler = func(w http.ResponseWriter, r *http.Request) {
+			data, err := content.ReadFile("public_html/admin-qa-embeddings.html")
+			if err != nil {
+				http.Error(w, "Page not found", http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(data)
+		}
 	}
 
 	httpapi.RegisterPageRoutes(http.DefaultServeMux, httpapi.PageRoutesConfig{
@@ -982,6 +993,7 @@ func main() {
 		AdminTourPageHandler:         adminTourPageHandler,
 		AdminAIHintsPageHandler:      adminAIHintsPageHandler,
 		AdminHelpPageHandler:         adminHelpPageHandler,
+		AdminQAEmbeddingsPageHandler: adminQAEmbeddingsPageHandler,
 	})
 
 	// Legacy public endpoints (non-/api) live in one registrar to keep route
@@ -1023,6 +1035,8 @@ func main() {
 	var adminAIHintsImportAPIHandler http.HandlerFunc
 	var adminAIHintsByIDAPIHandler http.HandlerFunc
 	var adminAIHintsAPIHandler http.HandlerFunc
+	var adminQAEmbeddingsAPIHandler http.HandlerFunc
+	var adminQAEmbeddingsByIDAPIHandler http.HandlerFunc
 	if authManager != nil {
 		adminMCPDataAPIHandler = adminMCPDataHandler
 		adminMCPExportAPIHandler = adminMCPExportHandler
@@ -1127,6 +1141,38 @@ func main() {
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			}
 		}
+
+		// Q&A semantic-cache admin API. The list root serves GET only; the by-id
+		// subtree dispatches to detail (GET /{id}) or actions (POST /{id}/{action}).
+		adminQAEmbeddingsAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			adminQAEmbeddingsListHandler(w, r)
+		}
+		adminQAEmbeddingsByIDAPIHandler = func(w http.ResponseWriter, r *http.Request) {
+			stripped := strings.TrimPrefix(r.URL.Path, "/api/admin/qa-embeddings/")
+			stripped = strings.Trim(stripped, "/")
+			parts := strings.Split(stripped, "/")
+			if len(parts) == 0 || parts[0] == "" {
+				http.Error(w, "Missing id", http.StatusBadRequest)
+				return
+			}
+			id, err := strconv.ParseInt(parts[0], 10, 64)
+			if err != nil {
+				http.Error(w, "Invalid id", http.StatusBadRequest)
+				return
+			}
+			switch {
+			case len(parts) == 1 && r.Method == http.MethodGet:
+				adminQAEmbeddingsDetailHandler(w, r, id)
+			case len(parts) == 2 && r.Method == http.MethodPost:
+				adminQAEmbeddingsActionHandler(w, r, id, parts[1])
+			default:
+				http.Error(w, "Not found", http.StatusNotFound)
+			}
+		}
 	}
 
 	httpapi.Register(http.DefaultServeMux, httpapi.RegisterConfig{
@@ -1166,6 +1212,8 @@ func main() {
 		AdminAIHintsImportHandler:        adminAIHintsImportAPIHandler,
 		AdminAIHintsByIDHandler:          adminAIHintsByIDAPIHandler,
 		AdminAIHintsHandler:              adminAIHintsAPIHandler,
+		AdminQAEmbeddingsByIDHandler:     adminQAEmbeddingsByIDAPIHandler,
+		AdminQAEmbeddingsHandler:         adminQAEmbeddingsAPIHandler,
 		APISensorsHandler:                restHandler.handleSensors,
 		APISensorsExportHandler:          restHandler.handleSensorsExport,
 		APISensorByIDHandler:             restHandler.handleSensor,

--- a/cmd/unified-server/mcp_register.go
+++ b/cmd/unified-server/mcp_register.go
@@ -312,7 +312,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 
 		if len(embedding) > 0 {
 			// 1. Check semantic cache: high-similarity + positive feedback → return instantly.
-			if cachedAnswer, _ := checkSemanticCache(embedding, chatReq.Message, chatReq.TrackID); cachedAnswer != "" {
+			if cachedAnswer, _ := checkSemanticCache(embedding, chatReq.Message, chatReq.TrackID, chatReq.Lang); cachedAnswer != "" {
 				writeChunkBuffered(w, chunk{Type: "text", Text: cachedAnswer}, &buffer, isCloudFront)
 				writeChunkBuffered(w, chunk{Type: "done", ChatID: embeddingChatID, Cached: true}, &buffer, isCloudFront)
 				if isCloudFront {
@@ -493,7 +493,7 @@ func handleWebChat(mcpURL, apiKey, model string) http.HandlerFunc {
 
 		// 3. Async: store Q&A + embedding in semantic cache for future lookups.
 		if len(embedding) > 0 && finalAnswer != "" {
-			storeQAEmbeddingAsync(ctx, embeddingChatID, chatQuestion, finalAnswer, embedding)
+			storeQAEmbeddingAsync(ctx, embeddingChatID, chatQuestion, finalAnswer, embedding, chatReq.Lang)
 		}
 	}
 }

--- a/cmd/unified-server/public_html/admin-ai-hints.html
+++ b/cmd/unified-server/public_html/admin-ai-hints.html
@@ -311,7 +311,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations' },
     { label: 'Tour Steps', href: '/admin/tour' },
     { label: 'AI Hints', href: '/admin/ai-hints', active: true },
-    { label: 'Help', href: '/admin/help' }
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-help.html
+++ b/cmd/unified-server/public_html/admin-help.html
@@ -791,7 +791,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations' },
     { label: 'Tour Steps', href: '/admin/tour' },
     { label: 'AI Hints', href: '/admin/ai-hints' },
-    { label: 'Help', href: '/admin/help', active: true }
+    { label: 'Help', href: '/admin/help', active: true },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-mcp.html
+++ b/cmd/unified-server/public_html/admin-mcp.html
@@ -362,7 +362,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations' },
     { label: 'Tour Steps', href: '/admin/tour' },
     { label: 'AI Hints', href: '/admin/ai-hints' },
-    { label: 'Help', href: '/admin/help' }
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-qa-embeddings.html
+++ b/cmd/unified-server/public_html/admin-qa-embeddings.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Q&amp;A Cache - Safecast Admin</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon-16x16.png">
+  <style>
+    :root {
+      --bg-primary: #f5f5f5;
+      --bg-card: white;
+      --text-primary: #333;
+      --text-secondary: #666;
+      --text-muted: #999;
+      --border-color: #ddd;
+      --link-color: #0066cc;
+      --shadow: 0 1px 3px rgba(0,0,0,0.1);
+      --th-bg: #424242;
+      --hover-bg: #f9f9f9;
+      --btn-border-radius: 8px;
+      --tab-active-bg: #2196F3;
+      --tab-active-text: white;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1a1a1a;
+        --bg-card: #2b2b2b;
+        --text-primary: #eee;
+        --text-secondary: #aaa;
+        --text-muted: #777;
+        --border-color: #444;
+        --link-color: #90caf9;
+        --shadow: 0 1px 3px rgba(255,255,255,0.1);
+        --th-bg: #616161;
+        --hover-bg: #333;
+        --tab-active-bg: #1976D2;
+        color-scheme: dark;
+      }
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-primary); color: var(--text-primary); padding: 20px; }
+    h1 { margin-bottom: 15px; font-size: 1.6em; }
+
+    .admin-tabs { display: flex; gap: 2px; margin-top: 10px; margin-bottom: 10px; background: var(--border-color); border-radius: 8px; overflow: hidden; flex-wrap: wrap; }
+    .admin-tabs a { padding: 10px 20px; text-decoration: none; color: var(--text-secondary); background: var(--bg-card); font-weight: 500; font-size: 0.95em; transition: background 0.2s; }
+    .admin-tabs a:hover { background: var(--hover-bg); color: var(--text-primary); }
+    .admin-tabs a.active { background: var(--tab-active-bg); color: var(--tab-active-text); }
+
+    .controls { display: flex; gap: 10px; align-items: center; margin-bottom: 15px; flex-wrap: wrap; }
+    .controls input[type="text"], .controls select { padding: 8px 12px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); font-size: 0.95em; }
+    .controls input[type="text"] { min-width: 280px; }
+    .controls button { padding: 8px 16px; border: 1px solid var(--border-color); border-radius: var(--btn-border-radius); background: var(--bg-card); color: var(--text-primary); cursor: pointer; font-size: 0.95em; }
+    .controls button:hover { background: var(--hover-bg); }
+
+    .summary { margin-bottom: 10px; color: var(--text-secondary); font-size: 0.9em; }
+
+    .table-wrap { overflow-x: auto; background: var(--bg-card); border-radius: 8px; box-shadow: var(--shadow); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+    th { background: var(--th-bg); color: white; padding: 10px 12px; text-align: left; white-space: nowrap; position: sticky; top: 0; }
+    td { padding: 8px 12px; border-bottom: 1px solid var(--border-color); vertical-align: top; }
+    tr:hover { background: var(--hover-bg); }
+    .sortable { cursor: pointer; user-select: none; position: relative; padding-right: 20px; }
+    .sortable:hover { background: rgba(255,255,255,0.1); }
+    .sortable::after { content: '\21C5'; position: absolute; right: 4px; opacity: 0.5; }
+    .sortable.asc::after  { content: '\25B2'; opacity: 1; }
+    .sortable.desc::after { content: '\25BC'; opacity: 1; }
+
+    .col-id        { width: 110px; }
+    .col-question  { max-width: 460px; }
+    .col-question-text { overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+    .col-score     { width: 70px;  text-align: right; }
+    .col-used      { width: 70px;  text-align: right; }
+    .col-status    { width: 90px; }
+    .col-lang      { width: 70px; }
+    .col-date      { width: 140px; }
+    .col-actions   { width: 200px; white-space: nowrap; }
+
+    .pagination { display: flex; gap: 5px; align-items: center; justify-content: center; margin-top: 15px; flex-wrap: wrap; }
+    .pagination button { padding: 6px 12px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-card); color: var(--text-primary); cursor: pointer; }
+    .pagination button:hover { background: var(--hover-bg); }
+    .pagination button.active { background: var(--tab-active-bg); color: white; border-color: var(--tab-active-bg); }
+    .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .no-data { text-align: center; padding: 40px; color: var(--text-muted); }
+    .loading { text-align: center; padding: 40px; color: var(--text-muted); }
+
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.8em; font-weight: 600; }
+    .badge-active   { background: #4CAF50; color: white; }
+    .badge-demoted  { background: #FF9800; color: white; }
+    .badge-archived { background: #9E9E9E; color: white; }
+    .badge-lang     { background: var(--tab-active-bg); color: white; }
+    .score-pos { color: #4CAF50; font-weight: 600; }
+    .score-neg { color: #f44336; font-weight: 600; }
+    .score-zero { color: var(--text-muted); }
+
+    .btn-view    { background: #2196F3; color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin: 0 2px; }
+    .btn-promote { background: #4CAF50; color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin: 0 2px; }
+    .btn-demote  { background: #FF9800; color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin: 0 2px; }
+    .btn-archive { background: #9E9E9E; color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin: 0 2px; }
+    .btn-restore { background: #2196F3; color: white; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; margin: 0 2px; }
+    .btn-view:hover, .btn-promote:hover, .btn-demote:hover, .btn-archive:hover, .btn-restore:hover { opacity: 0.85; }
+
+    .modal-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1000; }
+    .modal-overlay.visible { display: flex; align-items: center; justify-content: center; }
+    .modal { background: var(--bg-card); border-radius: 12px; padding: 24px; max-width: 900px; width: 95%; max-height: 90vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,0.3); }
+    .modal h3 { margin-bottom: 15px; }
+    .modal .field-label { font-weight: 600; color: var(--text-secondary); margin-top: 10px; font-size: 0.85em; }
+    .modal .field-value { padding: 8px 12px; background: var(--bg-primary); border-radius: 6px; margin-top: 4px; white-space: pre-wrap; word-break: break-word; line-height: 1.5; }
+    .modal .btn-row { display: flex; gap: 10px; justify-content: flex-end; margin-top: 16px; }
+    .modal .btn-cancel { background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border-color); padding: 10px 24px; border-radius: var(--btn-border-radius); cursor: pointer; }
+
+    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0; }
+    .page-header h1 { margin: 0; }
+    .back-to-map-btn { background: #2196F3 !important; color: white !important; padding: 8px 16px; border-radius: var(--btn-border-radius); text-decoration: none !important; font-weight: 500; transition: background 0.2s; }
+    .back-to-map-btn:hover { background: #1976D2 !important; }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Q&amp;A Cache</h1>
+  <a href="/" class="back-to-map-btn">Back to Map</a>
+</div>
+
+<div class="admin-tabs" id="adminTabs"></div>
+
+<div class="controls">
+  <select id="statusFilter" onchange="onFilterChange()">
+    <option value="">All statuses</option>
+  </select>
+  <select id="langFilter" onchange="onFilterChange()">
+    <option value="">All languages</option>
+  </select>
+  <select id="scoreFilter" onchange="onFilterChange()">
+    <option value="">All scores</option>
+    <option value="pos">Positive only</option>
+    <option value="zero">Zero</option>
+    <option value="neg">Negative</option>
+  </select>
+  <input type="text" id="searchInput" placeholder="Search question or answer text..." onkeydown="if(event.key==='Enter')doSearch()">
+  <button onclick="doSearch()">Search</button>
+  <button onclick="clearSearch()">Clear</button>
+  <span class="summary" id="summary"></span>
+</div>
+
+<div class="table-wrap">
+  <div class="loading" id="loading">Loading...</div>
+  <table id="dataTable" style="display:none">
+    <thead>
+      <tr>
+        <th class="col-id sortable" onclick="sortBy('id')">ID</th>
+        <th class="col-question">Question</th>
+        <th class="col-score sortable" onclick="sortBy('feedback_score')">Score</th>
+        <th class="col-used sortable" onclick="sortBy('used_count')">Used</th>
+        <th class="col-status sortable" onclick="sortBy('status')">Status</th>
+        <th class="col-lang sortable" onclick="sortBy('lang')">Lang</th>
+        <th class="col-date sortable" onclick="sortBy('created_at')">Created</th>
+        <th class="col-date sortable" onclick="sortBy('last_used_at')">Last used</th>
+        <th class="col-actions">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="tableBody"></tbody>
+  </table>
+  <div class="no-data" id="noData" style="display:none">No cached Q&amp;A pairs found.</div>
+</div>
+
+<div class="pagination" id="pagination"></div>
+
+<div class="modal-overlay" id="modalOverlay" onclick="closeModal()">
+  <div class="modal" onclick="event.stopPropagation()">
+    <h3>Cached Q&amp;A</h3>
+    <div class="field-label">Question</div>
+    <div class="field-value" id="modalQuestion"></div>
+    <div class="field-label">Answer</div>
+    <div class="field-value" id="modalAnswer"></div>
+    <div class="field-label">Metadata</div>
+    <div class="field-value" id="modalMeta" style="font-family: monospace; font-size: 0.85em;"></div>
+    <div class="btn-row">
+      <button class="btn-cancel" onclick="closeModal()">Close</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const PASSWORD = new URLSearchParams(window.location.search).get('password') || '';
+const PASSWORD_QS = PASSWORD ? '?password=' + encodeURIComponent(PASSWORD) : '';
+
+let currentSort = 'created_at';
+let currentOrder = 'desc';
+let currentLimit = 50;
+let currentOffset = 0;
+let currentSearch = '';
+let currentStatus = '';
+let currentLang = '';
+let currentScore = '';
+
+function renderAdminTabs() {
+  const tabs = [
+    { label: 'Users', href: '/admin/users' },
+    { label: 'Uploads', href: '/admin/uploads' },
+    { label: 'MCP Analytics', href: '/admin/mcp' },
+    { label: 'Realtime', href: '/admin/realtime' },
+    { label: 'Translations', href: '/admin/translations' },
+    { label: 'Tour Steps', href: '/admin/tour' },
+    { label: 'AI Hints', href: '/admin/ai-hints' },
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings', active: true }
+  ];
+  const container = document.getElementById('adminTabs');
+  tabs.forEach(t => {
+    const href = t.href + PASSWORD_QS;
+    container.innerHTML += `<a href="${href}" class="${t.active ? 'active' : ''}">${t.label}</a>`;
+  });
+}
+
+function fmtDate(s) {
+  if (!s) return '<span style="color: var(--text-muted)">—</span>';
+  return String(s).substring(0, 19).replace('T', ' ');
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str == null ? '' : String(str);
+  return div.innerHTML;
+}
+
+function scoreClass(n) {
+  if (n > 0) return 'score-pos';
+  if (n < 0) return 'score-neg';
+  return 'score-zero';
+}
+
+function statusBadge(s) {
+  const cls = s === 'demoted' ? 'badge-demoted' : (s === 'archived' ? 'badge-archived' : 'badge-active');
+  return `<span class="badge ${cls}">${escapeHtml(s)}</span>`;
+}
+
+async function fetchData() {
+  document.getElementById('loading').style.display = 'block';
+  document.getElementById('dataTable').style.display = 'none';
+  document.getElementById('noData').style.display = 'none';
+
+  const params = new URLSearchParams({
+    sort: currentSort,
+    order: currentOrder,
+    limit: currentLimit,
+    offset: currentOffset,
+  });
+  if (currentSearch) params.set('search', currentSearch);
+  if (currentStatus) params.set('status', currentStatus);
+  if (currentLang) params.set('lang', currentLang);
+  if (currentScore) params.set('score', currentScore);
+  if (PASSWORD) params.set('password', PASSWORD);
+
+  try {
+    const resp = await fetch('/api/admin/qa-embeddings?' + params.toString());
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const json = await resp.json();
+    renderTable(json);
+    populateFilters(json);
+    updateSortIndicators();
+  } catch (e) {
+    document.getElementById('loading').textContent = 'Error: ' + e.message;
+  }
+}
+
+function populateFilters(json) {
+  const statusSel = document.getElementById('statusFilter');
+  const langSel = document.getElementById('langFilter');
+  if (statusSel.options.length <= 1 && Array.isArray(json.statuses)) {
+    json.statuses.forEach(s => {
+      const o = document.createElement('option');
+      o.value = s; o.textContent = s || '(none)';
+      statusSel.appendChild(o);
+    });
+  }
+  if (langSel.options.length <= 1 && Array.isArray(json.languages)) {
+    json.languages.forEach(l => {
+      const o = document.createElement('option');
+      o.value = l; o.textContent = l || '(none)';
+      langSel.appendChild(o);
+    });
+  }
+}
+
+function renderTable(json) {
+  document.getElementById('loading').style.display = 'none';
+  const tbody = document.getElementById('tableBody');
+  tbody.innerHTML = '';
+  if (!json.data || json.data.length === 0) {
+    document.getElementById('noData').style.display = 'block';
+    document.getElementById('summary').textContent = '0 rows';
+    document.getElementById('pagination').innerHTML = '';
+    return;
+  }
+
+  document.getElementById('dataTable').style.display = 'table';
+  json.data.forEach(row => {
+    const tr = document.createElement('tr');
+    const isArchived = row.status === 'archived';
+    const restoreOrArchive = isArchived
+      ? `<button class="btn-restore" onclick="doAction(${row.id}, 'restore')" title="Restore">⤴</button>`
+      : `<button class="btn-archive" onclick="doAction(${row.id}, 'archive')" title="Archive">🗑</button>`;
+    tr.innerHTML = `
+      <td class="col-id">${row.id}</td>
+      <td class="col-question">
+        <div class="col-question-text" title="${escapeHtml(row.question)}">${escapeHtml(row.question)}</div>
+        <small style="color: var(--text-muted)">${row.answer_len} char answer · chat_id ${row.chat_id}</small>
+      </td>
+      <td class="col-score ${scoreClass(row.feedback_score)}">${row.feedback_score > 0 ? '+' : ''}${row.feedback_score}</td>
+      <td class="col-used">${row.used_count}</td>
+      <td class="col-status">${statusBadge(row.status)}</td>
+      <td class="col-lang">${row.lang ? `<span class="badge badge-lang">${escapeHtml(row.lang)}</span>` : '<span style="color: var(--text-muted)">—</span>'}</td>
+      <td class="col-date">${fmtDate(row.created_at)}</td>
+      <td class="col-date">${fmtDate(row.last_used_at)}</td>
+      <td class="col-actions">
+        <button class="btn-view"    onclick="viewRow(${row.id})"           title="View">👁</button>
+        <button class="btn-promote" onclick="doAction(${row.id}, 'promote')" title="Promote (+1)">⬆</button>
+        <button class="btn-demote"  onclick="doAction(${row.id}, 'demote')"  title="Demote (-1)">⬇</button>
+        ${restoreOrArchive}
+      </td>`;
+    tbody.appendChild(tr);
+  });
+
+  document.getElementById('summary').textContent =
+    `Showing ${currentOffset + 1}–${Math.min(currentOffset + json.data.length, json.total)} of ${json.total}`;
+  renderPagination(json.total);
+}
+
+function renderPagination(total) {
+  const container = document.getElementById('pagination');
+  container.innerHTML = '';
+  const pages = Math.ceil(total / currentLimit);
+  const curPage = Math.floor(currentOffset / currentLimit) + 1;
+  const mkBtn = (label, page, active=false, disabled=false) => {
+    const b = document.createElement('button');
+    b.textContent = label;
+    if (active) b.classList.add('active');
+    if (disabled) b.disabled = true;
+    b.onclick = () => { currentOffset = (page - 1) * currentLimit; fetchData(); };
+    container.appendChild(b);
+  };
+  mkBtn('‹', curPage - 1, false, curPage <= 1);
+  const start = Math.max(1, curPage - 3);
+  const end = Math.min(pages, curPage + 3);
+  if (start > 1) mkBtn('1', 1);
+  if (start > 2) { const s = document.createElement('span'); s.textContent = '…'; s.style.padding='0 6px'; container.appendChild(s); }
+  for (let p = start; p <= end; p++) mkBtn(String(p), p, p === curPage);
+  if (end < pages - 1) { const s = document.createElement('span'); s.textContent = '…'; s.style.padding='0 6px'; container.appendChild(s); }
+  if (end < pages) mkBtn(String(pages), pages);
+  mkBtn('›', curPage + 1, false, curPage >= pages);
+}
+
+function sortBy(col) {
+  if (currentSort === col) {
+    currentOrder = currentOrder === 'desc' ? 'asc' : 'desc';
+  } else {
+    currentSort = col;
+    currentOrder = (col === 'question' || col === 'lang' || col === 'status') ? 'asc' : 'desc';
+  }
+  currentOffset = 0;
+  fetchData();
+}
+
+function updateSortIndicators() {
+  document.querySelectorAll('th.sortable').forEach(th => {
+    th.classList.remove('asc', 'desc');
+    const col = th.getAttribute('onclick')?.match(/sortBy\('(\w+)'\)/)?.[1];
+    if (col === currentSort) th.classList.add(currentOrder);
+  });
+}
+
+function doSearch() {
+  currentSearch = document.getElementById('searchInput').value.trim();
+  currentOffset = 0;
+  fetchData();
+}
+function clearSearch() {
+  document.getElementById('searchInput').value = '';
+  currentSearch = '';
+  currentOffset = 0;
+  fetchData();
+}
+function onFilterChange() {
+  currentStatus = document.getElementById('statusFilter').value;
+  currentLang   = document.getElementById('langFilter').value;
+  currentScore  = document.getElementById('scoreFilter').value;
+  currentOffset = 0;
+  fetchData();
+}
+
+async function viewRow(id) {
+  try {
+    const resp = await fetch('/api/admin/qa-embeddings/' + id + PASSWORD_QS);
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const r = await resp.json();
+    document.getElementById('modalQuestion').textContent = r.question || '';
+    document.getElementById('modalAnswer').textContent = r.answer || '';
+    document.getElementById('modalMeta').textContent = JSON.stringify({
+      id: r.id,
+      chat_id: r.chat_id,
+      feedback_score: r.feedback_score,
+      used_count: r.used_count,
+      status: r.status,
+      lang: r.lang,
+      created_at: r.created_at,
+      last_used_at: r.last_used_at
+    }, null, 2);
+    document.getElementById('modalOverlay').classList.add('visible');
+  } catch (e) {
+    alert('Failed to load: ' + e.message);
+  }
+}
+
+function closeModal() {
+  document.getElementById('modalOverlay').classList.remove('visible');
+}
+
+async function doAction(id, action) {
+  if (action === 'archive' && !confirm('Archive this Q&A? It will no longer be served from cache, but the row is kept for audit.')) return;
+  try {
+    const resp = await fetch('/api/admin/qa-embeddings/' + id + '/' + action + PASSWORD_QS, { method: 'POST' });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    fetchData();
+  } catch (e) {
+    alert('Action failed: ' + e.message);
+  }
+}
+
+renderAdminTabs();
+fetchData();
+</script>
+</body>
+</html>

--- a/cmd/unified-server/public_html/admin-realtime.html
+++ b/cmd/unified-server/public_html/admin-realtime.html
@@ -218,7 +218,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations' },
     { label: 'Tour Steps', href: '/admin/tour' },
     { label: 'AI Hints', href: '/admin/ai-hints' },
-    { label: 'Help', href: '/admin/help' }
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-tour.html
+++ b/cmd/unified-server/public_html/admin-tour.html
@@ -265,7 +265,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations' },
     { label: 'Tour Steps', href: '/admin/tour', active: true },
     { label: 'AI Hints', href: '/admin/ai-hints' },
-    { label: 'Help', href: '/admin/help' }
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-translations.html
+++ b/cmd/unified-server/public_html/admin-translations.html
@@ -231,7 +231,8 @@ function buildAdminTabs() {
     { label: 'Translations', href: '/admin/translations', active: true },
     { label: 'Tour Steps', href: '/admin/tour' },
     { label: 'AI Hints', href: '/admin/ai-hints' },
-    { label: 'Help', href: '/admin/help' }
+    { label: 'Help', href: '/admin/help' },
+    { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
   ];
   const container = document.getElementById('adminTabs');
   tabs.forEach(t => {

--- a/cmd/unified-server/public_html/admin-users.html
+++ b/cmd/unified-server/public_html/admin-users.html
@@ -380,7 +380,8 @@
         { label: 'Translations', href: '/admin/translations' },
         { label: 'Tour Steps', href: '/admin/tour' },
         { label: 'AI Hints', href: '/admin/ai-hints' },
-        { label: 'Help', href: '/admin/help' }
+        { label: 'Help', href: '/admin/help' },
+        { label: 'Q&A Cache', href: '/admin/qa-embeddings' }
       ];
       const container = document.getElementById('adminTabs');
       tabs.forEach(t => {

--- a/cmd/unified-server/semantic_cache.go
+++ b/cmd/unified-server/semantic_cache.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -43,6 +44,8 @@ type qaEntry struct {
 	Answer        string
 	Embedding     []float32
 	FeedbackScore int
+	Status        string // 'active' | 'demoted' | 'archived'
+	Lang          string // IETF language tag; empty = legacy/unknown
 }
 
 // trackIDRegexp matches 5–10 character alphanumeric track IDs as whole words.
@@ -73,8 +76,11 @@ func extractTrackID(s string) string {
 // cosine similarity to the given embedding.
 // trackID is the explicit track the user is viewing (may be ""); question is
 // used as a fallback to extract a track ID when trackID is empty. Cache hits
-// from a different track are never returned. Returns ("", 0) on miss.
-func checkSemanticCache(embedding []float32, question, trackID string) (answer string, chatID int64) {
+// from a different track are never returned. lang scopes the lookup to entries
+// produced by the same language (legacy/empty-lang rows are matched too, so
+// a freshly migrated cache continues to serve hits during transition).
+// Returns ("", 0) on miss.
+func checkSemanticCache(embedding []float32, question, trackID, lang string) (answer string, chatID int64) {
 	if !duckDBAvailable() || len(embedding) == 0 {
 		return "", 0
 	}
@@ -93,6 +99,12 @@ func checkSemanticCache(embedding []float32, question, trackID string) (answer s
 	var bestScore float32
 	var best *qaEntry
 	for i := range entries {
+		// Cross-language hits would surface a Japanese answer for an English
+		// question (or vice versa). Reject unless the stored lang is empty,
+		// which keeps legacy pre-migration rows usable.
+		if lang != "" && entries[i].Lang != "" && entries[i].Lang != lang {
+			continue
+		}
 		if queryTrackID != "" {
 			if !strings.Contains(entries[i].Question, queryTrackID) &&
 				!strings.Contains(entries[i].Answer, queryTrackID) {
@@ -105,6 +117,14 @@ func checkSemanticCache(embedding []float32, question, trackID string) (answer s
 		}
 	}
 	if bestScore >= cacheHitThreshold && best != nil {
+		// Bump usage stats so the admin tab can sort by popularity. Failure
+		// here is non-fatal — the cache hit still serves correctly.
+		if _, err := duckDB.Exec(
+			`UPDATE qa_embeddings SET used_count = COALESCE(used_count, 0) + 1, last_used_at = now() WHERE id = ?`,
+			best.ID,
+		); err != nil {
+			log.Printf("qa_embeddings usage bump (non-fatal): %v", err)
+		}
 		return best.Answer, best.ChatID
 	}
 	return "", 0
@@ -196,7 +216,8 @@ func getLocationKnowledge() string {
 
 // storeQAEmbeddingAsync saves a new Q&A + embedding in the background.
 // embeddingChatID is the ID to use as chat_id (for later feedback linkage).
-func storeQAEmbeddingAsync(ctx context.Context, embeddingChatID int64, question, answer string, embedding []float32) {
+// lang records the language of the exchange so future lookups can scope by it.
+func storeQAEmbeddingAsync(ctx context.Context, embeddingChatID int64, question, answer string, embedding []float32, lang string) {
 	go func() {
 		if !duckDBAvailable() || len(embedding) == 0 {
 			return
@@ -207,8 +228,9 @@ func storeQAEmbeddingAsync(ctx context.Context, embeddingChatID int64, question,
 		}
 		id := time.Now().UnixMilli() // UnixNano exceeds JS MAX_SAFE_INTEGER
 		if _, err := duckDB.Exec(
-			`INSERT INTO qa_embeddings (id, chat_id, question, answer, embedding, feedback_score) VALUES (?, ?, ?, ?, ?, 0)`,
-			id, embeddingChatID, question, answer, string(embJSON),
+			`INSERT INTO qa_embeddings (id, chat_id, question, answer, embedding, feedback_score, used_count, status, lang)
+			 VALUES (?, ?, ?, ?, ?, 0, 0, 'active', ?)`,
+			id, embeddingChatID, question, answer, string(embJSON), lang,
 		); err != nil {
 			log.Printf("store qa_embedding: %v", err)
 		}
@@ -282,54 +304,54 @@ func extractLocationKnowledge(chatID int64) {
 	}
 }
 
-// loadQAEmbeddingsForTrack fetches positively-rated Q&A rows that mention
-// the given track ID in the question or answer text.
+// loadQAEmbeddingsForTrack fetches positively-rated, active Q&A rows that
+// mention the given track ID in the question or answer text.
+// COALESCE on status/lang keeps legacy rows (pre-migration) visible.
 func loadQAEmbeddingsForTrack(trackID string) ([]qaEntry, error) {
 	like := "%" + trackID + "%"
 	rows, err := duckDB.Query(
-		`SELECT id, chat_id, question, answer, embedding, feedback_score FROM qa_embeddings
+		`SELECT id, chat_id, question, answer, embedding, feedback_score,
+		        COALESCE(status, 'active'), COALESCE(lang, '')
+		 FROM qa_embeddings
 		 WHERE feedback_score > 0
-		 AND (question LIKE ? OR answer LIKE ?)`,
+		   AND COALESCE(status, 'active') = 'active'
+		   AND (question LIKE ? OR answer LIKE ?)`,
 		like, like,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-
-	var entries []qaEntry
-	for rows.Next() {
-		var e qaEntry
-		var embJSON string
-		if err := rows.Scan(&e.ID, &e.ChatID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
-			continue
-		}
-		if err := json.Unmarshal([]byte(embJSON), &e.Embedding); err != nil {
-			continue
-		}
-		entries = append(entries, e)
-	}
-	return entries, rows.Err()
+	return scanQAEntries(rows)
 }
 
-// loadQAEmbeddings fetches Q&A rows from DuckLake.
+// loadQAEmbeddings fetches active Q&A rows from DuckLake.
 // If positiveOnly is true, only rows with feedback_score > 0 are returned.
+// Demoted/archived rows are always excluded.
 func loadQAEmbeddings(positiveOnly bool) ([]qaEntry, error) {
-	query := `SELECT id, chat_id, question, answer, embedding, feedback_score FROM qa_embeddings`
+	query := `SELECT id, chat_id, question, answer, embedding, feedback_score,
+	                 COALESCE(status, 'active'), COALESCE(lang, '')
+	          FROM qa_embeddings
+	          WHERE COALESCE(status, 'active') = 'active'`
 	if positiveOnly {
-		query += ` WHERE feedback_score > 0`
+		query += ` AND feedback_score > 0`
 	}
 	rows, err := duckDB.Query(query)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanQAEntries(rows)
+}
 
+// scanQAEntries reads the columns produced by loadQAEmbeddings* into qaEntry
+// values. Rows with unparseable embeddings are silently dropped.
+func scanQAEntries(rows *sql.Rows) ([]qaEntry, error) {
 	var entries []qaEntry
 	for rows.Next() {
 		var e qaEntry
 		var embJSON string
-		if err := rows.Scan(&e.ID, &e.ChatID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore); err != nil {
+		if err := rows.Scan(&e.ID, &e.ChatID, &e.Question, &e.Answer, &embJSON, &e.FeedbackScore, &e.Status, &e.Lang); err != nil {
 			continue
 		}
 		if err := json.Unmarshal([]byte(embJSON), &e.Embedding); err != nil {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -163,7 +163,36 @@ The unified server uses DuckLake for analytics (tool usage logs, chat questions)
 - `DUCKLAKE_PG_URL` — PostgreSQL connection for DuckLake catalog (e.g., `dbname=ducklake_catalog host=localhost user=ducklake_rw`)
 - `DUCKLAKE_DATA_PATH` — Directory for Parquet data files (e.g., `/var/lib/safecast/ducklake/`)
 
-**Shared tables:** `chat_questions`, `mcp_query_log`, `mcp_ai_query_log`
+**Shared tables:** `chat_questions`, `mcp_query_log`, `mcp_ai_query_log`,
+`qa_embeddings` (semantic chat cache), `location_knowledge` (curated geo notes).
+
+### Q&A Semantic Cache (May 2026)
+
+The web-chat assistant caches answered questions in `qa_embeddings` and serves
+paraphrased repeats without re-calling the LLM. Hit criteria: cosine similarity
+≥ 0.85, `feedback_score > 0`, `status='active'`, matching `lang`.
+
+**Admin UI:** `/admin/qa-embeddings` — searchable/sortable, promote / demote /
+archive / restore actions per row.
+
+**Schema:** base table is created at startup; curation columns (`used_count`,
+`last_used_at`, `status`, `lang`) are applied in-place via idempotent
+`ALTER TABLE ADD COLUMN IF NOT EXISTS` on every boot. Standalone migration
+file: `migrations/add_qa_embeddings_columns.sql`.
+
+**Manual inspection** (DuckDB CLI against the live catalog):
+```sql
+ATTACH 'ducklake:postgres:dbname=ducklake_catalog host=localhost user=ducklake_rw'
+       AS analytics (DATA_PATH '/var/lib/safecast/ducklake/');
+USE analytics;
+SELECT id, chat_id, feedback_score, used_count, status, lang,
+       LEFT(question, 80) AS q
+FROM qa_embeddings
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+The cache only runs when the unified server is built with `-tags duckdb`.
 
 ## Translations (i18n)
 

--- a/migrations/add_qa_embeddings_columns.sql
+++ b/migrations/add_qa_embeddings_columns.sql
@@ -1,0 +1,26 @@
+-- Migration: add cache-management columns to qa_embeddings
+--
+-- These columns power the /admin/qa-embeddings curation tab. They are also
+-- applied automatically at unified-server startup
+-- (see cmd/unified-server/duckdb_analytics.go) — this file is the standalone
+-- record for ops/manual application.
+--
+-- Target: DuckLake `analytics` catalog (PostgreSQL + Parquet).
+-- Apply with the DuckDB CLI attached to the catalog, e.g.:
+--   ATTACH 'ducklake:postgres:dbname=ducklake_catalog host=localhost user=ducklake_rw'
+--          AS analytics (DATA_PATH '/var/lib/safecast/ducklake/');
+--   USE analytics;
+--   .read migrations/add_qa_embeddings_columns.sql
+--
+-- Columns:
+--   used_count    — bumped on every cache hit; surfaces popular Q&A in admin
+--   last_used_at  — timestamp of the most recent cache hit; drives staleness UI
+--   status        — 'active' | 'demoted' | 'archived'; only 'active' is eligible
+--                   for cache hits and RAG retrieval
+--   lang          — IETF tag (e.g. 'en', 'ja'); scopes lookups so a Japanese
+--                   question never matches an English cached answer
+
+ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS used_count   INTEGER     DEFAULT 0;
+ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ;
+ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS status       VARCHAR     DEFAULT 'active';
+ALTER TABLE qa_embeddings ADD COLUMN IF NOT EXISTS lang         VARCHAR     DEFAULT '';

--- a/pkg/httpapi/page_routes.go
+++ b/pkg/httpapi/page_routes.go
@@ -29,6 +29,7 @@ type PageRoutesConfig struct {
 	AdminTourPageHandler         http.HandlerFunc
 	AdminAIHintsPageHandler      http.HandlerFunc
 	AdminHelpPageHandler         http.HandlerFunc
+	AdminQAEmbeddingsPageHandler http.HandlerFunc
 }
 
 // RegisterPageRoutes attaches UI/admin page routes to mux.
@@ -90,4 +91,5 @@ func RegisterPageRoutes(mux *http.ServeMux, cfg PageRoutesConfig) {
 	registerOptionalAdmin("/admin/tour", cfg.AdminTourPageHandler)
 	registerOptionalAdmin("/admin/ai-hints", cfg.AdminAIHintsPageHandler)
 	registerOptionalAdmin("/admin/help", cfg.AdminHelpPageHandler)
+	registerOptionalAdmin("/admin/qa-embeddings", cfg.AdminQAEmbeddingsPageHandler)
 }

--- a/pkg/httpapi/public_routes.go
+++ b/pkg/httpapi/public_routes.go
@@ -53,6 +53,12 @@ const (
 	RouteAPIAdminAIHintsByID   = "/api/admin/ai-hints/"
 	RouteAPIAdminAIHints       = "/api/admin/ai-hints"
 
+	// Q&A semantic-cache admin routes. By-id (with trailing slash) is the
+	// prefix-match subtree that also handles /{id}/{action}; the bare list
+	// route must be registered after it so ServeMux longest-prefix matches.
+	RouteAPIAdminQAEmbeddingsByID = "/api/admin/qa-embeddings/"
+	RouteAPIAdminQAEmbeddings     = "/api/admin/qa-embeddings"
+
 	RouteAPISensors              = "/api/sensors"
 	RouteAPISensorsExport        = "/api/sensors/export"
 	RouteAPISensorByID           = "/api/sensor/"

--- a/pkg/httpapi/register.go
+++ b/pkg/httpapi/register.go
@@ -66,6 +66,8 @@ type RegisterConfig struct {
 	AdminAIHintsImportHandler        http.HandlerFunc
 	AdminAIHintsByIDHandler          http.HandlerFunc
 	AdminAIHintsHandler              http.HandlerFunc
+	AdminQAEmbeddingsByIDHandler     http.HandlerFunc
+	AdminQAEmbeddingsHandler         http.HandlerFunc
 
 	Logf func(string, ...any)
 }
@@ -199,6 +201,11 @@ func registerAuthAndAdminRoutes(mux *http.ServeMux, cfg RegisterConfig) {
 	registerOptionalAdmin(RouteAPIAdminAIHintsImport, cfg.AdminAIHintsImportHandler)
 	registerOptionalAdmin(RouteAPIAdminAIHintsByID, cfg.AdminAIHintsByIDHandler)
 	registerOptionalAdmin(RouteAPIAdminAIHints, cfg.AdminAIHintsHandler)
+
+	// Q&A semantic-cache admin endpoints: by-id subtree handles both detail
+	// (GET /{id}) and actions (POST /{id}/{action}), then the list root.
+	registerOptionalAdmin(RouteAPIAdminQAEmbeddingsByID, cfg.AdminQAEmbeddingsByIDHandler)
+	registerOptionalAdmin(RouteAPIAdminQAEmbeddings, cfg.AdminQAEmbeddingsHandler)
 
 	registerOptionalPublic := func(path string, handler http.HandlerFunc) {
 		if handler == nil {


### PR DESCRIPTION
## Summary

- Adds `/admin/qa-embeddings` — a searchable, sortable view of the existing semantic chat cache with promote / demote / archive / restore actions for curation.
- Extends `qa_embeddings` with four curation columns (`used_count`, `last_used_at`, `status`, `lang`) via idempotent in-place migration applied at startup.
- Thread language through `checkSemanticCache` / `storeQAEmbeddingAsync` so cache hits never cross languages; bump `used_count` / `last_used_at` on every hit.

## Admin UI

`/admin/qa-embeddings` — added to the nav strip on every existing admin page.

- Search on question/answer (ILIKE)
- Filters: status (`active` / `demoted` / `archived`), language, feedback-score sign
- Sortable on `id`, `feedback_score`, `used_count`, `last_used_at`, `created_at`, `status`, `lang`
- Modal view shows full Q&A and JSON metadata; the embedding vector itself is never sent to the browser
- Per-row actions:
  - **Promote** — `feedback_score += 1`, force `status='active'`
  - **Demote** — `feedback_score -= 1`, `status='demoted'` (excluded from cache; kept for audit)
  - **Archive** — `status='archived'` (audit-only)
  - **Restore** — bring `archived` / `demoted` rows back to `active`

## Schema migration

`migrations/add_qa_embeddings_columns.sql` is the standalone record; `cmd/unified-server/duckdb_analytics.go` applies the same `ALTER TABLE ADD COLUMN IF NOT EXISTS` statements at startup, so existing installs upgrade in place with no manual step.

## Behavioral changes to `semantic_cache.go`

- `loadQAEmbeddings` / `loadQAEmbeddingsForTrack` now filter `COALESCE(status,'active') = 'active'`. `COALESCE` keeps legacy pre-migration rows visible during transition.
- `checkSemanticCache` takes a new `lang` argument; entries with non-empty `lang` that doesn't match are skipped (empty `lang` is permissive for legacy rows).
- On cache hit, the row's `used_count` and `last_used_at` are bumped (best-effort; failure is non-fatal).
- `storeQAEmbeddingAsync` now persists `lang` and explicit `status='active'`.

## Routes

Added via `pkg/httpapi`:
- `GET /api/admin/qa-embeddings` — list
- `GET /api/admin/qa-embeddings/{id}` — detail
- `POST /api/admin/qa-embeddings/{id}/{promote|demote|archive|restore}`
- `GET /admin/qa-embeddings` — HTML shell

All gated by the existing admin password / admin-user check.

## Test plan

- [x] `go build -tags duckdb -o safecast-new-map ./cmd/unified-server/` — clean
- [x] `go vet -tags duckdb ./cmd/unified-server/ ./pkg/httpapi/` — clean
- [x] `go test -tags duckdb ./pkg/httpapi/` — pass
- [ ] Deploy to a server with a populated `qa_embeddings` table and confirm:
  - [ ] `/admin/qa-embeddings?password=…` lists rows
  - [ ] Search/sort/filter all work
  - [ ] Promote/Demote/Archive/Restore actions take effect (refresh shows updated state)
  - [ ] Demoted/archived rows no longer serve cache hits
  - [ ] A fresh chat answer is inserted with `lang` populated (check via DuckDB CLI)
  - [ ] A cache hit increments `used_count` and updates `last_used_at`

## Notes

- The cache only runs when built with `-tags duckdb`. Without it, the admin tab returns "Analytics database not available."
- This PR is the foundation for a follow-up Hermes proposer/approver flow that will read feedback and propose corpus curations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)