### PR TITLE
fix(ci): bump Go 1.24 → 1.25 for mcp-go v0.55.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,21 @@ jobs:
       matrix:
         include:
           # Linux
-          - { goos: linux,  goarch: amd64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: arm64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: 386,   goversion: "1.24", runner: "ubuntu-24.04" }
+          - { goos: linux,  goarch: amd64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: linux,  goarch: arm64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: linux,  goarch: 386,   goversion: "1.25", runner: "ubuntu-24.04" }
           # macOS
-          - { goos: darwin, goarch: amd64, goversion: "1.24", runner: "macos-13" }
-          - { goos: darwin, goarch: arm64, goversion: "1.24", runner: "macos-14" }
+          - { goos: darwin, goarch: amd64, goversion: "1.25", runner: "macos-13" }
+          - { goos: darwin, goarch: arm64, goversion: "1.25", runner: "macos-14" }
           # *BSD
-          - { goos: freebsd, goarch: amd64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: freebsd, goarch: arm64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: amd64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: arm64, goversion: "1.24", runner: "ubuntu-24.04" }
-          - { goos: netbsd,  goarch: amd64, goversion: "1.24", runner: "ubuntu-24.04" }
+          - { goos: freebsd, goarch: amd64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: freebsd, goarch: arm64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: openbsd, goarch: amd64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: openbsd, goarch: arm64, goversion: "1.25", runner: "ubuntu-24.04" }
+          - { goos: netbsd,  goarch: amd64, goversion: "1.25", runner: "ubuntu-24.04" }
           # Windows
-          - { goos: windows, goarch: amd64, goversion: "1.24", runner: "windows-latest" }
-          - { goos: windows, goarch: arm64, goversion: "1.24", runner: "windows-latest" }
+          - { goos: windows, goarch: amd64, goversion: "1.25", runner: "windows-latest" }
+          - { goos: windows, goarch: arm64, goversion: "1.25", runner: "windows-latest" }
 
     steps:
       - name: Checkout
@@ -111,7 +111,7 @@ jobs:
       - name: Build (Linux amd64 duckdb)
         uses: addnab/docker-run-action@v3
         with:
-          image: golang:1.24
+          image: golang:1.25
           options: -v ${{ github.workspace }}:/build -w /build
           run: |
             set -euo pipefail
@@ -139,7 +139,7 @@ jobs:
       matrix:
         include:
           # macOS arm64 (Apple Silicon)
-          - { target: darwin_arm64_duckdb, goos: darwin, goarch: arm64, goversion: "1.24", runner: "macos-14", in_container: false }
+          - { target: darwin_arm64_duckdb, goos: darwin, goarch: arm64, goversion: "1.25", runner: "macos-14", in_container: false }
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
Follow-up to #134. `mcp-go v0.55.1` requires `go >= 1.25.5`, but the release/test workflows pinned Go **1.24** with `GOTOOLCHAIN=local`, so the duckdb build failed:

```
go: go.mod requires go >= 1.25.5 (running go 1.24.13; GOTOOLCHAIN=local)
```

Bumps `setup-go` matrix entries and the `golang:1.24` docker image to `1.25` across [release.yml](.github/workflows/release.yml) and [test.yml](.github/workflows/test.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)