### PR TITLE
fix(shorten): accept public host behind CloudFront (fixes /api/shorten 400)

### DIFF
--- a/cmd/unified-server/main.go
+++ b/cmd/unified-server/main.go
@@ -1014,6 +1014,7 @@ func main() {
 	// routes avoids surprises for operators scanning main() for handlers.
 	limiter := httpapi.NewRateLimiter(time.Minute)
 	apiHandler := httpapi.NewHandler(db, *dbType, archiveGen, limiter, log.Printf, archiveFrequency)
+	apiHandler.PublicBaseURL = *baseURL // viewer-facing base URL for short links behind CloudFront
 	restHandler := &RESTHandler{}
 
 	// Keep MCP/realtime/translations admin APIs aligned with the legacy behavior:

--- a/pkg/httpapi/handlers_core.go
+++ b/pkg/httpapi/handlers_core.go
@@ -35,6 +35,10 @@ type Handler struct {
 	Logf             func(string, ...any)
 	Cache            *ResponseCache
 	TrackInfo        *TrackInfoCache // Cache expensive COUNT(DISTINCT) metadata so /api stays fast even on huge datasets.
+	// PublicBaseURL is the viewer-facing base URL (e.g. https://simplemap.safecast.org),
+	// wired from the -base-url flag. Behind CloudFront the origin only sees the internal
+	// origin host as Host, so short links need this to accept and emit the public domain.
+	PublicBaseURL string
 }
 
 // NewHandler constructs a Handler with sane defaults.
@@ -183,8 +187,10 @@ func (h *Handler) handleShorten(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scheme := requestScheme(r)
-	host := requestHost(r)
+	// The viewer-facing scheme/host used to build the short link. Behind
+	// CloudFront the origin only sees the internal origin host, so we resolve
+	// the public host from -base-url / Referer rather than r.Host alone.
+	scheme, host := h.publicBase(r)
 	if host == "" {
 		writeJSONError(w, http.StatusBadRequest, "missing host")
 		return
@@ -210,11 +216,16 @@ func (h *Handler) handleShorten(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "unsupported scheme")
 			return
 		}
-		if !strings.EqualFold(strings.TrimSpace(parsed.Host), host) {
+		// Accept the app's own host under any of its faces (public domain,
+		// origin host, Referer). Truly foreign hosts are still rejected. We
+		// then rebuild the stored target against the canonical public host so
+		// the link is same-origin and uses the viewer-facing domain.
+		if !h.shortLinkAllowedHosts(r)[strings.ToLower(strings.TrimSpace(parsed.Host))] {
 			writeJSONError(w, http.StatusBadRequest, "foreign host rejected")
 			return
 		}
-		target = parsed.String()
+		rebuilt := &url.URL{Scheme: scheme, Host: host, Path: parsed.Path, RawQuery: parsed.RawQuery}
+		target = rebuilt.String()
 	}
 
 	if len(target) > 4096 {
@@ -1462,6 +1473,67 @@ func requestHost(r *http.Request) string {
 		return forwarded
 	}
 	return ""
+}
+
+// isLocalHost reports whether host is a loopback/dev host we should not treat
+// as the canonical public host for building short links.
+func isLocalHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if i := strings.LastIndexByte(host, ':'); i >= 0 {
+		host = host[:i] // strip :port
+	}
+	switch host {
+	case "localhost", "127.0.0.1", "0.0.0.0", "::1", "":
+		return true
+	}
+	return false
+}
+
+// hostFromURL parses raw and returns its lowercase host, or "" if it has none.
+func hostFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if u, err := url.Parse(raw); err == nil {
+		return strings.ToLower(strings.TrimSpace(u.Host))
+	}
+	return ""
+}
+
+// publicBase returns the viewer-facing scheme+host used to build short links.
+// Behind CloudFront the Host the origin sees is the internal origin domain, so
+// we prefer the configured -base-url, then the Referer (which CloudFront
+// forwards and which carries the real viewer domain), then the request host.
+func (h *Handler) publicBase(r *http.Request) (scheme, host string) {
+	if h.PublicBaseURL != "" {
+		if u, err := url.Parse(h.PublicBaseURL); err == nil && u.Host != "" && !isLocalHost(u.Host) {
+			return u.Scheme, u.Host
+		}
+	}
+	if ref := strings.TrimSpace(r.Header.Get("Referer")); ref != "" {
+		if u, err := url.Parse(ref); err == nil && u.Host != "" && !isLocalHost(u.Host) {
+			return u.Scheme, u.Host
+		}
+	}
+	return requestScheme(r), requestHost(r)
+}
+
+// shortLinkAllowedHosts is the set of lowercase hosts an incoming absolute URL
+// may carry: the request host, the configured public host, and the Referer
+// host. Truly foreign hosts (e.g. evil.com) are still rejected.
+func (h *Handler) shortLinkAllowedHosts(r *http.Request) map[string]bool {
+	allowed := map[string]bool{}
+	add := func(host string) {
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host != "" {
+			allowed[host] = true
+		}
+	}
+	add(requestHost(r))
+	add(hostFromURL(h.PublicBaseURL))
+	add(hostFromURL(r.Header.Get("Referer")))
+	return allowed
 }
 
 func parseIntDefault(v string, def int) int {

--- a/pkg/httpapi/handlers_core_test.go
+++ b/pkg/httpapi/handlers_core_test.go
@@ -290,6 +290,43 @@ func TestHandleShorten(t *testing.T) {
 			t.Errorf("got %d, want 200; body: %s", rec.Code, rec.Body.String())
 		}
 	})
+	// Reproduce the CloudFront case: the origin sees the internal origin host
+	// as Host, but the client shortens a public-domain URL. The public host is
+	// recovered from the configured base URL, and the short link uses it.
+	t.Run("public host accepted via base URL and used in short link", func(t *testing.T) {
+		h.PublicBaseURL = "https://simplemap.safecast.org"
+		defer func() { h.PublicBaseURL = "" }()
+		req := httptest.NewRequest(http.MethodPost, "/api/shorten",
+			strings.NewReader(`{"url":"https://simplemap.safecast.org/?zoom=15","commit":false}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Host = "origin-simplemap.safecast.org" // internal origin host CloudFront sends
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+		var out map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if short, _ := out["short"].(string); !strings.HasPrefix(short, "https://simplemap.safecast.org/s/") {
+			t.Errorf("short link should use public host, got %q", short)
+		}
+	})
+	// Same case but the public host is recovered from the Referer header
+	// (CloudFront forwards Referer even when it does not forward the viewer Host).
+	t.Run("public host accepted via Referer", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/shorten",
+			strings.NewReader(`{"url":"https://simplemap.safecast.org/?zoom=15","commit":false}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Referer", "https://simplemap.safecast.org/?zoom=15")
+		req.Host = "origin-simplemap.safecast.org"
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("got %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+	})
 }
 
 func TestHandleTracksByYear(t *testing.T) {


### PR DESCRIPTION
## Symptom
The short-link button is broken in production — `POST /api/shorten` returns **400 "foreign host rejected"** for every request (confirmed via curl).

## Root cause
Behind CloudFront the origin receives the **internal origin domain** (`origin-simplemap.safecast.org`) as the `Host` header, not the viewer's public host (`simplemap.safecast.org`), and CloudFront does not forward the viewer `Host`. The client shortens its own public-domain page URL, so `parsed.Host` (`simplemap…`) ≠ `r.Host` (`origin-simplemap…`) and the guard rejected it. Probing prod confirmed: a URL with host `origin-simplemap.safecast.org` is accepted (200), the public host is not.

## Fix
- `Handler` gains `PublicBaseURL`, wired from the existing `-base-url` flag.
- `handleShorten` resolves the viewer-facing scheme/host via `publicBase()`: configured `-base-url` → else `Referer` (CloudFront forwards it; carries the real viewer domain) → else request host.
- Incoming absolute URL accepted if its host is any of the app's faces (request host, public host, Referer host). **Truly foreign hosts (`evil.com`) are still rejected.**
- Stored target and returned short link are rebuilt against the canonical public host — links are same-origin (no open-redirect) and use the viewer domain instead of the internal origin host.

## Tests
- All existing `TestHandleShorten` cases pass, including foreign-host rejection.
- Added two cases reproducing the CloudFront scenario: public host recovered from `-base-url`, and from `Referer`.
- Full `pkg/httpapi` suite green.

Note: depends on production running with `-base-url https://simplemap.safecast.org`; if it isn't, the `Referer` fallback still fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)