### PR TITLE
feat(realtime): backfill full device history from ttserve device-log

### DIFF
--- a/cmd/unified-server/handlers_realtime.go
+++ b/cmd/unified-server/handlers_realtime.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"log"
 	"math"
+	"context"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"safecast-new-map/pkg/database"
@@ -467,6 +469,39 @@ func collectRealtimeMeasurements(input <-chan realtimeMeasurementPayload, now ti
 	return agg
 }
 
+// deviceLogBackfillCooldown limits how often we re-download a device's
+// multi-MB ttserve log. Notecards upload in batches every few hours, so 15
+// minutes is frequent enough to catch new data without redundant downloads.
+const deviceLogBackfillCooldown = 15 * time.Minute
+
+var (
+	deviceLogBackfillMu sync.Mutex
+	deviceLogBackfillAt = map[string]time.Time{}
+)
+
+// backfillDeviceLogIfStale ingests a device's full-resolution ttserve history
+// into realtime_measurements, unless it was already done within the cooldown.
+// It runs synchronously so the response that follows includes the new peaks.
+func backfillDeviceLogIfStale(ctx context.Context, device string, now time.Time) {
+	deviceLogBackfillMu.Lock()
+	last, seen := deviceLogBackfillAt[device]
+	if seen && now.Sub(last) < deviceLogBackfillCooldown {
+		deviceLogBackfillMu.Unlock()
+		return
+	}
+	deviceLogBackfillAt[device] = now
+	deviceLogBackfillMu.Unlock()
+
+	stored, err := safecastrealtime.BackfillDeviceHistory(ctx, db, *dbType, device, now)
+	if err != nil {
+		log.Printf("device-log backfill %s: %v", device, err)
+		return
+	}
+	if stored > 0 {
+		log.Printf("device-log backfill %s: stored %d readings", device, stored)
+	}
+}
+
 // realtimeHistoryHandler returns one year of realtime measurements for a device.
 // The handler keeps the response lightweight so the frontend can draw Grafana-style
 // charts without shipping a dedicated dashboard backend.
@@ -497,6 +532,15 @@ func realtimeHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now()
+
+	// Pull the device's full-resolution history from ttserve's device-log so
+	// transient peaks (hidden by the latest-value /devices poll) are stored
+	// before we build the chart. Gated by a per-device cooldown so opening the
+	// modal repeatedly doesn't re-download the multi-MB log each time.
+	if strings.HasPrefix(device, "note:") {
+		backfillDeviceLogIfStale(r.Context(), device, now)
+	}
+
 	rows, err := db.GetRealtimeHistory(device, 0, *dbType)
 	if err != nil {
 		http.Error(w, "history error", http.StatusInternalServerError)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2918,6 +2918,57 @@ ON CONFLICT(device_id,measured_at) DO NOTHING`,
 	})
 }
 
+// InsertRealtimeMeasurements stores many readings efficiently. For PostgreSQL it
+// uses chunked multi-row INSERTs (one round-trip per chunk) so backfilling a
+// device's full history doesn't fan out into thousands of serialized writes.
+// Other drivers fall back to the per-row path, which is correct if slower.
+func (db *Database) InsertRealtimeMeasurements(ms []RealtimeMeasurement, dbType string) error {
+	if len(ms) == 0 {
+		return nil
+	}
+	if strings.ToLower(dbType) != "pgx" {
+		for _, m := range ms {
+			if err := db.InsertRealtimeMeasurement(m, dbType); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	const cols = 12
+	const chunkRows = 500 // 500*12 = 6000 params, well under Postgres' 65535 limit
+	return db.withSerializedConnectionFor(context.Background(), WorkloadRealtime, func(ctx context.Context, conn *sql.DB) error {
+		for start := 0; start < len(ms); start += chunkRows {
+			end := start + chunkRows
+			if end > len(ms) {
+				end = len(ms)
+			}
+			chunk := ms[start:end]
+
+			var sb strings.Builder
+			sb.WriteString(`INSERT INTO realtime_measurements (device_id,transport,device_name,tube,country,value,unit,lat,lon,measured_at,fetched_at,extra) VALUES `)
+			args := make([]any, 0, len(chunk)*cols)
+			for i, m := range chunk {
+				if i > 0 {
+					sb.WriteByte(',')
+				}
+				base := i * cols
+				fmt.Fprintf(&sb, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6,
+					base+7, base+8, base+9, base+10, base+11, base+12)
+				args = append(args, m.DeviceID, m.Transport, m.DeviceName, m.Tube, m.Country,
+					m.Value, m.Unit, m.Lat, m.Lon, m.MeasuredAt, m.FetchedAt, m.Extra)
+			}
+			sb.WriteString(` ON CONFLICT ON CONSTRAINT realtime_unique DO NOTHING`)
+
+			if _, err := conn.ExecContext(ctx, sb.String(), args...); err != nil {
+				return fmt.Errorf("batch insert realtime: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // GetLatestRealtimeByBounds returns the newest reading per device within bounds.
 // We keep SQL portable and filter duplicates in Go, following "Clear is better than clever".
 func (db *Database) GetLatestRealtimeByBounds(ctx context.Context, minLat, minLon, maxLat, maxLon float64, dbType string) ([]Marker, error) {

--- a/pkg/safecast-realtime/devicelog.go
+++ b/pkg/safecast-realtime/devicelog.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Safecast.  All rights reserved.
+// Use of this source code is governed by licenses granted by the
+// copyright holder including that found in the LICENSE file.
+
+// Device-log backfill: ttserve's /devices feed only exposes each device's
+// latest value (the last reading of each Notehub upload batch), so transient
+// peaks never reach us. ttserve also serves the *full* per-device monthly log
+// at /device-log/<YYYY-MM>$<urn-with-dashes>.json — every ~15-minute reading,
+// peaks included. This file pulls and parses those logs so the history table
+// reflects real peaks rather than sparse snapshots.
+package safecastrealtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"safecast-new-map/pkg/countryresolver"
+	"safecast-new-map/pkg/database"
+)
+
+// deviceLogBaseURL is the ttserve endpoint that serves full per-device history.
+const deviceLogBaseURL = "https://tt.safecast.org/device-log/"
+
+// deviceLogClient bounds device-log downloads so a slow-but-alive ttserve can't
+// hang a request goroutine indefinitely.
+var deviceLogClient = &http.Client{Timeout: 30 * time.Second}
+
+// deviceLogFilename builds a monthly log filename for a device URN, mirroring
+// ttserve's DeviceUIDFilename (colons and dots become dashes).
+// e.g. ("note:dev:867648049106527", June 2026) -> "2026-06$note-dev-867648049106527.json"
+func deviceLogFilename(urn string, month time.Time) string {
+	clean := strings.NewReplacer(":", "-", ".", "-").Replace(urn)
+	return fmt.Sprintf("%s$%s.json", month.UTC().Format("2006-01"), clean)
+}
+
+// FetchDeviceLog downloads and parses one device's monthly history log from
+// ttserve, returning radiation measurements ready to upsert. A missing month
+// (HTTP 404 / "no such file") is not an error — it returns an empty slice.
+func FetchDeviceLog(ctx context.Context, urn string, month time.Time) ([]database.RealtimeMeasurement, error) {
+	url := deviceLogBaseURL + deviceLogFilename(urn, month)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := deviceLogClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+
+	// The log is a stream of devicePayload-compatible JSON objects separated by
+	// "}\n,\n{" with a trailing comma. Normalise it into a JSON array so the
+	// existing devicePayload decoder handles each record.
+	trimmed := bytes.TrimRight(bytes.TrimSpace(body), ",\n\r\t ")
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if trimmed[0] != '{' {
+		// Not a log file (e.g. an error string like "no such file or directory").
+		return nil, nil
+	}
+	wrapped := make([]byte, 0, len(trimmed)+2)
+	wrapped = append(wrapped, '[')
+	wrapped = append(wrapped, trimmed...)
+	wrapped = append(wrapped, ']')
+
+	var payloads []devicePayload
+	if err := json.Unmarshal(wrapped, &payloads); err != nil {
+		return nil, fmt.Errorf("parse device log %s: %w", url, err)
+	}
+
+	fetchedAt := time.Now().Unix()
+	out := make([]database.RealtimeMeasurement, 0, len(payloads))
+	for _, d := range payloads {
+		if d.ID == "" || d.Time == 0 {
+			continue
+		}
+		if _, ok := convertIfRadiation(d); !ok {
+			continue
+		}
+		if d.Lat == 0 && d.Lon == 0 {
+			continue
+		}
+
+		country, _ := countryresolver.Resolve(d.Lat, d.Lon)
+		if country == "" {
+			country = strings.ToUpper(strings.TrimSpace(d.Country))
+		}
+
+		out = append(out, database.RealtimeMeasurement{
+			DeviceID:   d.ID,
+			Transport:  d.Type,
+			DeviceName: d.Name,
+			Tube:       DetectorLabel(d.Tube, d.Type, d.Name),
+			Country:    country,
+			Value:      d.Value,
+			Unit:       d.Unit,
+			Lat:        d.Lat,
+			Lon:        d.Lon,
+			MeasuredAt: d.Time,
+			FetchedAt:  fetchedAt,
+			Extra:      encodeMetrics(d.Metrics),
+		})
+	}
+	return out, nil
+}
+
+// BackfillDeviceHistory fetches the current month's device log (and the
+// previous month when we're early enough that it still matters for a 30-day
+// window) and upserts every reading. Duplicates are skipped by the insert's
+// unique constraint, so repeated calls are cheap and idempotent. It returns the
+// number of rows stored.
+func BackfillDeviceHistory(ctx context.Context, db *database.Database, dbType, urn string, now time.Time) (int, error) {
+	months := []time.Time{now.UTC()}
+	// Include the previous month so the 30-day chart is complete near month start.
+	if now.UTC().Day() <= 30 {
+		months = append(months, now.UTC().AddDate(0, -1, 0))
+	}
+
+	var all []database.RealtimeMeasurement
+	for _, m := range months {
+		measurements, err := FetchDeviceLog(ctx, urn, m)
+		if err != nil {
+			return 0, err
+		}
+		all = append(all, measurements...)
+	}
+	if err := db.InsertRealtimeMeasurements(all, dbType); err != nil {
+		return 0, err
+	}
+	return len(all), nil
+}


### PR DESCRIPTION
## Problem
The realtime chart polls `tt.safecast.org/devices`, which exposes only each device's **latest** value (the last reading of each Notehub upload batch). Notecards log ~every 15 min but upload in batches every few hours, so we stored only ~5 readings/day and **every transient peak was lost** — e.g. the 06/21 spike to 0.4 µSv/h showed as a flat ~0.13 line.

## Root cause
ttserve persists every reading to per-device monthly log files served publicly at `/device-log/<YYYY-MM>$<urn-with-dashes>.json` — full ~15-min resolution, peaks included. We just weren't reading it.

## Fix
- **`devicelog.go`**: `FetchDeviceLog` downloads & parses the monthly log (reuses the existing `devicePayload` decoder); `BackfillDeviceHistory` ingests current + previous month.
- **`InsertRealtimeMeasurements`**: chunked multi-row insert (pgx) so backfill doesn't fan out into thousands of serialized writes.
- **`handlers_realtime.go`**: on-demand backfill on `/realtime_history` requests, 15-min per-device cooldown, 30s HTTP timeout.

Data still comes only from ttserve (no Notehub/Blues credentials needed).

## Verified on production
- Parser: 2,144 June readings, peak 0.395 µSv/h at 06/21 00:41.
- Live API after deploy: month-max **0.17 → 0.395 µSv/h**; day buckets **5 → 23**.
- First call 3.5s (backfill), subsequent calls 1.1s (cooldown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)