### PR TITLE
fix(map): bottom-align radiation legend to theme toggle

### DIFF
--- a/cmd/unified-server/public_html/map.html
+++ b/cmd/unified-server/public_html/map.html
@@ -4255,7 +4255,8 @@ function updateLegendDisplay() {
   // Use local refs to ensure we have valid data
   var steps = (typeof currentColoring !== 'undefined' && currentColoring === 'chicha') ? schemeChicha : schemeSafecast;
   
-  // Set height
+  // Set height and anchor to bottom (near theme toggle), not top
+  legendBox.style.top = 'auto';
   legendBox.style.height = (typeof currentColoring !== 'undefined' && currentColoring === 'chicha') ? '180px' : '500px';
 
   // Build gradient string manually for maximum compatibility


### PR DESCRIPTION
## Problem
The radiation legend was stretching from the top of the map instead of sitting bottom-right near the dark/light theme switch (regression from the Matvey responsive sync in 92754ed).

## Cause
`updateLegendDisplay()` sets an inline `height` while CSS keeps `top: 284px`, so the fixed-height box grows downward from the top.

## Fix
Set `top: auto` so the box anchors from `bottom: 104px`, aligned with the theme toggle as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)