### PR TITLE
fix(map): disable marker parse worker that silently dropped markers

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -3676,11 +3676,19 @@ function initMarkerWorker() {
   }
 }
 
-// Initialize worker on page load
-if (typeof Worker !== 'undefined') {
-  // Defer initialization to avoid blocking page load
-  setTimeout(initMarkerWorker, 100);
-}
+// DISABLED (upstream alignment): the marker parse worker is intentionally not
+// initialized. It parses asynchronously, but handleStreamComplete deletes the
+// stream's worker handler synchronously when the SSE 'done' event fires — so
+// every marker still queued in the worker at that moment looked up a deleted
+// handler and was silently dropped. Because the server coalesces markers into
+// 64KB bursts followed immediately by 'done', large tiles lost most/all of
+// their markers (whole regions vanished on the map). Upstream chicha-isotope-map
+// has no worker and parses on the main thread, where SSE 'data:' events are
+// dispatched in order and fully queued before 'done'. Main-thread JSON.parse of
+// a viewport's markers is only a few ms, so the worker's benefit was marginal.
+// setupMarkerStream falls back to synchronous main-thread parsing when
+// markerWorker is null. See initMarkerWorker() above if this is ever revived —
+// it must first implement a worker drain/ack before deleting the handler.
 /* ===== END WORKER ===== */
 
 /* ===== MESSAGEPACK BINARY STREAMING =====


### PR DESCRIPTION
## Symptom
Whole regions of markers missing on the map at zoom 15, even after removing the tile cache (PR #139). Reported viewport: Port Hope, ON.

## Proof it's a client render-loss, not data/server
Queried `/stream_markers` directly for the exact viewport:
- Full viewport: **852 markers**
- All four client quadrants populated: SW=232, SE=77, **NW=359**, NE=187
- IDs unique, all `speed>0` (car bucket, shown by default)

So the server sends every marker; the client drops them.

## Root cause
Markers are parsed in a **Web Worker**. `handleStreamComplete` deletes the stream's worker handler **synchronously** when the SSE `done` event fires:

```
workerMessageHandlers.delete(currentStreamId);
```

The worker parses **asynchronously**. The server coalesces markers into 64KB bursts immediately followed by `done`, so at the moment `done` fires the worker still has a large backlog. Every marker it parses after the handler is deleted hits `workerMessageHandlers.get(streamId) → undefined` and is silently dropped. Larger tiles (NW=359) lose the most — matching the screenshot where whole northern regions vanished.

Upstream `chicha-isotope-map` has **no worker** and parses on the main thread, where SSE `data:` events are dispatched in order and fully queued before `done`. No race.

## Fix
Do not initialize the marker worker. `setupMarkerStream` already falls back to synchronous main-thread `JSON.parse` when `markerWorker` is null. Parsing a viewport's markers on the main thread is a few ms — the worker's benefit was marginal and it broke correctness.

Reviving the worker requires a drain/ack handshake before deleting the handler (noted in a comment at the init site).

## Testing
- `go build -tags duckdb` passes
- Server-side marker counts verified via curl (above)
- Needs runtime verification on deploy: reload the reported viewport and confirm the northern regions populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)