### PR TITLE
sync(map): selective port of Matvey's marker redraw and responsive controls fixes

### DIFF
--- a/cmd/unified-server/handlers_tracks.go
+++ b/cmd/unified-server/handlers_tracks.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
@@ -20,6 +21,13 @@ import (
 	"safecast-new-map/pkg/database"
 	safecastrealtime "safecast-new-map/pkg/safecast-realtime"
 )
+
+func logRealtimeQueryError(err error) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	logRealtimeQueryError(err)
+}
 
 func trackHandler(w http.ResponseWriter, r *http.Request) {
 	lang := getPreferredLanguage(r)
@@ -345,7 +353,7 @@ func getMarkersHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				markers = append(markers, rt...)
 			} else {
-				log.Printf("realtime query: %v", err)
+				logRealtimeQueryError(err)
 			}
 		}
 	} else {
@@ -370,7 +378,7 @@ func getMarkersHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				markers = append(markers, rt...)
 			} else {
-				log.Printf("realtime query: %v", err)
+				logRealtimeQueryError(err)
 			}
 		}
 	}
@@ -391,6 +399,39 @@ func aggregateMarkers(ctx context.Context, base <-chan database.Marker, updates 
 	out := make(chan database.Marker)
 	go func() {
 		defer close(out)
+
+		// At zoom ≥ 13 every marker is distinct enough to show individually —
+		// skip cell-based deduplication so walking tracks retain all points.
+		if zoom >= 13 {
+			for base != nil || updates != nil {
+				select {
+				case <-ctx.Done():
+					return
+				case m, ok := <-base:
+					if !ok {
+						base = nil
+						continue
+					}
+					select {
+					case out <- m:
+					case <-ctx.Done():
+						return
+					}
+				case m, ok := <-updates:
+					if !ok {
+						updates = nil
+						continue
+					}
+					select {
+					case out <- m:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			return
+		}
+
 		cells := make(map[string]database.Marker)
 		scale := math.Pow(2, float64(zoom))
 		baseCh := base
@@ -457,6 +498,9 @@ func calculateSampleRate(zoom int, minLat, minLon, maxLat, maxLon float64) float
 	latSpan := maxLat - minLat
 	lonSpan := maxLon - minLon
 	area := latSpan * lonSpan
+	if area <= 1 {
+		return 1.0
+	}
 
 	// For very large areas at low zoom, more aggressive sampling is needed
 	// At zoom 7, Europe view is ~9.5 lat × 19.5 lon ≈ 185 sq degrees
@@ -646,7 +690,7 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 		var err error
 		rtMarks, err = db.GetLatestRealtimeByBounds(ctx, minLat, minLon, maxLat, maxLon, *dbType)
 		if err != nil {
-			log.Printf("realtime query: %v", err)
+			logRealtimeQueryError(err)
 		}
 		// Log bounds alongside count to help diagnose empty map tiles.
 		log.Printf("realtime markers: %d lat[%f,%f] lon[%f,%f]", len(rtMarks), minLat, maxLat, minLon, maxLon)

--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -235,6 +235,103 @@ body, html {
           color: var(--modal-text);
         }
 
+        #legend {
+          position: absolute;
+          top: 284px;
+          bottom: 104px;
+          right: 20px;
+          background: var(--control-bg);
+          border: var(--legend-border);
+          border-radius: 4px;
+          box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+          padding: 4px;
+          font-size: var(--font-size-xs);
+          cursor: pointer;
+          z-index: 1000;
+          font-family: var(--font-family-base);
+          display: flex;
+          box-sizing: border-box;
+        }
+
+        #legend.legend--safecast {
+          height: auto;
+          min-height: 0;
+        }
+
+        #legend.legend--chicha {
+          height: min(160px, calc(100vh - 388px));
+          bottom: auto;
+        }
+
+        #legend-bar {
+          width: 18px;
+          margin-right: 6px;
+          border-radius: 10px;
+          border: 1px solid rgba(0,0,0,0.2);
+          flex: 0 0 auto;
+        }
+
+        #legend-labels {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          height: 100%;
+          font-weight: 700;
+          min-width: 30px;
+          text-align: left;
+          line-height: 1;
+        }
+
+        #legend-unit-overlay {
+          position: absolute;
+          bottom: 14px;
+          right: 4px;
+          width: 100%;
+          text-align: center;
+          font-size: var(--font-size-xs);
+          font-weight: 700;
+          color: white;
+          text-shadow: 0 1px 3px rgba(0,0,0,0.9), 0 0 6px rgba(0,0,0,0.7);
+          pointer-events: none;
+        }
+
+        @media (max-width: 600px) {
+          #legend {
+            right: 20px;
+            padding: 3px;
+            font-size: var(--font-size-xxs);
+          }
+
+          #legend.legend--safecast {
+            height: auto;
+            min-height: 0;
+          }
+
+          #legend.legend--chicha {
+            height: 140px;
+          }
+
+          #legend-bar {
+            width: 16px;
+            margin-right: 5px;
+          }
+
+          #legend-labels {
+            min-width: 26px;
+          }
+
+          #legend-unit-overlay {
+            bottom: 10px;
+            font-size: var(--font-size-xxs);
+          }
+        }
+
+        @media (max-height: 560px) {
+          #legend.legend--chicha {
+            height: 120px;
+          }
+        }
+
         /* Old short link display - now hidden, replaced by icon button */
         #shortLinkDisplay {
           display: none !important;
@@ -929,11 +1026,12 @@ body, html {
         .search-container {
           position: absolute;
           top: 20px;
-          left: 50%;
-          transform: translateX(-50%);
+          left: 64px;
+          right: 140px;
           z-index: 1001;
-          width: 90%;
+          width: auto;
           max-width: 400px;
+          margin: 0 auto;
         }
 
         /* Search input field */
@@ -981,6 +1079,25 @@ body, html {
 
         .search-results.active {
           display: block;
+        }
+
+        @media (max-width: 760px) {
+          .search-container {
+            max-width: none;
+            margin: 0;
+          }
+        }
+
+        @media (max-width: 420px) {
+          .search-container {
+            left: 56px;
+            right: 132px;
+          }
+
+          .search-input {
+            padding-left: 10px;
+            padding-right: 32px;
+          }
         }
 
         .search-result-item {
@@ -2057,25 +2174,11 @@ body, html {
   transition: background 0.2s;">⇄</button>
 
 <!-- Compact Legend (clickable) -->
-<div id="legend" role="button" tabindex="0" aria-label="{{translate "legend_button_tooltip"}}" style="
-  position: absolute;
-  bottom: 50px;
-  right: 10px;
-  background: var(--control-bg);
-  border: var(--legend-border);
-  border-radius: 4px;
-  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
-  padding: 5px;
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  z-index: 1000;
-  font-family: var(--font-family-base);
-  height: 500px;
-  display: flex;">
-    <div id="legend-bar" style="width:24px; margin-right:8px; border-radius:12px; border: 1px solid rgba(0,0,0,0.2);"></div>
-    <div id="legend-labels" style="display:flex; flex-direction:column; justify-content:space-between; height:100%; font-weight:bold; min-width:35px; text-align:left;">
+<div id="legend" class="legend--safecast" role="button" tabindex="0" aria-label="{{translate "legend_button_tooltip"}}">
+    <div id="legend-bar"></div>
+    <div id="legend-labels">
     </div>
-    <div style="position:absolute; bottom:20px;right:5px;width:100%;text-align:center; font-size:15px; font-weight:bold; color:white; text-shadow: 0 1px 3px rgba(0,0,0,0.9), 0 0 6px rgba(0,0,0,0.7);">
+    <div id="legend-unit-overlay">
        <span id="legend-unit-label">µSv/h</span>
     </div>
 </div>
@@ -2539,7 +2642,8 @@ body, html {
       // Check authentication status on page load
       async function checkAuthStatus() {
         try {
-          const response = await fetch('/api/user/profile');
+          const profileURL = new URL('/api/user/profile', window.location.href);
+          const response = await fetch(profileURL.href, { credentials: 'same-origin' });
           if (response.ok) {
             currentUser = await response.json();
             updateUIForLoggedInUser();
@@ -3539,6 +3643,7 @@ var currentTrackID = null;
 var currentTrackSourceURL = null;
 var currentTrackIDs = null;  // For multiple tracks view
 var lastViewportKey = null;
+var lastLoadedMarkerZoom = null;
 var lastFilterState = null;  // Track filter state to detect changes
 
 /* ===== WEB WORKER FOR JSON PARSING ===== */
@@ -4610,11 +4715,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // Load map state from URL (may call setView, which fires moveend → debounceUpdateMarkers).
-  // Call debounceUpdateMarkers() explicitly here as the fallback: if loadMapFromUrl() ends
-  // up at the same position as the map's initial center (e.g. first visit with no stored
-  // state), Leaflet won't fire moveend and the map would stay blank until the user pans.
   loadMapFromUrl();
-  debounceUpdateMarkers();
+  scheduleInitialMarkerRefreshAfterMapStateLoad();
 
   // Update URL on map changes
   map.on('baselayerchange', updateUrl);
@@ -5010,7 +5112,8 @@ function createDateRangeSlider(){
       lblMin().textContent = (mode==='year') ? rY.min : tsToNiceStr(rM.min);
       lblMax().textContent = (mode==='year') ? rY.max : tsToNiceStr(rM.max);
 
-      // "No filter" == no saved state (removed above); do not re-save here.
+      clearRenderedMarkers();
+      lastViewportKey = null;
       debounceUpdateMarkers();
     }
   };
@@ -5402,6 +5505,33 @@ function getCachedMarkerStyle(doseRate, zoom, speed) {
   return style;
 }
 
+function closeMarkerStreams() {
+  if (markerStreamSource) {
+    markerStreamSource.close();
+    markerStreamSource = null;
+  }
+  if (window.markerStreamSources) {
+    window.markerStreamSources.forEach(function(source) {
+      if (source) source.close();
+    });
+  }
+  window.markerStreamSources = [];
+}
+
+function clearRenderedMarkers() {
+  markerBatch.length = 0;
+  cancelPendingFlush();
+
+  for (const key in circleMarkers) {
+    const marker = circleMarkers[key];
+    if (!marker) continue;
+    map.removeLayer(marker);
+    markerPool.release(marker);
+  }
+  circleMarkers = {};
+  markerQuadTree.clear();
+}
+
 // Clear cache when zoom changes
 function invalidateMarkerStyleCache() {
   if (lastStyleCacheZoom !== map.getZoom()) {
@@ -5465,33 +5595,31 @@ function updateMarkers(){
   const newViewportKey = getViewportKey();
   const newFilterState = getFilterStateKey();
   const filterChanged = lastFilterState !== newFilterState;
+  const zoomChanged = lastLoadedMarkerZoom !== null && lastLoadedMarkerZoom !== zoom;
 
   if (lastViewportKey === newViewportKey && lastFilterState === newFilterState && !currentTrackID && !currentTrackIDs) {
     // Viewport and filters unchanged in global view - skip full redraw
     return;
   }
 
-  // In track view, only reload if filters changed or this is the first load
-  // We load ALL markers at once, so viewport changes don't require reloading
-  if ((currentTrackID || currentTrackIDs) && !filterChanged && Object.keys(circleMarkers).length > 0) {
-    // Track view: markers already loaded and filters unchanged - skip reload
+  // In track view, only reload if filters changed, zoom changed, or this is the first load.
+  // Zoom changes matter because aggregateMarkers behaviour changes at zoom ≥ 13.
+  if ((currentTrackID || currentTrackIDs) && !filterChanged && !zoomChanged && Object.keys(circleMarkers).length > 0) {
+    // Track view: markers already loaded and nothing relevant changed - skip reload
     return;
   }
 
   // Close any in-flight streams now that we know we're going to fetch.
   // (Moved here from the top of the function so the early-returns above don't
   // kill a loading stream and leave the map blank.)
-  if (markerStreamSource) markerStreamSource.close();
-  if (window.markerStreamSources) {
-    window.markerStreamSources.forEach(source => source.close());
-  }
-  window.markerStreamSources = [];
+  closeMarkerStreams();
 
   // Show spinner only when we are actually going to fetch data
   if (loadingEl) loadingEl.style.display='block';
 
   lastViewportKey = newViewportKey;
-  lastFilterState = newFilterState;  // Track filter state to detect future changes
+  lastFilterState = newFilterState;
+  lastLoadedMarkerZoom = zoom;
 
   // If filters changed, clear all markers to re-filter them
   if (filterChanged) {
@@ -8275,6 +8403,25 @@ function updateRenderMetrics(markerCount, renderTimeMs) {
   lastMarkerCount = markerCount;
   // Exponential moving average: 70% old, 30% new for stability
   lastRenderTime = lastRenderTime * 0.7 + renderTimeMs * 0.3;
+}
+
+function scheduleInitialMarkerRefreshAfterMapStateLoad() {
+  map.whenReady(function() {
+    const forceInitialMarkerLoad = function() {
+      if (Object.keys(circleMarkers).length > 0) return;
+      if (map.invalidateSize) map.invalidateSize(false);
+      closeMarkerStreams();
+      markerBatch.length = 0;
+      cancelPendingFlush();
+      lastViewportKey = null;
+      updateMarkers();
+    };
+    window.requestAnimationFrame(function() {
+      window.requestAnimationFrame(forceInitialMarkerLoad);
+    });
+    window.setTimeout(forceInitialMarkerLoad, 250);
+    window.setTimeout(forceInitialMarkerLoad, 1000);
+  });
 }
 
 function debounceUpdateMarkers() {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1120,7 +1120,10 @@ CREATE TABLE IF NOT EXISTS uploads (
   user_id         TEXT,
   username        TEXT,
   internal_user_id TEXT,
-  detector        TEXT
+  detector        TEXT,
+  name            TEXT,
+  notes           TEXT,
+  comment         TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_uploads_track_id ON uploads(track_id);
@@ -1204,6 +1207,51 @@ CREATE TABLE IF NOT EXISTS translations (
 
 CREATE INDEX IF NOT EXISTS idx_translations_lang ON translations(language_code);
 CREATE INDEX IF NOT EXISTS idx_translations_key ON translations(key);
+
+CREATE TABLE IF NOT EXISTS tour_steps (
+  id BIGSERIAL PRIMARY KEY,
+  step_key VARCHAR(64) NOT NULL UNIQUE,
+  sort_order INTEGER NOT NULL,
+  selector TEXT NOT NULL,
+  center BOOLEAN NOT NULL DEFAULT FALSE,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  require_login BOOLEAN,
+  require_admin BOOLEAN,
+  show_if_feature VARCHAR(64),
+  viewport VARCHAR(16) NOT NULL DEFAULT 'any',
+  first_time_only BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT tour_steps_viewport_check CHECK (viewport IN ('any', 'desktop', 'mobile'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tour_steps_order ON tour_steps(sort_order);
+
+CREATE TABLE IF NOT EXISTS ai_hints (
+  id BIGSERIAL PRIMARY KEY,
+  model VARCHAR(64) NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  capabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+  system_prompt TEXT NOT NULL DEFAULT '',
+  tools JSONB NOT NULL DEFAULT '{}'::jsonb,
+  global_formatting_rules JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_model ON ai_hints(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_deleted_at ON ai_hints(deleted_at);
+
+CREATE TABLE IF NOT EXISTS ai_hints_history (
+  id BIGSERIAL PRIMARY KEY,
+  model VARCHAR(64) NOT NULL,
+  snapshot JSONB NOT NULL,
+  change_kind VARCHAR(32) NOT NULL,
+  changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_model ON ai_hints_history(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_changed_at ON ai_hints_history(changed_at DESC);
 `
 
 	case "sqlite", "chai":
@@ -1301,7 +1349,10 @@ CREATE TABLE IF NOT EXISTS uploads (
   user_id         TEXT,
   username        TEXT,
   internal_user_id TEXT,
-  detector        TEXT
+  detector        TEXT,
+  name            TEXT,
+  notes           TEXT,
+  comment         TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_uploads_track_id ON uploads(track_id);
 CREATE INDEX IF NOT EXISTS idx_uploads_created_at ON uploads(created_at);
@@ -1387,6 +1438,51 @@ CREATE TABLE IF NOT EXISTS translations (
 
 CREATE INDEX IF NOT EXISTS idx_translations_lang ON translations(language_code);
 CREATE INDEX IF NOT EXISTS idx_translations_key ON translations(key);
+
+CREATE TABLE IF NOT EXISTS tour_steps (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  step_key TEXT NOT NULL UNIQUE,
+  sort_order INTEGER NOT NULL,
+  selector TEXT NOT NULL,
+  center INTEGER NOT NULL DEFAULT 0,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  require_login INTEGER,
+  require_admin INTEGER,
+  show_if_feature TEXT,
+  viewport TEXT NOT NULL DEFAULT 'any',
+  first_time_only INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT DEFAULT (datetime('now')),
+  CONSTRAINT tour_steps_viewport_check CHECK (viewport IN ('any', 'desktop', 'mobile'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tour_steps_order ON tour_steps(sort_order);
+
+CREATE TABLE IF NOT EXISTS ai_hints (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  model TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  capabilities TEXT NOT NULL DEFAULT '[]',
+  system_prompt TEXT NOT NULL DEFAULT '',
+  tools TEXT NOT NULL DEFAULT '{}',
+  global_formatting_rules TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_model ON ai_hints(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_deleted_at ON ai_hints(deleted_at);
+
+CREATE TABLE IF NOT EXISTS ai_hints_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  model TEXT NOT NULL,
+  snapshot TEXT NOT NULL,
+  change_kind TEXT NOT NULL,
+  changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_model ON ai_hints_history(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_changed_at ON ai_hints_history(changed_at DESC);
 `
 
 	case "duckdb":
@@ -1489,7 +1585,10 @@ CREATE TABLE IF NOT EXISTS uploads (
   user_id         TEXT,
   username        TEXT,
   internal_user_id TEXT,
-  detector        TEXT
+  detector        TEXT,
+  name            TEXT,
+  notes           TEXT,
+  comment         TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_uploads_track_id ON uploads(track_id);
 CREATE INDEX IF NOT EXISTS idx_uploads_created_at ON uploads(created_at);
@@ -1562,6 +1661,54 @@ CREATE TABLE IF NOT EXISTS email_verification_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token ON email_verification_tokens(token);
 CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user_id ON email_verification_tokens(user_id);
+
+CREATE SEQUENCE IF NOT EXISTS tour_steps_id_seq START 1;
+CREATE TABLE IF NOT EXISTS tour_steps (
+  id BIGINT PRIMARY KEY DEFAULT nextval('tour_steps_id_seq'),
+  step_key TEXT NOT NULL UNIQUE,
+  sort_order INTEGER NOT NULL,
+  selector TEXT NOT NULL,
+  center BOOLEAN NOT NULL DEFAULT FALSE,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  require_login BOOLEAN,
+  require_admin BOOLEAN,
+  show_if_feature TEXT,
+  viewport TEXT NOT NULL DEFAULT 'any',
+  first_time_only BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_at TIMESTAMP DEFAULT NOW(),
+  CONSTRAINT tour_steps_viewport_check CHECK (viewport IN ('any', 'desktop', 'mobile'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tour_steps_order ON tour_steps(sort_order);
+
+CREATE SEQUENCE IF NOT EXISTS ai_hints_id_seq START 1;
+CREATE TABLE IF NOT EXISTS ai_hints (
+  id BIGINT PRIMARY KEY DEFAULT nextval('ai_hints_id_seq'),
+  model TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  capabilities JSON NOT NULL DEFAULT '[]',
+  system_prompt TEXT NOT NULL DEFAULT '',
+  tools JSON NOT NULL DEFAULT '{}',
+  global_formatting_rules JSON NOT NULL DEFAULT '{}',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_model ON ai_hints(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_deleted_at ON ai_hints(deleted_at);
+
+CREATE SEQUENCE IF NOT EXISTS ai_hints_history_id_seq START 1;
+CREATE TABLE IF NOT EXISTS ai_hints_history (
+  id BIGINT PRIMARY KEY DEFAULT nextval('ai_hints_history_id_seq'),
+  model TEXT NOT NULL,
+  snapshot JSON NOT NULL,
+  change_kind TEXT NOT NULL,
+  changed_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_model ON ai_hints_history(model);
+CREATE INDEX IF NOT EXISTS idx_ai_hints_history_changed_at ON ai_hints_history(changed_at DESC);
 `
 
 	case "clickhouse":
@@ -1884,6 +2031,9 @@ func (db *Database) ensureUploadsMetadataColumns(dbType string) error {
 	required := []column{
 		{name: "source", def: "source TEXT"},
 		{name: "source_id", def: "source_id TEXT"},
+		{name: "name", def: "name TEXT"},
+		{name: "notes", def: "notes TEXT"},
+		{name: "comment", def: "comment TEXT"},
 	}
 
 	switch strings.ToLower(dbType) {
@@ -1905,7 +2055,12 @@ func (db *Database) ensureUploadsMetadataColumns(dbType string) error {
 		return nil
 
 	case "clickhouse":
-		// ClickHouse schema already contains these columns.
+		for _, col := range required {
+			stmt := fmt.Sprintf("ALTER TABLE uploads ADD COLUMN IF NOT EXISTS %s String", col.name)
+			if _, err := db.DB.Exec(stmt); err != nil {
+				return err
+			}
+		}
 		return nil
 
 	default:


### PR DESCRIPTION
## Summary

Selectively ports the good changes from Codeberg PR #17 (matveynator) that don't conflict with existing work and don't remove features.

**Server-side (handlers_tracks.go)**
- `logRealtimeQueryError`: suppress noisy `context.Canceled` log entries from realtime queries
- `aggregateMarkers` zoom ≥ 13 passthrough: skip cell-based deduplication at close zoom so walking tracks keep all their points (pairs with the client-side tile cache fix in #137)
- `calculateSampleRate`: small viewport (≤ 1 sq degree) always returns 100% of markers

**Frontend (map.html)**
- Legend CSS: replace 500px inline style with proper CSS classes (`legend--safecast` / `legend--chicha`) and responsive media queries for 600px width and 560px height breakpoints
- Search bar: responsive left/right anchoring instead of `left:50% + translateX(-50%)`; media queries for 760px and 420px
- `credentials: 'same-origin'` on `/api/user/profile` fetch
- `closeMarkerStreams()` / `clearRenderedMarkers()` helpers for cleaner stream lifecycle management
- `scheduleInitialMarkerRefreshAfterMapStateLoad()`: robust initial load using `map.whenReady` + double-rAF + fallback timeouts (replaces bare `debounceUpdateMarkers()`)
- `lastLoadedMarkerZoom` tracking so track view reloads when zoom changes (needed alongside the zoom ≥ 13 server passthrough)
- Reset button forces full reload via `clearRenderedMarkers()` + `lastViewportKey = null`

**Database (database.go)**
- `uploads` table: add `name`, `notes`, `comment` columns across pgx, sqlite, duckdb schemas
- `ensureUploadsMetadataColumns`: migrate existing installations lazily
- ClickHouse: actually run `ALTER TABLE` instead of silently skipping
- `tour_steps`, `ai_hints`, `ai_hints_history` DDL added to pgx, sqlite, and duckdb schema blocks

## What was NOT taken
- Removal of `bufio` 64KB buffered writer in `streamMarkersHandler` (our batched flush is significantly faster)
- Removal of `X-Accel-Buffering: no` header (required for nginx SSE streaming)
- Removal of `max` field from `realtimePoint` (used by realtime charts)
- Feature deletions: `devicelog.go`, `admin_qa_embeddings`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)