### PR TITLE
fix(map): stop tile cache and date slider from silently dropping markers

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -4593,9 +4593,6 @@ document.addEventListener('DOMContentLoaded', function () {
   if (Array.isArray(initialMarkers) && initialMarkers.length > 0) {
     isTrackView = true;
 
-    // Don't show initialMarkers immediately; load them in parts via get_markers
-    map.on('load', debounceUpdateMarkers);
-
     // Adjust marker size on zoom
     map.on('zoomend', function() {
       invalidateMarkerStyleCache();  // Clear style cache on zoom
@@ -4605,17 +4602,19 @@ document.addEventListener('DOMContentLoaded', function () {
     map.on('moveend', debounceUpdateMarkers);
   } else {
     // Dynamic marker updates in global mode
-    map.on('load', debounceUpdateMarkers);
     map.on('zoomend', function() {
       adjustMarkerRadius();
       debounceUpdateMarkers();
     });
     map.on('moveend', debounceUpdateMarkers);
-    debounceUpdateMarkers;
   }
 
-  // Load map state from URL
+  // Load map state from URL (may call setView, which fires moveend → debounceUpdateMarkers).
+  // Call debounceUpdateMarkers() explicitly here as the fallback: if loadMapFromUrl() ends
+  // up at the same position as the map's initial center (e.g. first visit with no stored
+  // state), Leaflet won't fire moveend and the map would stay blank until the user pans.
   loadMapFromUrl();
+  debounceUpdateMarkers();
 
   // Update URL on map changes
   map.on('baselayerchange', updateUrl);
@@ -5423,12 +5422,6 @@ function updateMarkers(){
 
   const loadingEl = document.getElementById('loadingOverlay');
 
-  if (markerStreamSource) markerStreamSource.close();
-  if (window.markerStreamSources) {
-    window.markerStreamSources.forEach(source => source.close());
-  }
-  window.markerStreamSources = [];
-
   const zoom   = map.getZoom();
   const bounds = map.getBounds();
 
@@ -5448,7 +5441,7 @@ function updateMarkers(){
     baseParams.maxLat = 90;
     baseParams.maxLon = 180;
   }
-  
+
   // When viewing multiple tracks, load all markers for those tracks
   if (currentTrackIDs && currentTrackIDs.length > 0) {
     baseParams.trackIDs = currentTrackIDs.join(',');
@@ -5466,11 +5459,13 @@ function updateMarkers(){
 
   const savedRange = loadDateRangeState();
 
-  // Skip if viewport hasn't meaningfully changed (prevents unnecessary redraws)
+  // Check viewport/filter state BEFORE closing in-flight streams.
+  // The old order closed streams first, so an unchanged-viewport early-return
+  // killed the loading stream and left the map blank until the next user action.
   const newViewportKey = getViewportKey();
   const newFilterState = getFilterStateKey();
   const filterChanged = lastFilterState !== newFilterState;
-  
+
   if (lastViewportKey === newViewportKey && lastFilterState === newFilterState && !currentTrackID && !currentTrackIDs) {
     // Viewport and filters unchanged in global view - skip full redraw
     return;
@@ -5482,6 +5477,15 @@ function updateMarkers(){
     // Track view: markers already loaded and filters unchanged - skip reload
     return;
   }
+
+  // Close any in-flight streams now that we know we're going to fetch.
+  // (Moved here from the top of the function so the early-returns above don't
+  // kill a loading stream and leave the map blank.)
+  if (markerStreamSource) markerStreamSource.close();
+  if (window.markerStreamSources) {
+    window.markerStreamSources.forEach(source => source.close());
+  }
+  window.markerStreamSources = [];
 
   // Show spinner only when we are actually going to fetch data
   if (loadingEl) loadingEl.style.display='block';

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -4961,6 +4961,13 @@ function createDateRangeSlider(){
       !!saved && !(saved[0] === prevFull?.[0] && saved[1] === prevFull?.[1]) &&
       !(saved[0] === fullRange[0] && saved[1] === fullRange[1]);
 
+    // Migrate sessions poisoned by the old auto-save: a saved range that
+    // merely mirrors a viewport full range is not a user filter — drop it
+    // so it stops filtering markers on the next redraw.
+    if (!hasCustom && saved) {
+      sessionStorage.removeItem('dateRangeState');
+    }
+
     // Update YEAR slider bounds
     const minYear = new Date(minTs*1000).getUTCFullYear();
     const maxYear = new Date(maxTs*1000).getUTCFullYear();
@@ -4984,8 +4991,11 @@ function createDateRangeSlider(){
         lblMin().textContent = tsToNiceStr(minTs);
         lblMax().textContent = tsToNiceStr(maxTs);
       }
-      // persist that "no filter" means full range
-      saveDateRangeState([minTs,maxTs]);
+      // "No filter" is represented by the ABSENCE of saved state.
+      // Auto-saving the viewport's data range here poisoned the filter:
+      // the next viewport applied the previous viewport's range as a hard
+      // date filter, progressively dropping markers (and churning the
+      // tile cache via constant filter-state changes).
     }
   };
 
@@ -5001,8 +5011,7 @@ function createDateRangeSlider(){
       lblMin().textContent = (mode==='year') ? rY.min : tsToNiceStr(rM.min);
       lblMax().textContent = (mode==='year') ? rY.max : tsToNiceStr(rM.max);
 
-      // remember "no filter" == full range of the viewport
-      saveDateRangeState([rM.min, rM.max]);
+      // "No filter" == no saved state (removed above); do not re-save here.
       debounceUpdateMarkers();
     }
   };
@@ -6012,6 +6021,14 @@ function setupMarkerStream(es, tracks, markerDateRange, savedRange, tileIndex, c
       markerBounds.maxLon = Math.max(markerBounds.maxLon, m.lon);
       markerBounds.hasData = true;
     }
+
+    // Cache the UNFILTERED marker so cache hits can re-apply the current
+    // filters at render time. Caching post-filter data poisoned the tile
+    // cache: points dropped by a stale date range were lost for the TTL.
+    if (tileMarkers) {
+      tileMarkers.push(m);
+    }
+
     if (savedRange && (m.date < savedRange[0] || m.date > savedRange[1])) return;
 
     // Show spectrum markers independently from speed filter if spectrum toggle is on
@@ -6033,11 +6050,6 @@ function setupMarkerStream(es, tracks, markerDateRange, savedRange, tileIndex, c
     markerCount++;
     queueMarkerForBatch(marker, m.id);
     circleMarkers[m.id || m.trackID] = marker;
-
-    // Collect marker data for caching
-    if (tileMarkers) {
-      tileMarkers.push(m);
-    }
   };
 
   // Register handler for worker messages (if using worker)


### PR DESCRIPTION
## Summary

- **Root cause:** Two interacting bugs created a ratchet that progressively dropped map markers on each pan/zoom. (1) The tile cache stored post-filter marker data, so a stale date range permanently evicted points for the cache TTL. (2) The date slider auto-saved the viewport's current data range as if it were a user filter, so the next viewport would apply the previous viewport's range as a hard filter.

- **Fix 1 — tile cache:** Move `tileMarkers.push(m)` to before the date/speed filter in `handleParsedMarker`. Cache hits now hold unfiltered data and re-apply the current filters at render time.

- **Fix 2 — date slider:** Remove the two `saveDateRangeState` calls in the `__syncDateSliders` sync branch and the reset button handler. "No filter" is now represented by the absence of saved state rather than saving the viewport's full range.

- **Migration:** Sessions already poisoned by the old auto-save are healed on the next `__syncDateSliders` call: if the saved range merely mirrors the viewport's full range (`hasCustom === false`) and a saved value exists, `sessionStorage.removeItem('dateRangeState')` clears it.

## Test plan

- [ ] Load a track, pan/zoom several times — confirm no markers disappear
- [ ] Set a real date filter, pan/zoom — confirm filter is respected and markers outside range are hidden
- [ ] Clear the date filter — confirm all markers reappear on next redraw
- [ ] Reload the page with a stale `dateRangeState` in sessionStorage that equals the full range — confirm it is cleared and all markers load

🤖 Generated with [Claude Code](https://claude.com/claude-code)