### PR TITLE
feat(web-chat): OpenAI-compatible LLM provider (North Mini Code)

### DIFF
--- a/cmd/web-chat/main.go
+++ b/cmd/web-chat/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -300,9 +301,180 @@ func mcpToolsToAnthropic(tools []mcp.Tool) []anthropicTool {
 	return out
 }
 
+// ── OpenAI-compatible provider (vLLM / Cohere Compatibility API) ───────────
+
+type llmConfig struct {
+	provider string // "anthropic" | "openai"
+	apiKey   string
+	model    string
+	baseURL  string // openai only, e.g. http://localhost:8000/v1
+}
+
+type openAIFunction struct {
+	Name      string          `json:"name"`
+	Arguments string          `json:"arguments,omitempty"`  // response: JSON string
+	Parameters json.RawMessage `json:"parameters,omitempty"` // request: tool schema
+	Description string         `json:"description,omitempty"`
+}
+
+type openAIToolCall struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Function openAIFunction `json:"function"`
+}
+
+type openAITool struct {
+	Type     string         `json:"type"`
+	Function openAIFunction `json:"function"`
+}
+
+type openAIMessage struct {
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openAIRequest struct {
+	Model     string          `json:"model"`
+	MaxTokens int             `json:"max_tokens"`
+	Messages  []openAIMessage `json:"messages"`
+	Tools     []openAITool    `json:"tools,omitempty"`
+}
+
+type openAIResponse struct {
+	Choices []struct {
+		Message      openAIMessage `json:"message"`
+		FinishReason string        `json:"finish_reason"`
+	} `json:"choices"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// anthropicToOpenAIMessages translates our internal Anthropic-shaped history
+// into OpenAI chat-completion messages.
+func anthropicToOpenAIMessages(system string, messages []anthropicMessage) []openAIMessage {
+	out := []openAIMessage{{Role: "system", Content: system}}
+	for _, m := range messages {
+		switch c := m.Content.(type) {
+		case string:
+			out = append(out, openAIMessage{Role: m.Role, Content: c})
+		case []contentBlock:
+			msg := openAIMessage{Role: m.Role}
+			var toolResults []openAIMessage
+			for _, b := range c {
+				switch b.Type {
+				case "text":
+					msg.Content += b.Text
+				case "tool_use":
+					msg.ToolCalls = append(msg.ToolCalls, openAIToolCall{
+						ID:   b.ID,
+						Type: "function",
+						Function: openAIFunction{
+							Name:      b.Name,
+							Arguments: string(b.Input),
+						},
+					})
+				case "tool_result":
+					// Each tool_result becomes its own role:"tool" message.
+					toolResults = append(toolResults, openAIMessage{
+						Role:       "tool",
+						ToolCallID: b.ToolUseID,
+						Content:    b.Content,
+					})
+				}
+			}
+			if msg.Content != "" || len(msg.ToolCalls) > 0 {
+				out = append(out, msg)
+			}
+			out = append(out, toolResults...)
+		}
+	}
+	return out
+}
+
+func callOpenAI(ctx context.Context, cfg llmConfig, messages []anthropicMessage, tools []anthropicTool) (*anthropicResponse, error) {
+	messages = truncateHistory(messages, maxPromptTokens)
+
+	oaTools := make([]openAITool, 0, len(tools))
+	for _, t := range tools {
+		oaTools = append(oaTools, openAITool{
+			Type: "function",
+			Function: openAIFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+
+	reqBody := openAIRequest{
+		Model:     cfg.model,
+		MaxTokens: 4096,
+		Messages:  anthropicToOpenAIMessages(systemPrompt, messages),
+		Tools:     oaTools,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	url := strings.TrimRight(cfg.baseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var or openAIResponse
+	if err := json.Unmarshal(raw, &or); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if or.Error != nil {
+		return nil, fmt.Errorf("openai %s: %s", or.Error.Type, or.Error.Message)
+	}
+	if len(or.Choices) == 0 {
+		return nil, fmt.Errorf("openai: empty choices")
+	}
+
+	choice := or.Choices[0]
+	ar := &anthropicResponse{}
+	if choice.Message.Content != "" {
+		ar.Content = append(ar.Content, contentBlock{Type: "text", Text: choice.Message.Content})
+	}
+	for _, tc := range choice.Message.ToolCalls {
+		ar.Content = append(ar.Content, contentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: json.RawMessage(tc.Function.Arguments),
+		})
+	}
+	if choice.FinishReason != "tool_calls" {
+		ar.StopReason = "end_turn"
+	}
+	return ar, nil
+}
+
 // ── Chat handler ───────────────────────────────────────────────────────────
 
-func handleChat(mcpURL, apiKey, model string) http.HandlerFunc {
+func handleChat(mcpURL string, cfg llmConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// CORS preflight
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -396,7 +568,13 @@ func handleChat(mcpURL, apiKey, model string) http.HandlerFunc {
 		messages = append(messages, anthropicMessage{Role: "user", Content: chatReq.Message})
 
 		for {
-			resp, err := callAnthropic(ctx, apiKey, model, messages, tools)
+			var resp *anthropicResponse
+			var err error
+			if cfg.provider == "openai" {
+				resp, err = callOpenAI(ctx, cfg, messages, tools)
+			} else {
+				resp, err = callAnthropic(ctx, cfg.apiKey, cfg.model, messages, tools)
+			}
 			if err != nil {
 				writeChunkBuffered(w, chunk{Type: "error", Error: err.Error()}, &buffer, isCloudfFront)
 				if isCloudfFront {
@@ -478,13 +656,29 @@ func handleChat(mcpURL, apiKey, model string) http.HandlerFunc {
 // ── Main ───────────────────────────────────────────────────────────────────
 
 func main() {
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		log.Fatal("ANTHROPIC_API_KEY is required")
+	cfg := llmConfig{
+		provider: os.Getenv("LLM_PROVIDER"),
+		baseURL:  os.Getenv("LLM_BASE_URL"),
+		apiKey:   os.Getenv("LLM_API_KEY"),
+		model:    os.Getenv("LLM_MODEL"),
 	}
-	model := os.Getenv("CLAUDE_MODEL")
-	if model == "" {
-		model = "claude-haiku-4-5-20251001"
+	if cfg.provider == "" {
+		cfg.provider = "anthropic"
+	}
+	if cfg.apiKey == "" {
+		cfg.apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if cfg.model == "" {
+		cfg.model = os.Getenv("CLAUDE_MODEL")
+	}
+	if cfg.model == "" {
+		cfg.model = "claude-haiku-4-5-20251001"
+	}
+	if cfg.provider == "anthropic" && cfg.apiKey == "" {
+		log.Fatal("ANTHROPIC_API_KEY (or LLM_API_KEY) is required")
+	}
+	if cfg.provider == "openai" && cfg.baseURL == "" {
+		log.Fatal("LLM_BASE_URL is required when LLM_PROVIDER=openai")
 	}
 	mcpURL := os.Getenv("MCP_URL")
 	if mcpURL == "" {
@@ -504,12 +698,12 @@ func main() {
 		w.Header().Set("Cache-Control", "public, max-age=86400")
 		w.Write(logoPNG)
 	})
-	http.HandleFunc("/chat", handleChat(mcpURL, apiKey, model))
+	http.HandleFunc("/chat", handleChat(mcpURL, cfg))
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "ok")
 	})
 
-	log.Printf("Safecast web-chat on :%s  MCP→%s  model=%s", port, mcpURL, model)
+	log.Printf("Safecast web-chat on :%s  MCP→%s  provider=%s  model=%s", port, mcpURL, cfg.provider, cfg.model)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/docs/plans/web-chat-openai-provider.md
+++ b/docs/plans/web-chat-openai-provider.md
@@ -1,0 +1,100 @@
+# Swap web-chat LLM call to support North Mini Code (local test)
+
+## Context
+The Safecast AI assistant (`cmd/web-chat`) currently hardcodes the Anthropic
+Messages API (`https://api.anthropic.com/v1/messages`, Anthropic request/response
+structs, Anthropic tool-call format). The user wants to test **Cohere North Mini
+Code** — a 30B-MoE/3B-active, Apache-2.0, agentic-coding model (256K ctx, trained
+with 43% tool-use data) — as a drop-in replacement, running **locally first**.
+
+North Mini Code is served through an **OpenAI-compatible** endpoint (self-hosted
+via vLLM at `/v1/chat/completions`, or Cohere's Compatibility API). The MCP tool
+layer is already model-agnostic (`model-adapter` has Claude/Kimi/Qwen hint
+providers), so the only Anthropic-locked code is the single HTTP call + payload
+translation in web-chat. Goal: add an OpenAI-compatible provider path behind an
+env flag, leaving the agentic loop untouched.
+
+## Approach
+Add a provider switch at the `callAnthropic` boundary in
+[cmd/web-chat/main.go](cmd/web-chat/main.go). The agentic loop
+([main.go:398-466](cmd/web-chat/main.go#L398)) keeps operating on
+`anthropicMessage`/`contentBlock` internally; a new OpenAI adapter translates
+in and out so nothing downstream changes.
+
+### 1. Config / wiring (`main()` ~[main.go:481-513](cmd/web-chat/main.go#L481))
+Add env vars (defaults preserve current Anthropic behavior):
+- `LLM_PROVIDER` = `anthropic` (default) | `openai`
+- `LLM_BASE_URL` = e.g. `http://localhost:8000/v1` for local vLLM
+- `LLM_API_KEY`  = falls back to `ANTHROPIC_API_KEY` if unset (vLLM accepts any)
+- `LLM_MODEL`    = e.g. `CohereLabs/North-Mini-Code-1.0` (falls back to `CLAUDE_MODEL`)
+
+Thread `provider`, `baseURL` into `handleChat` (extend its signature, or pass a
+small `llmConfig` struct).
+
+### 2. New `callOpenAI` (sibling of `callAnthropic`, [main.go:243](cmd/web-chat/main.go#L243))
+Same signature shape, returns `*anthropicResponse` so the loop is unchanged.
+- **Request translation** (`anthropicMessage[] + system + tools → OpenAI body`):
+  - `system` → leading `{role:"system"}` message.
+  - String-content messages → `{role, content}`.
+  - Assistant messages whose content is `[]contentBlock`: emit `tool_use` blocks
+    as `tool_calls[]` (`id`, `function.name`, `function.arguments` = JSON string
+    of `Input`); any text block → `content`.
+  - User messages whose content is `[]contentBlock` of `tool_result`: emit one
+    `{role:"tool", tool_call_id, content}` per block.
+  - `anthropicTool` → `{type:"function", function:{name, description, parameters:InputSchema}}`.
+- **HTTP**: POST `LLM_BASE_URL + /chat/completions`, `Authorization: Bearer <key>`.
+- **Response translation** (`choices[0].message → anthropicResponse`):
+  - `message.content` → one `{Type:"text"}` block.
+  - each `message.tool_calls[]` → `{Type:"tool_use", ID, Name, Input}` (Input =
+    raw `function.arguments`).
+  - `finish_reason`: `tool_calls` → leave `StopReason` empty (loop continues);
+    `stop`/`length` → `"end_turn"`.
+
+Add minimal OpenAI structs (`openAIRequest`, `openAIMessage`, `openAIToolCall`,
+`openAIResponse`) in the types section near [main.go:167](cmd/web-chat/main.go#L167).
+
+### 3. Dispatch
+At [main.go:399](cmd/web-chat/main.go#L399) call `callAnthropic` or `callOpenAI`
+based on `provider`. Keep `truncateHistory`/`systemPrompt`/`maxTokens` shared.
+
+## Out of scope
+- No streaming-token support for OpenAI path (current code already buffers
+  per-block; one text block per turn is fine for local testing).
+- No changes to MCP server, model-adapter hints, or production deploy.
+- vLLM server setup (tool-call-parser + Cohere `melody` lib) is the user's local
+  serving step, not a code change here.
+
+## Run via OpenCode Zen (free, recommended for testing)
+No serving needed — OpenCode Zen exposes `north-mini-code-free` over an
+OpenAI-compatible endpoint, which the new `callOpenAI` path already supports.
+Get an API key at https://opencode.ai/auth, then:
+```
+LLM_PROVIDER=openai \
+LLM_BASE_URL=https://opencode.ai/zen/v1 \
+LLM_MODEL=north-mini-code-free \
+LLM_API_KEY=<opencode-zen-key> \
+MCP_URL=http://localhost:3333/mcp-http ./web-chat
+```
+Note: during the free period OpenCode may use submitted data to improve the
+model — do not send sensitive data.
+
+## Verification (local self-host alternative)
+1. Serve the model locally, OpenAI-compatible, e.g.:
+   `vllm serve CohereLabs/North-Mini-Code-1.0 --tool-call-parser <cohere> --enable-auto-tool-choice`
+   (per Cohere docs; needs `melody` for correct parsing).
+2. Build web-chat: `/usr/local/go/bin/go build -o web-chat ./cmd/web-chat/`.
+3. Run:
+   ```
+   LLM_PROVIDER=openai LLM_BASE_URL=http://localhost:8000/v1 \
+   LLM_MODEL=CohereLabs/North-Mini-Code-1.0 LLM_API_KEY=local \
+   MCP_URL=http://localhost:3333/... ./web-chat
+   ```
+4. POST to `/chat` with a question that forces a tool call (e.g. "radiation near
+   Fukushima") and confirm: text streams back AND an MCP tool actually fires
+   (check web-chat logs for `CallTool`). This validates the tool-call round-trip,
+   the main risk with a small model.
+5. Regression: unset `LLM_PROVIDER` (or `=anthropic`) → original Claude path still
+   works unchanged.
+
+## Key files
+- [cmd/web-chat/main.go](cmd/web-chat/main.go) — only file changed.


### PR DESCRIPTION
## What
Adds an env-gated OpenAI-compatible LLM path to `cmd/web-chat` alongside the existing Anthropic call, so the assistant can run non-Claude models — e.g. **Cohere North Mini Code** via **OpenCode Zen** (free) or self-hosted vLLM — without changing the agentic/tool loop.

A translation layer (`callOpenAI` + `anthropicToOpenAIMessages`) maps the internal Anthropic message/tool shape to/from OpenAI chat-completions.

## Config (defaults preserve current Claude behavior)
- `LLM_PROVIDER` = `anthropic` (default) | `openai`
- `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`

### Run with North Mini Code (OpenCode Zen, free)
```
LLM_PROVIDER=openai LLM_BASE_URL=https://opencode.ai/zen/v1 \
LLM_MODEL=north-mini-code-free LLM_API_KEY=<zen-key> \
MCP_URL=http://localhost:3333/mcp-http ./web-chat
```

## Status
⚠️ Compiles and preserves the default Claude path, but the OpenAI path is **not yet verified against a live model**. Plan/verification steps in `docs/plans/web-chat-openai-provider.md`. Hold merge until local tool-call round-trip is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)